### PR TITLE
Fix ffmpeg invalid arguments

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,10 @@ Feb 21, 2022 V.3.5.6
   * Fixed downloader log names.
   * Improved log management (the log folder is created at program startup 
     instead of ondemand).
+  * Fixed ffmpeg `invalid argument` when converting with double pass.
+  * Fixed the ffmpeg audio output mapping string error on 
+    `AV-Conversion.on_audioOUTstream` method, which raises 
+    `Invalid stream specifier: a1` type error.
 
 
 +------------------------------------+

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,14 @@ License: GPL3
 Change Log:
 
 +------------------------------------+
+Feb 21, 2022 V.3.5.6
+
+  * Fixed downloader log names.
+  * Improved log management (the log folder is created at program startup 
+    instead of ondemand).
+
+
++------------------------------------+
 Feb 16, 2022 V.3.5.5
 
   * AV/Conversions: Added 'opus' enc to ogg audio format.

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,10 @@ videomass (3.5.6-1) UNRELEASED; urgency=medium
   * Fixed downloader log names.
   * Improved log management (the log folder is created at program startup 
     instead of ondemand).
+  * Fixed ffmpeg `invalid argument` when converting with double pass.
+  * Fixed the ffmpeg audio output mapping string error on 
+    `AV-Conversion.on_audioOUTstream` method, which raises 
+    `Invalid stream specifier: a1` type error.
 
  -- Gianluca Pernigotto <jeanlucperni@gmail.com>  Mon, 21 Feb 2022 13:38:00 +0200
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+videomass (3.5.6-1) UNRELEASED; urgency=medium
+
+  * Fixed downloader log names.
+  * Improved log management (the log folder is created at program startup 
+    instead of ondemand).
+
+ -- Gianluca Pernigotto <jeanlucperni@gmail.com>  Mon, 21 Feb 2022 13:38:00 +0200
+
 videomass (3.5.5-1) UNRELEASED; urgency=medium
 
   * AV/Conversions: Added 'opus' enc to ogg audio format.

--- a/videomass/gui_app.py
+++ b/videomass/gui_app.py
@@ -6,7 +6,7 @@ Compatibility: Python3, wxPython Phoenix
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
 Copyright: (c) 2018/2022 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
-Rev: Feb.14.2022
+Rev: Feb.21.2022
 Code checker:
     - flake8: --ignore F821, W504, F401
     - pylint: --ignore E0602, E1101, C0415, E0401, C0103
@@ -104,14 +104,6 @@ class Videomass(wx.App):
         if ckydl is True or ckffmpeg is True:
             self.wizard(self.iconset['videomass'])
             return True
-
-        if not os.path.exists(os.path.join(self.appset['cachedir'], 'tmp')):
-            try:  # make temporary folder on cache dir
-                tmp = os.path.join(self.appset['cachedir'], 'tmp')
-                os.makedirs(tmp, mode=0o777)
-            except OSError as err:
-                wx.MessageBox(f'{err}', 'Videomass', wx.ICON_STOP)
-                return False
 
         from videomass.vdms_main.main_frame import MainFrame
         main_frame = MainFrame()

--- a/videomass/vdms_dialogs/showlogs.py
+++ b/videomass/vdms_dialogs/showlogs.py
@@ -38,7 +38,8 @@ class ShowLogs(wx.Dialog):
     """
     # list of logs files to include
     LOGNAMES = ('volumedected.log',
-                'youtubedl_lib.log',
+                'youtube_dl.log',
+                'yt_dlp.log',
                 'AV_conversions.log',
                 'presets_manager.log',
                 'ffplay.log',

--- a/videomass/vdms_io/io_tools.py
+++ b/videomass/vdms_io/io_tools.py
@@ -49,7 +49,7 @@ from videomass.vdms_frames import (ffmpeg_conf,
                                    ffmpeg_codecs,
                                    )
 from videomass.vdms_dialogs.widget_utils import PopupDialog
-from videomass.vdms_io.make_filelog import write_log  # write initial log
+from videomass.vdms_io.make_filelog import make_log_template
 
 
 def stream_info(title, filepath):
@@ -334,7 +334,7 @@ def appimage_update(appimage, script):
     get = wx.GetApp()  # get data from bootstrap
     logname = 'AppImage_Updates.log'
     logfile = os.path.join(get.appset['logdir'], logname)
-    write_log(logname, get.appset['logdir'])  # write log file first
+    make_log_template(logname, get.appset['logdir'])  # write log file first
 
     thread = appimage_updater.AppImageUpdate(appimage, script, logfile)
 

--- a/videomass/vdms_io/make_filelog.py
+++ b/videomass/vdms_io/make_filelog.py
@@ -31,7 +31,8 @@ import os
 
 def logwrite(cmd, stderr, logfile):
     """
-    writes ffmpeg commands and status error during threads
+    This function writes status messages
+    to a given `logfile` during a process.
     """
     if stderr:
         apnd = f"...{stderr}\n\n"
@@ -42,34 +43,30 @@ def logwrite(cmd, stderr, logfile):
         log.write(apnd)
 
 
-def write_log(logfile, logdir):
+def make_log_template(logname, logdir):
     """
-    Before starting a process, a log file is created from this
-    template and then written later by the process.
-    see also `vdms_sys/ctrl_run.py` .
+    Most log files are initialized from a template
+    before starting a process and writing status
+    messages to a given log file.
 
-    - logfile,  log name from which the command was generated
+    - logname,  example: `mylog.log`
     - logdir, log files location
+
+    Returns the absolute/relative pathname of the log
     """
-    if not os.path.isdir(logdir):
-        try:
-            os.makedirs(logdir, mode=0o777)
-        except OSError as error:
-            return error
-
     current_date = time.strftime("%c")  # date/time
-    path = os.path.join(logdir, logfile)
+    logfile = os.path.join(logdir, logname)
 
-    with open(path, "a", encoding='utf8') as logfile:
-        logfile.write(f"""
+    with open(logfile, "a", encoding='utf8') as log:
+        log.write(f"""
 ==============================================================================
 [DATE]:
 {current_date}
 
 [LOCATION]:
-{path}
+{logfile}
 
 [VIDEOMASS]:
 """)
 
-    return path
+    return logfile

--- a/videomass/vdms_io/make_filelog.py
+++ b/videomass/vdms_io/make_filelog.py
@@ -4,10 +4,10 @@ File Name: make_filelog.py
 Porpose: log file generator
 Compatibility: Python3, Python2
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
-Copyright: (c) 2018/2021 Gianluca Pernigotto <jeanlucperni@gmail.com>
+Copyright: (c) 2018/2022 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
-Rev: May.16.2021
-Code checker: pycodestyle, flake8, pylint .
+Rev: Feb.20.2022
+Code checker: flake8, pylint .
 
 This file is part of Videomass.
 
@@ -29,7 +29,7 @@ import time
 import os
 
 
-def logwrite(cmd, stderr, logname, logdir):
+def logwrite(cmd, stderr, logfile):
     """
     writes ffmpeg commands and status error during threads
     """
@@ -38,7 +38,7 @@ def logwrite(cmd, stderr, logname, logdir):
     else:
         apnd = f"{cmd}\n\n"
 
-    with open(os.path.join(logdir, logname), "a", encoding='utf8') as log:
+    with open(logfile, "a", encoding='utf8') as log:
         log.write(apnd)
 
 
@@ -60,15 +60,16 @@ def write_log(logfile, logdir):
     current_date = time.strftime("%c")  # date/time
     path = os.path.join(logdir, logfile)
 
-    with open(path, "a", encoding='utf8') as log:
-        log.write("""
+    with open(path, "a", encoding='utf8') as logfile:
+        logfile.write(f"""
+==============================================================================
 [DATE]:
-%s
+{current_date}
 
 [LOCATION]:
-%s
+{path}
 
 [VIDEOMASS]:
-""" % (current_date, path))
+""")
 
-    return None
+    return path

--- a/videomass/vdms_main/main_frame.py
+++ b/videomass/vdms_main/main_frame.py
@@ -6,7 +6,7 @@ Compatibility: Python3, wxPython Phoenix
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
 Copyright: (c) 2018/2022 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
-Rev: Feb.11.2022
+Rev: Feb.21.2022
 Code checker: pylint, flake8 --ignore=F821,W503
 ########################################################
 
@@ -962,17 +962,11 @@ class MainFrame(wx.Frame):
         """
         Show miniframe to view log files
         """
-        if not os.path.exists(self.appdata['logdir']):
-            wx.MessageBox(_("There are no logs to show."),
-                          "Videomass", wx.ICON_INFORMATION, self)
-            return
-
-        else:
-            mf = ShowLogs(self,
-                          self.appdata['logdir'],
-                          self.appdata['ostype']
-                          )
-            mf.Show()
+        mf = ShowLogs(self,
+                      self.appdata['logdir'],
+                      self.appdata['ostype']
+                      )
+        mf.Show()
     # ------------------------------------------------------------------#
 
     def view_Timeline(self, event):
@@ -1051,10 +1045,6 @@ class MainFrame(wx.Frame):
         Open the log directory with file manager
 
         """
-        if not os.path.exists(self.appdata['logdir']):
-            wx.MessageBox(_("There are no logs to show."),
-                          "Videomass", wx.ICON_INFORMATION, self)
-            return
         io_tools.openpath(self.appdata['logdir'])
     # ------------------------------------------------------------------#
 

--- a/videomass/vdms_panels/av_conversions.py
+++ b/videomass/vdms_panels/av_conversions.py
@@ -1745,7 +1745,7 @@ class AV_Conv(wx.Panel):
             self.opt["AudioOutMap"] = ['-map 0:a?', '']
         else:
             sel = int(sel) - 1
-            self.opt["AudioOutMap"] = ['-map 0:a%s?' % str(sel),
+            self.opt["AudioOutMap"] = ['-map 0:a:%s?' % str(sel),
                                        '%s' % str(sel)]
         if self.opt["AudioCodec"][0]:
             self.opt["AudioCodec"][0] = "-c:a:%s" % self.opt["AudioOutMap"][1]

--- a/videomass/vdms_panels/choose_topic.py
+++ b/videomass/vdms_panels/choose_topic.py
@@ -27,7 +27,6 @@ This file is part of Videomass.
 """
 import sys
 import wx
-import wx.lib.agw.hyperlink as hpl
 from videomass.vdms_utils.get_bmpfromsvg import get_bmp
 from videomass.vdms_sys.msg_info import current_release
 
@@ -110,13 +109,6 @@ class Choose_Topic(wx.Panel):
         sizer_base.Add(grid_buttons, 1, wx.ALIGN_CENTER_VERTICAL |
                        wx.ALIGN_CENTER_HORIZONTAL, 5
                        )
-
-        url = ('https://youtu.be/cE-T8VnymJA')
-        static0 = _("Video complaint for what is happening in Italy")
-        instpkg = hpl.HyperLinkCtrl(self, -1, static0, URL=url)
-        sizer_base.Add(instpkg, 0, wx.ALL | wx.CENTRE, 2)
-        sizer_base.Add(20, 20)
-
         self.SetSizerAndFit(sizer_base)
 
         # ---------------------- Tooltips

--- a/videomass/vdms_panels/long_processing_task.py
+++ b/videomass/vdms_panels/long_processing_task.py
@@ -31,7 +31,7 @@ import os
 from pubsub import pub
 import wx
 from videomass.vdms_dialogs.widget_utils import notification_area
-from videomass.vdms_io.make_filelog import write_log
+from videomass.vdms_io.make_filelog import make_log_template
 from videomass.vdms_threads.ydl_downloader import YdlDownloader
 from videomass.vdms_threads.one_pass import OnePass
 from videomass.vdms_threads.two_pass import TwoPass
@@ -175,7 +175,7 @@ class LogOut(wx.Panel):
         self.txtout.Clear()
         self.labperc.SetLabel('')
 
-        self.logname = write_log(varargs[8], self.appdata['logdir'])
+        self.logname = make_log_template(varargs[8], self.appdata['logdir'])
 
         if varargs[0] == 'onepass':  # from Audio/Video Conv.
             self.thread_type = OnePass(varargs, duration,

--- a/videomass/vdms_panels/youtubedl_ui.py
+++ b/videomass/vdms_panels/youtubedl_ui.py
@@ -1011,7 +1011,7 @@ class Downloader(wx.Panel):
         else:
             _id = '%(title).100s'
 
-        logname = 'youtubedl_lib.log'
+        logname = f"{Downloader.appdata['downloader']}.log"
         nooverwrites = self.ckbx_w.IsChecked() is True
         restrictfn = self.ckbx_restrict_fn.IsChecked() is True
         postprocessors = []

--- a/videomass/vdms_sys/msg_info.py
+++ b/videomass/vdms_sys/msg_info.py
@@ -39,7 +39,7 @@ def current_release():
     """
     release_name = 'Videomass'
     program_name = 'videomass'
-    version = '3.5.5'
+    version = '3.5.6'
     release = 'Unreleased'
     copyr = '2013-2022'
     website = 'http://jeanslack.github.io/Videomass/'

--- a/videomass/vdms_threads/concat_demuxer.py
+++ b/videomass/vdms_threads/concat_demuxer.py
@@ -112,11 +112,7 @@ class ConcatDemuxer(Thread):
                      # fname=", ".join(self.filelist),
                      end='',
                      )
-        logwrite(com,
-                 '',
-                 self.logname,
-                 ConcatDemuxer.appdata['logdir'],
-                 )  # write n/n + command only
+        logwrite(com, '', self.logname)  # write n/n + command only
 
         if not platform.system() == 'Windows':
             cmd = shlex.split(cmd)
@@ -146,9 +142,7 @@ class ConcatDemuxer(Thread):
                                  )
                     logwrite('',
                              f"Exit status: {proc.wait}",
-                             self.logname,
-                             ConcatDemuxer.appdata['logdir'],
-                             )  # append exit error number
+                             self.logname)  # append exit error number
                 else:  # ok
                     wx.CallAfter(pub.sendMessage,
                                  "COUNT_EVT",

--- a/videomass/vdms_threads/ffplay_file.py
+++ b/videomass/vdms_threads/ffplay_file.py
@@ -33,7 +33,7 @@ import subprocess
 import platform
 import wx
 from pubsub import pub
-from videomass.vdms_io.make_filelog import write_log  # write initial log
+from videomass.vdms_io.make_filelog import make_log_template
 if not platform.system() == 'Windows':
     import shlex
 
@@ -83,7 +83,7 @@ class FilePlay(Thread):
         self.ffplay_params = ffplay_params
         self.autoexit = '-autoexit' if autoexit is True else ''
         self.logf = os.path.join(logdir, 'ffplay.log')
-        write_log('ffplay.log', logdir)
+        make_log_template('ffplay.log', logdir)
         # set initial file LOG
 
         Thread.__init__(self)

--- a/videomass/vdms_threads/one_pass.py
+++ b/videomass/vdms_threads/one_pass.py
@@ -120,11 +120,7 @@ class OnePass(Thread):
                          duration=duration,
                          end='',
                          )
-            logwrite(com,
-                     '',
-                     self.logname,
-                     OnePass.appdata['logdir'],
-                     )  # write n/n + command only
+            logwrite(com, '', self.logname)  # write n/n + command only
 
             if not platform.system() == 'Windows':
                 cmd = shlex.split(cmd)
@@ -156,7 +152,6 @@ class OnePass(Thread):
                         logwrite('',
                                  f"Exit status: {proc.wait()}",
                                  self.logname,
-                                 OnePass.appdata['logdir'],
                                  )  # append exit error number
                     else:  # ok
                         wx.CallAfter(pub.sendMessage,

--- a/videomass/vdms_threads/picture_exporting.py
+++ b/videomass/vdms_threads/picture_exporting.py
@@ -94,11 +94,7 @@ class PicturesFromVideo(Thread):
                      duration=self.duration,
                      end='',
                      )
-        logwrite(com,
-                 '',
-                 self.logname,
-                 PicturesFromVideo.appdata['logdir'],
-                 )  # write n/n + command only
+        logwrite(com, '', self.logname)  # write n/n + command only
 
         if not PicturesFromVideo.appdata['ostype'] == 'Windows':
             cmd = shlex.split(cmd)
@@ -129,7 +125,6 @@ class PicturesFromVideo(Thread):
                     logwrite('',
                              f"Exit status: {proc.wait()}",
                              self.logname,
-                             PicturesFromVideo.appdata['logdir'],
                              )  # append exit error number
 
                 else:  # status ok

--- a/videomass/vdms_threads/two_pass.py
+++ b/videomass/vdms_threads/two_pass.py
@@ -179,7 +179,7 @@ class TwoPass(Thread):
                      f'{TwoPass.appdata["ffmpegloglev"]} '
                      f'{TwoPass.appdata["ffmpeg+params"]} {self.time_seq} '
                      f'-i "{files}" {self.passlist[1]} {volume} '
-                     f'{TwoPass.appdata["ffthreads"]} -y {outfile}'
+                     f'{TwoPass.appdata["ffthreads"]} -y "{outfile}"'
                      )
             count = f'File {self.count}/{self.countmax} - Pass Two'
             cmd = (f'{count}\nSource: "{files}"\nDestination: "{outfile}"'

--- a/videomass/vdms_threads/two_pass.py
+++ b/videomass/vdms_threads/two_pass.py
@@ -115,11 +115,7 @@ class TwoPass(Thread):
                          duration=duration,
                          end='',
                          )
-            logwrite(cmd,
-                     '',
-                     self.logname,
-                     TwoPass.appdata['logdir'],
-                     )  # write n/n + command only
+            logwrite(cmd, '', self.logname)  # write n/n + command only
 
             if not TwoPass.OS == 'Windows':
                 pass1 = shlex.split(pass1)
@@ -151,7 +147,6 @@ class TwoPass(Thread):
                         logwrite('',
                                  f"Exit status: {proc1.wait()}",
                                  self.logname,
-                                 TwoPass.appdata['logdir']
                                  )  # append exit error number
 
             except (OSError, FileNotFoundError) as err:
@@ -199,7 +194,7 @@ class TwoPass(Thread):
                          duration=duration,
                          end='',
                          )
-            logwrite(cmd, '', self.logname, TwoPass.appdata['logdir'])
+            logwrite(cmd, '', self.logname)
 
             if not TwoPass.OS == 'Windows':
                 pass2 = shlex.split(pass2)
@@ -231,7 +226,6 @@ class TwoPass(Thread):
                     logwrite('',
                              f"Exit status: {proc2.wait()}",
                              self.logname,
-                             TwoPass.appdata['logdir'],
                              )  # append exit error number
 
             if self.stop_work_thread:  # break first 'for' loop

--- a/videomass/vdms_threads/two_pass_ebu.py
+++ b/videomass/vdms_threads/two_pass_ebu.py
@@ -126,11 +126,7 @@ class Loudnorm(Thread):
                          duration=duration,
                          end='',
                          )
-            logwrite(cmd,
-                     '',
-                     self.logname,
-                     Loudnorm.appdata['logdir']
-                     )  # write n/n + command only
+            logwrite(cmd, '', self.logname)  # write n/n + command only
 
             if not Loudnorm.OS == 'Windows':
                 pass1 = shlex.split(pass1)
@@ -166,7 +162,6 @@ class Loudnorm(Thread):
                         logwrite('',
                                  "Exit status: %s" % proc1.wait(),
                                  self.logname,
-                                 Loudnorm.appdata['logdir'],
                                  )  # append exit error number
                         break
 
@@ -236,7 +231,7 @@ class Loudnorm(Thread):
                          duration=duration,
                          end='',
                          )
-            logwrite(cmd, '', self.logname, Loudnorm.appdata['logdir'])
+            logwrite(cmd, '', self.logname)
 
             if not Loudnorm.OS == 'Windows':
                 pass2 = shlex.split(pass2)
@@ -267,7 +262,6 @@ class Loudnorm(Thread):
                     logwrite('',
                              "Exit status: %s" % proc2.wait(),
                              self.logname,
-                             Loudnorm.appdata['logdir'],
                              )  # append exit error number
 
             if self.stop_work_thread:  # break first 'for' loop

--- a/videomass/vdms_threads/video_stabilization.py
+++ b/videomass/vdms_threads/video_stabilization.py
@@ -134,11 +134,7 @@ class VidStab(Thread):
                          duration=duration,
                          end='',
                          )
-            logwrite(cmd,
-                     '',
-                     self.logname,
-                     VidStab.appdata['logdir'],
-                     )  # write n/n + command only
+            logwrite(cmd, '', self.logname)  # write n/n + command only
 
             if not VidStab.OS == 'Windows':
                 pass1 = shlex.split(pass1)
@@ -170,7 +166,6 @@ class VidStab(Thread):
                         logwrite('',
                                  "Exit status: %s" % proc1.wait(),
                                  self.logname,
-                                 VidStab.appdata['logdir']
                                  )  # append exit error number
 
             except (OSError, FileNotFoundError) as err:
@@ -227,7 +222,7 @@ class VidStab(Thread):
                          duration=duration,
                          end='',
                          )
-            logwrite(cmd, '', self.logname, VidStab.appdata['logdir'])
+            logwrite(cmd, '', self.logname)
 
             if not VidStab.OS == 'Windows':
                 pass2 = shlex.split(pass2)
@@ -259,7 +254,6 @@ class VidStab(Thread):
                     logwrite('',
                              "Exit status: %s" % proc2.wait(),
                              self.logname,
-                             VidStab.appdata['logdir'],
                              )  # append exit status error
 
             if self.stop_work_thread:  # break first 'for' loop
@@ -306,7 +300,7 @@ class VidStab(Thread):
                              duration=duration,
                              end='',
                              )
-                logwrite(cmd, '', self.logname, VidStab.appdata['logdir'])
+                logwrite(cmd, '', self.logname)
 
                 if not VidStab.OS == 'Windows':
                     pass3 = shlex.split(pass3)
@@ -338,7 +332,6 @@ class VidStab(Thread):
                         logwrite('',
                                  "Exit status: %s" % proc3.wait(),
                                  self.logname,
-                                 VidStab.appdata['logdir'],
                                  )  # append exit error number
 
                 if self.stop_work_thread:  # break first 'for' loop

--- a/videomass/vdms_threads/volumedetect.py
+++ b/videomass/vdms_threads/volumedetect.py
@@ -33,7 +33,7 @@ import platform
 import wx
 from pubsub import pub
 from videomass.vdms_utils.utils import Popen
-from videomass.vdms_io.make_filelog import write_log
+from videomass.vdms_io.make_filelog import make_log_template
 if not platform.system() == 'Windows':
     import shlex
 
@@ -70,7 +70,7 @@ class VolumeDetectThread(Thread):
         self.data = None
         self.nul = 'NUL' if platform.system() == 'Windows' else '/dev/null'
         self.logf = os.path.join(logdir, 'volumedected.log')
-        write_log('volumedected.log', logdir)
+        make_log_template('volumedected.log', logdir)
         # set initial file LOG
 
         Thread.__init__(self)

--- a/videomass/vdms_threads/ydl_downloader.py
+++ b/videomass/vdms_threads/ydl_downloader.py
@@ -227,11 +227,7 @@ class YdlDownloader(Thread):
                 'progress_hooks': [my_hook],
             }
 
-            logwrite(ydl_opts,
-                     '',
-                     self.args['logname'],
-                     YdlDownloader.appdata['logdir'],
-                     )  # write n/n + command only
+            logwrite(ydl_opts, '', self.args['logname'])  # write log cmd
 
             if YdlDownloader.DOWNLOADER == 'youtube_dl':
                 with youtube_dl.YoutubeDL(ydl_opts) as ydl:


### PR DESCRIPTION
This PR fixes following errors:

* ffmpeg `invalid argument` when converting with double pass.
* ffmpeg audio output mapping string error on `AV-Conversion.on_audioOUTstream` method, which raises `Invalid stream specifier: a1` type error. This did not allow to perform audio normalizations on indexed audio streams through specific mapping selections.