### PR TITLE
fix DeprecationWarning

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,7 +7,7 @@ License: GPL3
 Change Log:
 
 +------------------------------------+
-Jan 10, 2023 V.4.0.5
+Jan 11, 2023 V.4.0.5
 
   * Fixed the status-bar messages and colors for all platforms.
   * ffplay failing on Windows with Fontconfig error #172 (thanks to @CComparon).
@@ -29,7 +29,8 @@ Jan 10, 2023 V.4.0.5
     wxPython version 4.1.1 not 4.0.7).
   * Removed ability to select multiple items from file drop panel
     due to previous issue.
-  * Fixed `TypeError using Python3.10.8 wxPython4.2.0` #178
+  * Fixed `TypeError` and various stacktraces using Python3.10
+    with wxPython4.2.0 #178
 
 +------------------------------------+
 Dec 12, 2022 V.4.0.2

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,7 +7,7 @@ License: GPL3
 Change Log:
 
 +------------------------------------+
-Jan 07, 2023 V.4.0.5
+Jan 10, 2023 V.4.0.5
 
   * Fixed the status-bar messages and colors for all platforms.
   * ffplay failing on Windows with Fontconfig error #172 (thanks to @CComparon).
@@ -29,6 +29,7 @@ Jan 07, 2023 V.4.0.5
     wxPython version 4.1.1 not 4.0.7).
   * Removed ability to select multiple items from file drop panel
     due to previous issue.
+  * Fixed `TypeError using Python3.10.8 wxPython4.2.0` #178
 
 +------------------------------------+
 Dec 12, 2022 V.4.0.2

--- a/debian/changelog
+++ b/debian/changelog
@@ -20,9 +20,10 @@ videomass (4.0.5-1) UNRELEASED; urgency=medium
     wxPython version 4.1.1 not 4.0.7).
   * Removed ability to select multiple items from file drop panel
     due to previous issue.
-  * Fixed `TypeError using Python3.10.8 wxPython4.2.0` #178
+  * Fixed `TypeError` and various stacktraces using Python3.10
+    with wxPython4.2.0 #178
 
- -- Gianluca Pernigotto <jeanlucperni@gmail.com>  Tue, 10 Jan 2023 18:30:00 +0200
+ -- Gianluca Pernigotto <jeanlucperni@gmail.com>  Tue, 11 Jan 2023 11:30:00 +0200
 
 videomass (4.0.2-1) UNRELEASED; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -20,8 +20,9 @@ videomass (4.0.5-1) UNRELEASED; urgency=medium
     wxPython version 4.1.1 not 4.0.7).
   * Removed ability to select multiple items from file drop panel
     due to previous issue.
+  * Fixed `TypeError using Python3.10.8 wxPython4.2.0` #178
 
- -- Gianluca Pernigotto <jeanlucperni@gmail.com>  Sat, 07 Jan 2023 13:00:00 +0200
+ -- Gianluca Pernigotto <jeanlucperni@gmail.com>  Tue, 10 Jan 2023 18:30:00 +0200
 
 videomass (4.0.2-1) UNRELEASED; urgency=medium
 

--- a/videomass/vdms_dialogs/filter_crop.py
+++ b/videomass/vdms_dialogs/filter_crop.py
@@ -45,7 +45,7 @@ def make_bitmap(width, height, image):
     """
     bitmap = wx.Bitmap(image)
     img = bitmap.ConvertToImage()
-    img = img.Scale(width, height, wx.IMAGE_QUALITY_NORMAL)
+    img = img.Scale(int(width), int(height), wx.IMAGE_QUALITY_NORMAL)
     bmp = img.ConvertToBitmap()
 
     return wx.Bitmap(bmp)
@@ -94,7 +94,11 @@ class Actor(wx.lib.statbmp.GenStaticBitmap):
         dc.DrawBitmap(self.current_bmp, 0, 0, True)
         dc.SetPen(wx.Pen('red', 2, wx.PENSTYLE_SOLID))
         dc.SetBrush(wx.Brush('green', wx.BRUSHSTYLE_TRANSPARENT))
-        dc.DrawRectangle(self.x + 1, self.y + 1, self.w + 2, self.h + 2)
+        dc.DrawRectangle(int(self.x + 1),
+                         int(self.y + 1),
+                         int(self.w + 2),
+                         int(self.h + 2),
+                         )
     # ------------------------------------------------------------------#
 
     def onRedraw(self, x, y, w, h):
@@ -115,7 +119,11 @@ class Actor(wx.lib.statbmp.GenStaticBitmap):
         dc.DrawBitmap(self.current_bmp, 0, 0, True)
         dc.SetPen(wx.Pen('red', 2, wx.PENSTYLE_SOLID))
         dc.SetBrush(wx.Brush('green', wx.BRUSHSTYLE_TRANSPARENT))
-        dc.DrawRectangle(self.x + 1, self.y + 1, self.w + 2, self.h + 2)
+        dc.DrawRectangle(int(self.x + 1),
+                         int(self.y + 1),
+                         int(self.w + 2),
+                         int(self.h + 2),
+                         )
 
 
 class Crop(wx.Dialog):
@@ -162,17 +170,18 @@ class Crop(wx.Dialog):
         self.v_height = v_height
         # resizing values preserving aspect ratio for monitor
         self.thr = 180 if self.v_height >= self.v_width else 270
-        self.h_ratio = (self.v_height / self.v_width) * self.thr  # height
-        self.w_ratio = (self.v_width / self.v_height) * self.h_ratio  # width
-
+        self.h_ratio = int((self.v_height
+                            / self.v_width) * self.thr)  # height
+        self.w_ratio = int((self.v_width
+                            / self.v_height) * self.h_ratio)  # width
         self.video = fname  # selected filename on queued list
         name = os.path.splitext(os.path.basename(self.video))[0]
         self.frame = os.path.join(f'{Crop.TMP}', f'{name}.png')  # image
 
         if os.path.exists(self.frame):
             self.image = self.frame
-        else:
-            self.image = wx.Bitmap(self.w_ratio, self.h_ratio)  # make empty
+        else:  # make empty
+            self.image = wx.Bitmap(self.w_ratio, self.h_ratio)
 
         duration = get_milliseconds(timeformat)  # convert to ms
         # hhmmss = milliseconds2clock(duration)  # convert to 24-hour clock
@@ -182,7 +191,7 @@ class Crop(wx.Dialog):
         self.panelrect = wx.Panel(self, wx.ID_ANY,
                                   size=(self.w_ratio, self.h_ratio)
                                   )
-        bmp = make_bitmap(self.w_ratio, self.h_ratio, self.image)
+        bmp = make_bitmap(self.w_ratio, self.h_ratio, self.image)####
         self.bob = Actor(self.panelrect, bmp, 1, "")
         sizerBase.Add(self.panelrect, 0, wx.ALL | wx.CENTER, 5)
         sizersize = wx.BoxSizer(wx.VERTICAL)

--- a/videomass/vdms_dialogs/filter_crop.py
+++ b/videomass/vdms_dialogs/filter_crop.py
@@ -6,7 +6,7 @@ Compatibility: Python3, wxPython Phoenix
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
 Copyleft - 2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
-Rev: March.12.2022
+Rev: Jan.11.2023
 Code checker: pylint, flake8
 ########################################################
 

--- a/videomass/vdms_dialogs/filter_transpose.py
+++ b/videomass/vdms_dialogs/filter_transpose.py
@@ -6,7 +6,7 @@ Compatibility: Python3, wxPython Phoenix
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
 Copyleft - 2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
-Rev: March.13.2022
+Rev: Jan.11.2023
 Code checker: pylint, flake8
 ########################################################
 
@@ -177,14 +177,14 @@ class Transpose(wx.Dialog):
 
     def onLoad(self, event):
         """
-        Build FFmpeg argument to get a specific video frame for
-        loading as StaticBitmap
+        Build FFmpeg argument to get a specific video frame
+        to loading as StaticBitmap
 
         """
-        t = self.duration.split(':')
-        h, m, s = (int(t[0]) / 2, int(t[1]) / 2, float(t[2]) / 2)
-        h, m, s = ("%02d" % h, "%02d" % m, "%02d" % s)
-        arg = f'-ss {h}:{m}:{s} -i "{self.video}" -vframes 1 -y "{self.frame}"'
+        h, m, s = self.duration.split(':')
+        intseq = (int(h) // 2, int(m) // 2, round(float(s) / 2))
+        stime = ':'.join([str(x).zfill(2) for x in intseq])
+        arg = f'-ss {stime} -i "{self.video}" -vframes 1 -y "{self.frame}"'
         thread = FFmpegGenericTask(arg)
         thread.join()  # wait end thread
         error = thread.status
@@ -192,7 +192,7 @@ class Transpose(wx.Dialog):
             wx.MessageBox(f'{error}', 'ERROR', wx.ICON_ERROR)
             return
 
-        sleep(1.0)  # need to wait end task for saving
+        sleep(1.0)  # need to wait end task to save file on drive
         bitmap = wx.Bitmap(self.frame)
         img = bitmap.ConvertToImage()
         img = img.Scale(self.w_ratio, self.h_ratio)

--- a/videomass/vdms_dialogs/filter_transpose.py
+++ b/videomass/vdms_dialogs/filter_transpose.py
@@ -52,10 +52,12 @@ class Transpose(wx.Dialog):
         self.v_height = v_height
         # resizing values preserving aspect ratio for pseudo-monitor
         self.thr = 150 if self.v_height > self.v_width else 270
-        self.h_ratio = (self.v_height / self.v_width) * self.thr
-        self.w_ratio = (self.v_width / self.v_height) * self.h_ratio
+        self.h_ratio = int((self.v_height / self.v_width) * self.thr)
+        self.w_ratio = int((self.v_width / self.v_height) * self.h_ratio)
         self.current_angle = 0
-        self.center = ((self.w_ratio/2), (self.h_ratio/2))  # orignal center
+        self.center = (int((self.w_ratio/2)),
+                       int((self.h_ratio/2)),
+                       )  # original center
         self.transpose = {'degrees': ['', 0]}
 
         self.duration = duration

--- a/videomass/vdms_panels/timeline.py
+++ b/videomass/vdms_panels/timeline.py
@@ -163,10 +163,11 @@ class Timeline(wx.Panel):
         timems = get_milliseconds(timef)
 
         if timems >= self.ms_end:
-            h, m, s = self.ctrl_end.GetTime()
-            self.ctrl_start.SetTime(h, m, s-1)
+            start = milliseconds2clock(self.ms_end - 1000)
+            h, m, s = start.split(':')
+            self.ctrl_start.SetTime(int(h), int(m), int(s.split('.')[0]))
             timef = self.time_join(self.ctrl_start.GetTime())
-            timems = get_milliseconds(timef)
+            timems = self.ms_end - 1000
 
         self.time_start = timef
         self.ms_start = timems
@@ -187,12 +188,13 @@ class Timeline(wx.Panel):
                 self.ctrl_start.Enable()
 
         if timems <= self.ms_start:
-            h, m, s = self.ctrl_start.GetTime()
             if self.ms_start == 0:
-                self.ctrl_end.SetTime(h, m, s)
+                self.ctrl_end.SetTime(00, 00, 00)
                 self.ctrl_start.Disable()
             else:
-                self.ctrl_end.SetTime(h, m, s+1)
+                end = milliseconds2clock(self.ms_start + 1000)
+                h, m, s = end.split(':')
+                self.ctrl_end.SetTime(int(h), int(m), int(s.split('.')[0]))
             timef = self.time_join(self.ctrl_end.GetTime())
             timems = get_milliseconds(timef)
 


### PR DESCRIPTION
Closes #178 

This PR fix `DeprecationWarning` to works with Python >= 3.10 (In Python 3.10, a change was implemented where extension functions that take integer arguments will no longer silently accept non-integer arguments (e.g., floats) that can only be converted to integers with a loss of precision).

This problem occurs when using the Crop and Rotation filters (also the old timeline bar on Videomass <= 4.0.2). This leads to various stacktraces using Python >= 3.10