### PR TITLE
fix videomass AppImage errors

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,7 +7,7 @@ License: GPL3
 Change Log:
 
 +------------------------------------+
-Mar 04, 2022 V.3.5.7
+Mar 05, 2022 V.3.5.7
 
   * Improved controls and automations for indexing and audio mapping.
   * Added feature to move files to the Videomass trash folder after successful
@@ -20,6 +20,10 @@ Mar 04, 2022 V.3.5.7
   * Added new option to disable SSL certificate #73 .
   * Added new option to the menu bar -> File -> Open..., to choose the files
     to open without using Drag N Drop #68 .
+  * [AppImage] Fixed AttributeError: `object has no attribute 'ydlupdate'`
+    when downloader is disabled.
+  * [AppImage] Fixed FATAL error popup using --appimage-portable-home argument
+    due missing source directory.
 
 +------------------------------------+
 Feb 21, 2022 V.3.5.6

--- a/debian/changelog
+++ b/debian/changelog
@@ -11,8 +11,12 @@ videomass (3.5.7-1) UNRELEASED; urgency=medium
   * Added new option to disable SSL certificate #73 .
   * Added new option to the menu bar -> File -> Open..., to choose the files
     to open without using Drag N Drop #68 .
+  * [AppImage] Fixed AttributeError: `object has no attribute 'ydlupdate'`
+    when downloader is disabled.
+  * [AppImage] Fixed FATAL error popup using --appimage-portable-home argument
+    due missing source directory.
 
- -- Gianluca Pernigotto <jeanlucperni@gmail.com>  Fri, 04 Mar 2022 23:51:00 +0200
+ -- Gianluca Pernigotto <jeanlucperni@gmail.com>  Sat, 05 Mar 2022 18:30:00 +0200
 
 videomass (3.5.6-1) UNRELEASED; urgency=medium
 

--- a/videomass/share/README
+++ b/videomass/share/README
@@ -20,14 +20,19 @@ To keep all application data inside the program folder, you can create a folder
 called "portable_data". On MS-Windows, when this folder exists and is in "appdata", 
 only relative paths will be provided. In all other cases they will be absolute paths. 
 
+-------------------
 For AppImage users: 
+-------------------
+WARNING: DO NOT PLACE THE "portable_data" FOLDER INSIDE APPIMAGE !
+
 If you would like the Videomass*.AppImage to store its data alongside the 
 Videomass*.AppImage rather than in your home directory, the AppImage natively has 
-this capability, just enable one of the following options:
+this capability, just enable this option, like this:
     
-`$ Videomass*.AppImage --appimage-portable-home`
-`$ Videomass*.AppImage --appimage-portable-config`
+`$ Videomass-3.5.7-x86_64.AppImage --appimage-portable-home`
 
-to more info type:
+Fo more information type:
 
-`$ Videomass*.AppImage --appimage-help`
+`$ Videomass-3.5.7-x86_64.AppImage --appimage-help`
+
+

--- a/videomass/vdms_main/main_frame.py
+++ b/videomass/vdms_main/main_frame.py
@@ -1831,7 +1831,8 @@ class MainFrame(wx.Frame):
         # self.SetTitle('Videomass')
         [self.menuBar.EnableTop(x, False) for x in range(3, 5)]
         if self.appdata['app'] == 'appimage':
-            self.ydlupdate.Enable(False)  # do not update during a process
+            if self.appdata['PYLIBYDL'] is None:
+                self.ydlupdate.Enable(False)  # do not update during a process
         self.viewtimeline.Enable(False)
         self.openmedia.Enable(False)
         # Hide the tool bar
@@ -1894,6 +1895,7 @@ class MainFrame(wx.Frame):
         # Enable all top menu bar:
         [self.menuBar.EnableTop(x, True) for x in range(3, 5)]
         if self.appdata['app'] == 'appimage':
-            self.ydlupdate.Enable(True)
+            if self.appdata['PYLIBYDL'] is None:
+                self.ydlupdate.Enable(True)  # re-enable it after processing
         # show buttons bar if the user has shown it:
         self.Layout()

--- a/videomass/vdms_sys/configurator.py
+++ b/videomass/vdms_sys/configurator.py
@@ -6,7 +6,7 @@ Compatibility: Python3
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
 Copyright: (c) 2018/2022 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
-Rev: Feb.21.2022
+Rev: March.05.2022
 Code checker: pycodestyle, flake8, pylint .
 
  This file is part of Videomass.
@@ -75,15 +75,14 @@ def restore_presets_dir(dirconf, srcpath):
     """
     if not os.path.exists(os.path.join(dirconf, "presets")):
         # try to restoring presets directory on videomass dir
-        drest = copydir_recursively(os.path.join(srcpath, "presets"),
-                                    dirconf)
+        drest = copydir_recursively(os.path.join(srcpath, "presets"), dirconf)
         if drest:
             return {'ERROR': drest}
 
     return {'R': None}
 
 
-def get_options(dirconf, fileconf):
+def get_options(dirconf, fileconf, srcpath):
     """
     Check the application options. Reads the `settings.json`
     file; if it does not exist or is unreadable try to restore
@@ -115,10 +114,12 @@ def get_options(dirconf, fileconf):
             data = {'R': conf.read_options()}
 
     else:  # try to restore entire configuration directory
-        try:  # make conf folder
-            os.mkdir(dirconf, mode=0o777)
-        except (OSError, TypeError) as err:
-            data = {'ERROR': err}
+        dconf = copydir_recursively(srcpath,
+                                    os.path.dirname(dirconf),
+                                    "videomass"
+                                    )
+        if dconf:
+            data = {'ERROR': dconf}
         else:
             conf.write_options()
             data = {'R': conf.read_options()}
@@ -415,7 +416,9 @@ class DataSource():
         fatal error in the gui_app bootstrap.
         """
         # handle configuration file
-        userconf = get_options(DataSource.DIR_CONF, DataSource.FILE_CONF)
+        userconf = get_options(DataSource.DIR_CONF,
+                               DataSource.FILE_CONF,
+                               self.srcpath)
         if userconf.get('ERROR'):
             return userconf
         userconf = userconf['R']


### PR DESCRIPTION
Closes #77 
Closes #78 

This PR fixes two bugs related to Videomass AppImage v3.5.5 and v3.5.6:
* AttributeError: `object has no attribute 'ydlupdate'` when the downloader is disabled and the user proceeds with a transcoding.
* A FATAL error popup using --appimage-portable-home argument due missing source directory.