### PR TITLE
fix pathnames on ffprobe command

### DIFF
--- a/videomass/vdms_panels/choose_topic.py
+++ b/videomass/vdms_panels/choose_topic.py
@@ -27,6 +27,7 @@ This file is part of Videomass.
 """
 import sys
 import wx
+import wx.lib.agw.hyperlink as hpl
 from videomass.vdms_utils.get_bmpfromsvg import get_bmp
 from videomass.vdms_sys.msg_info import current_release
 
@@ -109,6 +110,13 @@ class Choose_Topic(wx.Panel):
         sizer_base.Add(grid_buttons, 1, wx.ALIGN_CENTER_VERTICAL |
                        wx.ALIGN_CENTER_HORIZONTAL, 5
                        )
+
+        url = ('https://youtu.be/cE-T8VnymJA')
+        static0 = _("Video complaint for what is happening in Italy")
+        instpkg = hpl.HyperLinkCtrl(self, -1, static0, URL=url)
+        sizer_base.Add(instpkg, 0, wx.ALL | wx.CENTRE, 2)
+        sizer_base.Add(20, 20)
+
         self.SetSizerAndFit(sizer_base)
 
         # ---------------------- Tooltips

--- a/videomass/vdms_threads/ffprobe.py
+++ b/videomass/vdms_threads/ffprobe.py
@@ -7,7 +7,7 @@ Platform: all platforms
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
 Copyright: (c) 2022/2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
-Rev: Feb.14.2022
+Rev: Feb.17.2022
 Code checker: flake8, pylint
 ########################################################
 
@@ -27,6 +27,7 @@ This file is part of FFcuesplitter.
    along with FFcuesplitter.  If not, see <http://www.gnu.org/licenses/>.
 """
 import subprocess
+import shlex
 import platform
 import json
 from videomass.vdms_utils.utils import Popen
@@ -65,10 +66,11 @@ def ffprobe(filename, cmd='ffprobe', **kwargs):
                 etc,
                 )
     """
-    args = [cmd, '-show_format', '-show_streams', '-of', 'json']
-    args += from_kwargs_to_args(kwargs)
-    args += [filename]
-    args = ' '.join(args) if platform.system() == 'Windows' else args
+    args = (f'"{cmd}" -show_format -show_streams -of json '
+            f'{" ".join(from_kwargs_to_args(kwargs))} '
+            f'"{filename}"'
+            )
+    args = shlex.split(args) if platform.system() != 'Windows' else args
 
     try:
         with Popen(args,


### PR DESCRIPTION
This PR fixes:

- Double quotes on `ffprobe` command path-name.
- Double quotes on input filename.