### PR TITLE
correct day of date and month abbreviation to fix dch warnings and remove extra empty line in debian/control

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -15,7 +15,7 @@ videomass (3.4.3-1) UNRELEASED; urgency=medium
   * some code refactor (based on flake8/pylint)
   * Dutch translation completed.
 
- -- Gianluca Pernigotto <jeanlucperni@gmail.com>  Thu, 01 June 2021 10:35:00 +0200
+ -- Gianluca Pernigotto <jeanlucperni@gmail.com>  Tue, 01 Jun 2021 10:35:00 +0200
 
 videomass (3.4.2-1) UNRELEASED; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,6 @@ Standards-Version: 4.1.4
 Homepage: https://github.com/jeanslack/Videomass
 X-Python3-Version: >= 3.6
 
-
 Package: python3-videomass
 Architecture: all
 Depends: ${misc:Depends},


### PR DESCRIPTION
I package videomass for MX Linux, while doing so dch spit out some warnings due to the wrong day of the week for the specific date in June, as well as incorrect abbreviation for June.  Also removed an extra empty line from the control file.