### PR TITLE
resolve downloader log names

### DIFF
--- a/videomass/vdms_dialogs/showlogs.py
+++ b/videomass/vdms_dialogs/showlogs.py
@@ -38,7 +38,8 @@ class ShowLogs(wx.Dialog):
     """
     # list of logs files to include
     LOGNAMES = ('volumedected.log',
-                'youtubedl_lib.log',
+                'youtube_dl.log',
+                'yt_dlp.log',
                 'AV_conversions.log',
                 'presets_manager.log',
                 'ffplay.log',

--- a/videomass/vdms_io/make_filelog.py
+++ b/videomass/vdms_io/make_filelog.py
@@ -4,10 +4,10 @@ File Name: make_filelog.py
 Porpose: log file generator
 Compatibility: Python3, Python2
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
-Copyright: (c) 2018/2021 Gianluca Pernigotto <jeanlucperni@gmail.com>
+Copyright: (c) 2018/2022 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
-Rev: May.16.2021
-Code checker: pycodestyle, flake8, pylint .
+Rev: Feb.20.2022
+Code checker: flake8, pylint .
 
 This file is part of Videomass.
 
@@ -29,7 +29,7 @@ import time
 import os
 
 
-def logwrite(cmd, stderr, logname, logdir):
+def logwrite(cmd, stderr, logfile):
     """
     writes ffmpeg commands and status error during threads
     """
@@ -38,7 +38,7 @@ def logwrite(cmd, stderr, logname, logdir):
     else:
         apnd = f"{cmd}\n\n"
 
-    with open(os.path.join(logdir, logname), "a", encoding='utf8') as log:
+    with open(logfile, "a", encoding='utf8') as log:
         log.write(apnd)
 
 
@@ -60,15 +60,16 @@ def write_log(logfile, logdir):
     current_date = time.strftime("%c")  # date/time
     path = os.path.join(logdir, logfile)
 
-    with open(path, "a", encoding='utf8') as log:
-        log.write("""
+    with open(path, "a", encoding='utf8') as logfile:
+        logfile.write(f"""
+==============================================================================
 [DATE]:
-%s
+{current_date}
 
 [LOCATION]:
-%s
+{path}
 
 [VIDEOMASS]:
-""" % (current_date, path))
+""")
 
-    return None
+    return path

--- a/videomass/vdms_panels/youtubedl_ui.py
+++ b/videomass/vdms_panels/youtubedl_ui.py
@@ -1011,7 +1011,7 @@ class Downloader(wx.Panel):
         else:
             _id = '%(title).100s'
 
-        logname = 'youtubedl_lib.log'
+        logname = f"{Downloader.appdata['downloader']}.log"
         nooverwrites = self.ckbx_w.IsChecked() is True
         restrictfn = self.ckbx_restrict_fn.IsChecked() is True
         postprocessors = []

--- a/videomass/vdms_sys/msg_info.py
+++ b/videomass/vdms_sys/msg_info.py
@@ -39,7 +39,7 @@ def current_release():
     """
     release_name = 'Videomass'
     program_name = 'videomass'
-    version = '3.5.5'
+    version = '3.5.6'
     release = 'Unreleased'
     copyr = '2013-2022'
     website = 'http://jeanslack.github.io/Videomass/'

--- a/videomass/vdms_threads/concat_demuxer.py
+++ b/videomass/vdms_threads/concat_demuxer.py
@@ -112,11 +112,7 @@ class ConcatDemuxer(Thread):
                      # fname=", ".join(self.filelist),
                      end='',
                      )
-        logwrite(com,
-                 '',
-                 self.logname,
-                 ConcatDemuxer.appdata['logdir'],
-                 )  # write n/n + command only
+        logwrite(com, '', self.logname)  # write n/n + command only
 
         if not platform.system() == 'Windows':
             cmd = shlex.split(cmd)
@@ -146,9 +142,7 @@ class ConcatDemuxer(Thread):
                                  )
                     logwrite('',
                              f"Exit status: {proc.wait}",
-                             self.logname,
-                             ConcatDemuxer.appdata['logdir'],
-                             )  # append exit error number
+                             self.logname)  # append exit error number
                 else:  # ok
                     wx.CallAfter(pub.sendMessage,
                                  "COUNT_EVT",

--- a/videomass/vdms_threads/one_pass.py
+++ b/videomass/vdms_threads/one_pass.py
@@ -120,11 +120,7 @@ class OnePass(Thread):
                          duration=duration,
                          end='',
                          )
-            logwrite(com,
-                     '',
-                     self.logname,
-                     OnePass.appdata['logdir'],
-                     )  # write n/n + command only
+            logwrite(com, '', self.logname)  # write n/n + command only
 
             if not platform.system() == 'Windows':
                 cmd = shlex.split(cmd)
@@ -156,7 +152,6 @@ class OnePass(Thread):
                         logwrite('',
                                  f"Exit status: {proc.wait()}",
                                  self.logname,
-                                 OnePass.appdata['logdir'],
                                  )  # append exit error number
                     else:  # ok
                         wx.CallAfter(pub.sendMessage,

--- a/videomass/vdms_threads/picture_exporting.py
+++ b/videomass/vdms_threads/picture_exporting.py
@@ -94,11 +94,7 @@ class PicturesFromVideo(Thread):
                      duration=self.duration,
                      end='',
                      )
-        logwrite(com,
-                 '',
-                 self.logname,
-                 PicturesFromVideo.appdata['logdir'],
-                 )  # write n/n + command only
+        logwrite(com, '', self.logname)  # write n/n + command only
 
         if not PicturesFromVideo.appdata['ostype'] == 'Windows':
             cmd = shlex.split(cmd)
@@ -129,7 +125,6 @@ class PicturesFromVideo(Thread):
                     logwrite('',
                              f"Exit status: {proc.wait()}",
                              self.logname,
-                             PicturesFromVideo.appdata['logdir'],
                              )  # append exit error number
 
                 else:  # status ok

--- a/videomass/vdms_threads/two_pass.py
+++ b/videomass/vdms_threads/two_pass.py
@@ -115,11 +115,7 @@ class TwoPass(Thread):
                          duration=duration,
                          end='',
                          )
-            logwrite(cmd,
-                     '',
-                     self.logname,
-                     TwoPass.appdata['logdir'],
-                     )  # write n/n + command only
+            logwrite(cmd, '', self.logname)  # write n/n + command only
 
             if not TwoPass.OS == 'Windows':
                 pass1 = shlex.split(pass1)
@@ -151,7 +147,6 @@ class TwoPass(Thread):
                         logwrite('',
                                  f"Exit status: {proc1.wait()}",
                                  self.logname,
-                                 TwoPass.appdata['logdir']
                                  )  # append exit error number
 
             except (OSError, FileNotFoundError) as err:
@@ -199,7 +194,7 @@ class TwoPass(Thread):
                          duration=duration,
                          end='',
                          )
-            logwrite(cmd, '', self.logname, TwoPass.appdata['logdir'])
+            logwrite(cmd, '', self.logname)
 
             if not TwoPass.OS == 'Windows':
                 pass2 = shlex.split(pass2)
@@ -231,7 +226,6 @@ class TwoPass(Thread):
                     logwrite('',
                              f"Exit status: {proc2.wait()}",
                              self.logname,
-                             TwoPass.appdata['logdir'],
                              )  # append exit error number
 
             if self.stop_work_thread:  # break first 'for' loop

--- a/videomass/vdms_threads/two_pass_ebu.py
+++ b/videomass/vdms_threads/two_pass_ebu.py
@@ -126,11 +126,7 @@ class Loudnorm(Thread):
                          duration=duration,
                          end='',
                          )
-            logwrite(cmd,
-                     '',
-                     self.logname,
-                     Loudnorm.appdata['logdir']
-                     )  # write n/n + command only
+            logwrite(cmd, '', self.logname)  # write n/n + command only
 
             if not Loudnorm.OS == 'Windows':
                 pass1 = shlex.split(pass1)
@@ -166,7 +162,6 @@ class Loudnorm(Thread):
                         logwrite('',
                                  "Exit status: %s" % proc1.wait(),
                                  self.logname,
-                                 Loudnorm.appdata['logdir'],
                                  )  # append exit error number
                         break
 
@@ -236,7 +231,7 @@ class Loudnorm(Thread):
                          duration=duration,
                          end='',
                          )
-            logwrite(cmd, '', self.logname, Loudnorm.appdata['logdir'])
+            logwrite(cmd, '', self.logname)
 
             if not Loudnorm.OS == 'Windows':
                 pass2 = shlex.split(pass2)
@@ -267,7 +262,6 @@ class Loudnorm(Thread):
                     logwrite('',
                              "Exit status: %s" % proc2.wait(),
                              self.logname,
-                             Loudnorm.appdata['logdir'],
                              )  # append exit error number
 
             if self.stop_work_thread:  # break first 'for' loop

--- a/videomass/vdms_threads/video_stabilization.py
+++ b/videomass/vdms_threads/video_stabilization.py
@@ -134,11 +134,7 @@ class VidStab(Thread):
                          duration=duration,
                          end='',
                          )
-            logwrite(cmd,
-                     '',
-                     self.logname,
-                     VidStab.appdata['logdir'],
-                     )  # write n/n + command only
+            logwrite(cmd, '', self.logname)  # write n/n + command only
 
             if not VidStab.OS == 'Windows':
                 pass1 = shlex.split(pass1)
@@ -170,7 +166,6 @@ class VidStab(Thread):
                         logwrite('',
                                  "Exit status: %s" % proc1.wait(),
                                  self.logname,
-                                 VidStab.appdata['logdir']
                                  )  # append exit error number
 
             except (OSError, FileNotFoundError) as err:
@@ -227,7 +222,7 @@ class VidStab(Thread):
                          duration=duration,
                          end='',
                          )
-            logwrite(cmd, '', self.logname, VidStab.appdata['logdir'])
+            logwrite(cmd, '', self.logname)
 
             if not VidStab.OS == 'Windows':
                 pass2 = shlex.split(pass2)
@@ -259,7 +254,6 @@ class VidStab(Thread):
                     logwrite('',
                              "Exit status: %s" % proc2.wait(),
                              self.logname,
-                             VidStab.appdata['logdir'],
                              )  # append exit status error
 
             if self.stop_work_thread:  # break first 'for' loop
@@ -306,7 +300,7 @@ class VidStab(Thread):
                              duration=duration,
                              end='',
                              )
-                logwrite(cmd, '', self.logname, VidStab.appdata['logdir'])
+                logwrite(cmd, '', self.logname)
 
                 if not VidStab.OS == 'Windows':
                     pass3 = shlex.split(pass3)
@@ -338,7 +332,6 @@ class VidStab(Thread):
                         logwrite('',
                                  "Exit status: %s" % proc3.wait(),
                                  self.logname,
-                                 VidStab.appdata['logdir'],
                                  )  # append exit error number
 
                 if self.stop_work_thread:  # break first 'for' loop

--- a/videomass/vdms_threads/ydl_downloader.py
+++ b/videomass/vdms_threads/ydl_downloader.py
@@ -227,11 +227,7 @@ class YdlDownloader(Thread):
                 'progress_hooks': [my_hook],
             }
 
-            logwrite(ydl_opts,
-                     '',
-                     self.args['logname'],
-                     YdlDownloader.appdata['logdir'],
-                     )  # write n/n + command only
+            logwrite(ydl_opts, '', self.args['logname'])  # write log cmd
 
             if YdlDownloader.DOWNLOADER == 'youtube_dl':
                 with youtube_dl.YoutubeDL(ydl_opts) as ydl:


### PR DESCRIPTION
Fixes log names for the downloaders. 
As mentioned in this [reply](https://github.com/jeanslack/Videomass/issues/60#issuecomment-1045505437), this PR improves downloader logs, specifically `youtubedl_lib.log` is replaced with `yt_dlp.log` or with `youtube_dl.log`, this will depend on the downloader used.