### PR TITLE
fix comp on MS-Windows

### DIFF
--- a/develop/make_pot.sh
+++ b/develop/make_pot.sh
@@ -38,7 +38,7 @@ $XGETTEXT -d videomass "../gui_app.py" \
 "../vdms_dialogs/list_warning.py" \
 "../vdms_dialogs/wizard_dlg.py" \
 "../vdms_dialogs/about.py" \
-"../vdms_dialogs/presets_addnew.py" \
+"../vdms_dialogs/setting_profiles.py" \
 "../vdms_dialogs/set_timestamp.py" \
 "../vdms_dialogs/preferences.py" \
 "../vdms_dialogs/videomass_check_version.py" \

--- a/videomass/locale/en_US/LC_MESSAGES/videomass.po
+++ b/videomass/locale/en_US/LC_MESSAGES/videomass.po
@@ -727,61 +727,61 @@ msgstr ""
 msgid "Cross-platform graphical user interface for FFmpeg and yt-dlp.\n"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:39
+#: ../vdms_dialogs/setting_profiles.py:39
 msgid ""
 "One-Pass, Do not start with `ffmpeg -i filename`; do not end with `output-"
 "filename`"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:43
+#: ../vdms_dialogs/setting_profiles.py:43
 msgid ""
 "Two-Pass (optional), Do not start with `ffmpeg -i filename`; do not end with "
 "`output-filename`"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:47
+#: ../vdms_dialogs/setting_profiles.py:47
 msgid "Supported Formats list (optional). Do not include the `.`"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:48
+#: ../vdms_dialogs/setting_profiles.py:48
 msgid "Output Format. Empty to copy format and codec. Do not include the `.`"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:75
+#: ../vdms_dialogs/setting_profiles.py:75
 msgid "Profile Name"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:81 ../vdms_panels/presets_manager.py:433
+#: ../vdms_dialogs/setting_profiles.py:81 ../vdms_panels/presets_manager.py:433
 msgid "Description"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:165
+#: ../vdms_dialogs/setting_profiles.py:165
 msgid "A short profile name"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:166
+#: ../vdms_dialogs/setting_profiles.py:166
 msgid "A long description of the profile"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:167 ../vdms_panels/presets_manager.py:306
+#: ../vdms_dialogs/setting_profiles.py:167 ../vdms_panels/presets_manager.py:306
 msgid "FFmpeg arguments code for one-pass encoding"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:169 ../vdms_panels/presets_manager.py:308
+#: ../vdms_dialogs/setting_profiles.py:169 ../vdms_panels/presets_manager.py:308
 msgid "FFmpeg arguments code for two-pass encoding"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:171
+#: ../vdms_dialogs/setting_profiles.py:171
 msgid ""
 "One or more comma-separated format names that are not compatible with this "
 "profile."
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:174
+#: ../vdms_dialogs/setting_profiles.py:174
 msgid "Output format extension. Leave empty to copy codec and format"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:177 ../vdms_dialogs/presets_addnew.py:181
+#: ../vdms_dialogs/setting_profiles.py:177 ../vdms_dialogs/setting_profiles.py:181
 #: ../vdms_panels/presets_manager.py:314
 msgid ""
 "Any optional arguments to add before input file on the two-pass encoding, e."
@@ -789,23 +789,23 @@ msgid ""
 "CUDA."
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:290
+#: ../vdms_dialogs/setting_profiles.py:290
 msgid "Incomplete profile assignments"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:297
+#: ../vdms_dialogs/setting_profiles.py:297
 msgid "Formats must be comma-separated"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:313 ../vdms_dialogs/presets_addnew.py:332
+#: ../vdms_dialogs/setting_profiles.py:313 ../vdms_dialogs/setting_profiles.py:332
 msgid "Profile already stored with same name"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:317
+#: ../vdms_dialogs/setting_profiles.py:317
 msgid "Successful storing!"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:335
+#: ../vdms_dialogs/setting_profiles.py:335
 msgid "Successful changes!"
 msgstr ""
 

--- a/videomass/locale/es_CU/LC_MESSAGES/videomass.po
+++ b/videomass/locale/es_CU/LC_MESSAGES/videomass.po
@@ -854,14 +854,14 @@ msgstr "¡Terminado!"
 msgid "Cross-platform graphical user interface for FFmpeg and yt-dlp.\n"
 msgstr "Interfaz grafica multiplataforma para FFmpeg y yt-dlp.\n"
 
-#: ../vdms_dialogs/presets_addnew.py:39
+#: ../vdms_dialogs/setting_profiles.py:39
 msgid ""
 "One-Pass, Do not start with `ffmpeg -i filename`; do not end with `output-"
 "filename`"
 msgstr ""
 "Un-Paso, No inicie con `ffmpeg -i archivo`; no termine con `archivo-destino`"
 
-#: ../vdms_dialogs/presets_addnew.py:43
+#: ../vdms_dialogs/setting_profiles.py:43
 msgid ""
 "Two-Pass (optional), Do not start with `ffmpeg -i filename`; do not end with "
 "`output-filename`"
@@ -869,39 +869,39 @@ msgstr ""
 "Dos-Pasos (opcional), No inicie con `ffmpeg -i archivo`; no termine con "
 "`archivo-destino`"
 
-#: ../vdms_dialogs/presets_addnew.py:47
+#: ../vdms_dialogs/setting_profiles.py:47
 msgid "Supported Formats list (optional). Do not include the `.`"
 msgstr "Lista de formatos soportados (opcional). No incluya el `.`"
 
-#: ../vdms_dialogs/presets_addnew.py:48
+#: ../vdms_dialogs/setting_profiles.py:48
 msgid "Output Format. Empty to copy format and codec. Do not include the `.`"
 msgstr "Formato de Salida. Vacio, copia el formato y codec. No incluya el `.`"
 
-#: ../vdms_dialogs/presets_addnew.py:75
+#: ../vdms_dialogs/setting_profiles.py:75
 msgid "Profile Name"
 msgstr "Nombre de Perfil"
 
-#: ../vdms_dialogs/presets_addnew.py:81 ../vdms_panels/presets_manager.py:433
+#: ../vdms_dialogs/setting_profiles.py:81 ../vdms_panels/presets_manager.py:433
 msgid "Description"
 msgstr "Descripción"
 
-#: ../vdms_dialogs/presets_addnew.py:165
+#: ../vdms_dialogs/setting_profiles.py:165
 msgid "A short profile name"
 msgstr "Un nombre corto de perfil"
 
-#: ../vdms_dialogs/presets_addnew.py:166
+#: ../vdms_dialogs/setting_profiles.py:166
 msgid "A long description of the profile"
 msgstr "Una descripción amplia del perfil"
 
-#: ../vdms_dialogs/presets_addnew.py:167 ../vdms_panels/presets_manager.py:306
+#: ../vdms_dialogs/setting_profiles.py:167 ../vdms_panels/presets_manager.py:306
 msgid "FFmpeg arguments code for one-pass encoding"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:169 ../vdms_panels/presets_manager.py:308
+#: ../vdms_dialogs/setting_profiles.py:169 ../vdms_panels/presets_manager.py:308
 msgid "FFmpeg arguments code for two-pass encoding"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:171
+#: ../vdms_dialogs/setting_profiles.py:171
 #, fuzzy
 #| msgid "One or more comma-separated format names to include in the profile"
 msgid ""
@@ -909,12 +909,12 @@ msgid ""
 "profile."
 msgstr "Uno o más nombres de formato separados con coma a incluir en el perfil"
 
-#: ../vdms_dialogs/presets_addnew.py:174
+#: ../vdms_dialogs/setting_profiles.py:174
 msgid "Output format extension. Leave empty to copy codec and format"
 msgstr ""
 "Extensión del formato de salida. Deje vació para copiar codec y formato"
 
-#: ../vdms_dialogs/presets_addnew.py:177 ../vdms_dialogs/presets_addnew.py:181
+#: ../vdms_dialogs/setting_profiles.py:177 ../vdms_dialogs/setting_profiles.py:181
 #: ../vdms_panels/presets_manager.py:314
 msgid ""
 "Any optional arguments to add before input file on the two-pass encoding, e."
@@ -922,23 +922,23 @@ msgid ""
 "CUDA."
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:290
+#: ../vdms_dialogs/setting_profiles.py:290
 msgid "Incomplete profile assignments"
 msgstr "Asignaciones de perfil incompletas"
 
-#: ../vdms_dialogs/presets_addnew.py:297
+#: ../vdms_dialogs/setting_profiles.py:297
 msgid "Formats must be comma-separated"
 msgstr "Debe separar con coma los formatos"
 
-#: ../vdms_dialogs/presets_addnew.py:313 ../vdms_dialogs/presets_addnew.py:332
+#: ../vdms_dialogs/setting_profiles.py:313 ../vdms_dialogs/setting_profiles.py:332
 msgid "Profile already stored with same name"
 msgstr "Ya existe perfil con ese nombre"
 
-#: ../vdms_dialogs/presets_addnew.py:317
+#: ../vdms_dialogs/setting_profiles.py:317
 msgid "Successful storing!"
 msgstr "¡Guardado con exito!"
 
-#: ../vdms_dialogs/presets_addnew.py:335
+#: ../vdms_dialogs/setting_profiles.py:335
 msgid "Successful changes!"
 msgstr "¡Cambios exitosos!"
 

--- a/videomass/locale/es_ES/LC_MESSAGES/videomass.po
+++ b/videomass/locale/es_ES/LC_MESSAGES/videomass.po
@@ -854,14 +854,14 @@ msgstr "¡Terminado!"
 msgid "Cross-platform graphical user interface for FFmpeg and yt-dlp.\n"
 msgstr "Interfaz grafica multiplataforma para FFmpeg y yt-dlp.\n"
 
-#: ../vdms_dialogs/presets_addnew.py:39
+#: ../vdms_dialogs/setting_profiles.py:39
 msgid ""
 "One-Pass, Do not start with `ffmpeg -i filename`; do not end with `output-"
 "filename`"
 msgstr ""
 "Un-Paso, No inicie con `ffmpeg -i archivo`; no termine con `archivo-destino`"
 
-#: ../vdms_dialogs/presets_addnew.py:43
+#: ../vdms_dialogs/setting_profiles.py:43
 msgid ""
 "Two-Pass (optional), Do not start with `ffmpeg -i filename`; do not end with "
 "`output-filename`"
@@ -869,39 +869,39 @@ msgstr ""
 "Dos-Pasos (opcional), No inicie con `ffmpeg -i archivo`; no termine con "
 "`archivo-destino`"
 
-#: ../vdms_dialogs/presets_addnew.py:47
+#: ../vdms_dialogs/setting_profiles.py:47
 msgid "Supported Formats list (optional). Do not include the `.`"
 msgstr "Lista de formatos soportados (opcional). No incluya el `.`"
 
-#: ../vdms_dialogs/presets_addnew.py:48
+#: ../vdms_dialogs/setting_profiles.py:48
 msgid "Output Format. Empty to copy format and codec. Do not include the `.`"
 msgstr "Formato de Salida. Vacio, copia el formato y codec. No incluya el `.`"
 
-#: ../vdms_dialogs/presets_addnew.py:75
+#: ../vdms_dialogs/setting_profiles.py:75
 msgid "Profile Name"
 msgstr "Nombre de Perfil"
 
-#: ../vdms_dialogs/presets_addnew.py:81 ../vdms_panels/presets_manager.py:433
+#: ../vdms_dialogs/setting_profiles.py:81 ../vdms_panels/presets_manager.py:433
 msgid "Description"
 msgstr "Descripción"
 
-#: ../vdms_dialogs/presets_addnew.py:165
+#: ../vdms_dialogs/setting_profiles.py:165
 msgid "A short profile name"
 msgstr "Un nombre corto de perfil"
 
-#: ../vdms_dialogs/presets_addnew.py:166
+#: ../vdms_dialogs/setting_profiles.py:166
 msgid "A long description of the profile"
 msgstr "Una descripción amplia del perfil"
 
-#: ../vdms_dialogs/presets_addnew.py:167 ../vdms_panels/presets_manager.py:306
+#: ../vdms_dialogs/setting_profiles.py:167 ../vdms_panels/presets_manager.py:306
 msgid "FFmpeg arguments code for one-pass encoding"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:169 ../vdms_panels/presets_manager.py:308
+#: ../vdms_dialogs/setting_profiles.py:169 ../vdms_panels/presets_manager.py:308
 msgid "FFmpeg arguments code for two-pass encoding"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:171
+#: ../vdms_dialogs/setting_profiles.py:171
 #, fuzzy
 #| msgid "One or more comma-separated format names to include in the profile"
 msgid ""
@@ -909,12 +909,12 @@ msgid ""
 "profile."
 msgstr "Uno o más nombres de formato separados con coma a incluir en el perfil"
 
-#: ../vdms_dialogs/presets_addnew.py:174
+#: ../vdms_dialogs/setting_profiles.py:174
 msgid "Output format extension. Leave empty to copy codec and format"
 msgstr ""
 "Extensión del formato de salida. Deje vació para copiar codec y formato"
 
-#: ../vdms_dialogs/presets_addnew.py:177 ../vdms_dialogs/presets_addnew.py:181
+#: ../vdms_dialogs/setting_profiles.py:177 ../vdms_dialogs/setting_profiles.py:181
 #: ../vdms_panels/presets_manager.py:314
 msgid ""
 "Any optional arguments to add before input file on the two-pass encoding, e."
@@ -922,23 +922,23 @@ msgid ""
 "CUDA."
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:290
+#: ../vdms_dialogs/setting_profiles.py:290
 msgid "Incomplete profile assignments"
 msgstr "Asignaciones de perfil incompletas"
 
-#: ../vdms_dialogs/presets_addnew.py:297
+#: ../vdms_dialogs/setting_profiles.py:297
 msgid "Formats must be comma-separated"
 msgstr "Debe separar con coma los formatos"
 
-#: ../vdms_dialogs/presets_addnew.py:313 ../vdms_dialogs/presets_addnew.py:332
+#: ../vdms_dialogs/setting_profiles.py:313 ../vdms_dialogs/setting_profiles.py:332
 msgid "Profile already stored with same name"
 msgstr "Ya existe perfil con ese nombre"
 
-#: ../vdms_dialogs/presets_addnew.py:317
+#: ../vdms_dialogs/setting_profiles.py:317
 msgid "Successful storing!"
 msgstr "¡Guardado con exito!"
 
-#: ../vdms_dialogs/presets_addnew.py:335
+#: ../vdms_dialogs/setting_profiles.py:335
 msgid "Successful changes!"
 msgstr "¡Cambios exitosos!"
 

--- a/videomass/locale/es_MX/LC_MESSAGES/videomass.po
+++ b/videomass/locale/es_MX/LC_MESSAGES/videomass.po
@@ -854,14 +854,14 @@ msgstr "¡Terminado!"
 msgid "Cross-platform graphical user interface for FFmpeg and yt-dlp.\n"
 msgstr "Interfaz grafica multiplataforma para FFmpeg y yt-dlp.\n"
 
-#: ../vdms_dialogs/presets_addnew.py:39
+#: ../vdms_dialogs/setting_profiles.py:39
 msgid ""
 "One-Pass, Do not start with `ffmpeg -i filename`; do not end with `output-"
 "filename`"
 msgstr ""
 "Un-Paso, No inicie con `ffmpeg -i archivo`; no termine con `archivo-destino`"
 
-#: ../vdms_dialogs/presets_addnew.py:43
+#: ../vdms_dialogs/setting_profiles.py:43
 msgid ""
 "Two-Pass (optional), Do not start with `ffmpeg -i filename`; do not end with "
 "`output-filename`"
@@ -869,39 +869,39 @@ msgstr ""
 "Dos-Pasos (opcional), No inicie con `ffmpeg -i archivo`; no termine con "
 "`archivo-destino`"
 
-#: ../vdms_dialogs/presets_addnew.py:47
+#: ../vdms_dialogs/setting_profiles.py:47
 msgid "Supported Formats list (optional). Do not include the `.`"
 msgstr "Lista de formatos soportados (opcional). No incluya el `.`"
 
-#: ../vdms_dialogs/presets_addnew.py:48
+#: ../vdms_dialogs/setting_profiles.py:48
 msgid "Output Format. Empty to copy format and codec. Do not include the `.`"
 msgstr "Formato de Salida. Vacio, copia el formato y codec. No incluya el `.`"
 
-#: ../vdms_dialogs/presets_addnew.py:75
+#: ../vdms_dialogs/setting_profiles.py:75
 msgid "Profile Name"
 msgstr "Nombre de Perfil"
 
-#: ../vdms_dialogs/presets_addnew.py:81 ../vdms_panels/presets_manager.py:433
+#: ../vdms_dialogs/setting_profiles.py:81 ../vdms_panels/presets_manager.py:433
 msgid "Description"
 msgstr "Descripción"
 
-#: ../vdms_dialogs/presets_addnew.py:165
+#: ../vdms_dialogs/setting_profiles.py:165
 msgid "A short profile name"
 msgstr "Un nombre corto de perfil"
 
-#: ../vdms_dialogs/presets_addnew.py:166
+#: ../vdms_dialogs/setting_profiles.py:166
 msgid "A long description of the profile"
 msgstr "Una descripción amplia del perfil"
 
-#: ../vdms_dialogs/presets_addnew.py:167 ../vdms_panels/presets_manager.py:306
+#: ../vdms_dialogs/setting_profiles.py:167 ../vdms_panels/presets_manager.py:306
 msgid "FFmpeg arguments code for one-pass encoding"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:169 ../vdms_panels/presets_manager.py:308
+#: ../vdms_dialogs/setting_profiles.py:169 ../vdms_panels/presets_manager.py:308
 msgid "FFmpeg arguments code for two-pass encoding"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:171
+#: ../vdms_dialogs/setting_profiles.py:171
 #, fuzzy
 #| msgid "One or more comma-separated format names to include in the profile"
 msgid ""
@@ -909,12 +909,12 @@ msgid ""
 "profile."
 msgstr "Uno o más nombres de formato separados con coma a incluir en el perfil"
 
-#: ../vdms_dialogs/presets_addnew.py:174
+#: ../vdms_dialogs/setting_profiles.py:174
 msgid "Output format extension. Leave empty to copy codec and format"
 msgstr ""
 "Extensión del formato de salida. Deje vació para copiar codec y formato"
 
-#: ../vdms_dialogs/presets_addnew.py:177 ../vdms_dialogs/presets_addnew.py:181
+#: ../vdms_dialogs/setting_profiles.py:177 ../vdms_dialogs/setting_profiles.py:181
 #: ../vdms_panels/presets_manager.py:314
 msgid ""
 "Any optional arguments to add before input file on the two-pass encoding, e."
@@ -922,23 +922,23 @@ msgid ""
 "CUDA."
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:290
+#: ../vdms_dialogs/setting_profiles.py:290
 msgid "Incomplete profile assignments"
 msgstr "Asignaciones de perfil incompletas"
 
-#: ../vdms_dialogs/presets_addnew.py:297
+#: ../vdms_dialogs/setting_profiles.py:297
 msgid "Formats must be comma-separated"
 msgstr "Debe separar con coma los formatos"
 
-#: ../vdms_dialogs/presets_addnew.py:313 ../vdms_dialogs/presets_addnew.py:332
+#: ../vdms_dialogs/setting_profiles.py:313 ../vdms_dialogs/setting_profiles.py:332
 msgid "Profile already stored with same name"
 msgstr "Ya existe perfil con ese nombre"
 
-#: ../vdms_dialogs/presets_addnew.py:317
+#: ../vdms_dialogs/setting_profiles.py:317
 msgid "Successful storing!"
 msgstr "¡Guardado con exito!"
 
-#: ../vdms_dialogs/presets_addnew.py:335
+#: ../vdms_dialogs/setting_profiles.py:335
 msgid "Successful changes!"
 msgstr "¡Cambios exitosos!"
 

--- a/videomass/locale/fr_FR/LC_MESSAGES/videomass.po
+++ b/videomass/locale/fr_FR/LC_MESSAGES/videomass.po
@@ -867,7 +867,7 @@ msgstr "Terminé !"
 msgid "Cross-platform graphical user interface for FFmpeg and yt-dlp.\n"
 msgstr "Interface graphique multiplateforme pour FFmpeg et yt-dlp.\n"
 
-#: ../vdms_dialogs/presets_addnew.py:39
+#: ../vdms_dialogs/setting_profiles.py:39
 msgid ""
 "One-Pass, Do not start with `ffmpeg -i filename`; do not end with `output-"
 "filename`"
@@ -875,7 +875,7 @@ msgstr ""
 "Passe Unique, Ne pas commencer par `ffmpeg -i filename`;ne pas terminer avec "
 "`output-filename`"
 
-#: ../vdms_dialogs/presets_addnew.py:43
+#: ../vdms_dialogs/setting_profiles.py:43
 msgid ""
 "Two-Pass (optional), Do not start with `ffmpeg -i filename`; do not end with "
 "`output-filename`"
@@ -883,41 +883,41 @@ msgstr ""
 "Deux Passes (facultatif), ne pas commencer par `ffmpeg -i filename`;ne pas "
 "terminer avec `output-filename`"
 
-#: ../vdms_dialogs/presets_addnew.py:47
+#: ../vdms_dialogs/setting_profiles.py:47
 msgid "Supported Formats list (optional). Do not include the `.`"
 msgstr "Liste des Formats pris en charge (facultatif).Ne pas inclure le `.`"
 
-#: ../vdms_dialogs/presets_addnew.py:48
+#: ../vdms_dialogs/setting_profiles.py:48
 msgid "Output Format. Empty to copy format and codec. Do not include the `.`"
 msgstr ""
 "Format de Sortie.Vide pour copier le format et le codec. Ne pas inclure le "
 "``. '"
 
-#: ../vdms_dialogs/presets_addnew.py:75
+#: ../vdms_dialogs/setting_profiles.py:75
 msgid "Profile Name"
 msgstr "Nom du profil"
 
-#: ../vdms_dialogs/presets_addnew.py:81 ../vdms_panels/presets_manager.py:433
+#: ../vdms_dialogs/setting_profiles.py:81 ../vdms_panels/presets_manager.py:433
 msgid "Description"
 msgstr "Description"
 
-#: ../vdms_dialogs/presets_addnew.py:165
+#: ../vdms_dialogs/setting_profiles.py:165
 msgid "A short profile name"
 msgstr "Nom de profil court"
 
-#: ../vdms_dialogs/presets_addnew.py:166
+#: ../vdms_dialogs/setting_profiles.py:166
 msgid "A long description of the profile"
 msgstr "Description longue du profil"
 
-#: ../vdms_dialogs/presets_addnew.py:167 ../vdms_panels/presets_manager.py:306
+#: ../vdms_dialogs/setting_profiles.py:167 ../vdms_panels/presets_manager.py:306
 msgid "FFmpeg arguments code for one-pass encoding"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:169 ../vdms_panels/presets_manager.py:308
+#: ../vdms_dialogs/setting_profiles.py:169 ../vdms_panels/presets_manager.py:308
 msgid "FFmpeg arguments code for two-pass encoding"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:171
+#: ../vdms_dialogs/setting_profiles.py:171
 #, fuzzy
 #| msgid "One or more comma-separated format names to include in the profile"
 msgid ""
@@ -927,12 +927,12 @@ msgstr ""
 "Un ou plusieurs noms de format séparés par une virgule à inclure dans le "
 "profil"
 
-#: ../vdms_dialogs/presets_addnew.py:174
+#: ../vdms_dialogs/setting_profiles.py:174
 msgid "Output format extension. Leave empty to copy codec and format"
 msgstr ""
 "Extension du format de sortie.Laisser vide pour copier le codec et le format"
 
-#: ../vdms_dialogs/presets_addnew.py:177 ../vdms_dialogs/presets_addnew.py:181
+#: ../vdms_dialogs/setting_profiles.py:177 ../vdms_dialogs/setting_profiles.py:181
 #: ../vdms_panels/presets_manager.py:314
 msgid ""
 "Any optional arguments to add before input file on the two-pass encoding, e."
@@ -940,23 +940,23 @@ msgid ""
 "CUDA."
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:290
+#: ../vdms_dialogs/setting_profiles.py:290
 msgid "Incomplete profile assignments"
 msgstr "Profil incomplet"
 
-#: ../vdms_dialogs/presets_addnew.py:297
+#: ../vdms_dialogs/setting_profiles.py:297
 msgid "Formats must be comma-separated"
 msgstr "Les formats doivent être séparés par une virgule"
 
-#: ../vdms_dialogs/presets_addnew.py:313 ../vdms_dialogs/presets_addnew.py:332
+#: ../vdms_dialogs/setting_profiles.py:313 ../vdms_dialogs/setting_profiles.py:332
 msgid "Profile already stored with same name"
 msgstr "Profil déjà enregistré sous le même nom"
 
-#: ../vdms_dialogs/presets_addnew.py:317
+#: ../vdms_dialogs/setting_profiles.py:317
 msgid "Successful storing!"
 msgstr "Enregistré avec succès !"
 
-#: ../vdms_dialogs/presets_addnew.py:335
+#: ../vdms_dialogs/setting_profiles.py:335
 msgid "Successful changes!"
 msgstr "Modifications réussies!"
 

--- a/videomass/locale/it_IT/LC_MESSAGES/videomass.po
+++ b/videomass/locale/it_IT/LC_MESSAGES/videomass.po
@@ -877,7 +877,7 @@ msgstr "Fatto!"
 msgid "Cross-platform graphical user interface for FFmpeg and yt-dlp.\n"
 msgstr "Interfaccia grafica multi-piattaforma per FFmpeg e yt-dlp\n"
 
-#: ../vdms_dialogs/presets_addnew.py:39
+#: ../vdms_dialogs/setting_profiles.py:39
 msgid ""
 "One-Pass, Do not start with `ffmpeg -i filename`; do not end with `output-"
 "filename`"
@@ -885,7 +885,7 @@ msgstr ""
 "Passata uno, Non iniziare con: `ffmpeg -i nomefile`; Non finire con "
 "`nomefile_in_uscita`"
 
-#: ../vdms_dialogs/presets_addnew.py:43
+#: ../vdms_dialogs/setting_profiles.py:43
 msgid ""
 "Two-Pass (optional), Do not start with `ffmpeg -i filename`; do not end with "
 "`output-filename`"
@@ -893,40 +893,40 @@ msgstr ""
 "Passata due (opzionale), Non iniziare con `ffmpeg -i nomefile`; Non finire "
 "con `nomefile_in_uscita`"
 
-#: ../vdms_dialogs/presets_addnew.py:47
+#: ../vdms_dialogs/setting_profiles.py:47
 msgid "Supported Formats list (optional). Do not include the `.`"
 msgstr "Lista dei formati supportati (opzionale). Non includere il `.`"
 
-#: ../vdms_dialogs/presets_addnew.py:48
+#: ../vdms_dialogs/setting_profiles.py:48
 msgid "Output Format. Empty to copy format and codec. Do not include the `.`"
 msgstr ""
 "Formato in uscita. Vuoto per copiare formato e codec. Non includere il `.`"
 
-#: ../vdms_dialogs/presets_addnew.py:75
+#: ../vdms_dialogs/setting_profiles.py:75
 msgid "Profile Name"
 msgstr "Nome Profilo"
 
-#: ../vdms_dialogs/presets_addnew.py:81 ../vdms_panels/presets_manager.py:433
+#: ../vdms_dialogs/setting_profiles.py:81 ../vdms_panels/presets_manager.py:433
 msgid "Description"
 msgstr "Descrizione"
 
-#: ../vdms_dialogs/presets_addnew.py:165
+#: ../vdms_dialogs/setting_profiles.py:165
 msgid "A short profile name"
 msgstr "Un nome di profilo breve"
 
-#: ../vdms_dialogs/presets_addnew.py:166
+#: ../vdms_dialogs/setting_profiles.py:166
 msgid "A long description of the profile"
 msgstr "Una lunga descrizione del profilo"
 
-#: ../vdms_dialogs/presets_addnew.py:167 ../vdms_panels/presets_manager.py:306
+#: ../vdms_dialogs/setting_profiles.py:167 ../vdms_panels/presets_manager.py:306
 msgid "FFmpeg arguments code for one-pass encoding"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:169 ../vdms_panels/presets_manager.py:308
+#: ../vdms_dialogs/setting_profiles.py:169 ../vdms_panels/presets_manager.py:308
 msgid "FFmpeg arguments code for two-pass encoding"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:171
+#: ../vdms_dialogs/setting_profiles.py:171
 #, fuzzy
 #| msgid "One or more comma-separated format names to include in the profile"
 msgid ""
@@ -934,12 +934,12 @@ msgid ""
 "profile."
 msgstr "Uno o più nomi di formato separati da virgole da includere nel profilo"
 
-#: ../vdms_dialogs/presets_addnew.py:174
+#: ../vdms_dialogs/setting_profiles.py:174
 msgid "Output format extension. Leave empty to copy codec and format"
 msgstr ""
 "Estensione del formato di output. Lascia vuoto per copiare codec e formato"
 
-#: ../vdms_dialogs/presets_addnew.py:177 ../vdms_dialogs/presets_addnew.py:181
+#: ../vdms_dialogs/setting_profiles.py:177 ../vdms_dialogs/setting_profiles.py:181
 #: ../vdms_panels/presets_manager.py:314
 msgid ""
 "Any optional arguments to add before input file on the two-pass encoding, e."
@@ -947,23 +947,23 @@ msgid ""
 "CUDA."
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:290
+#: ../vdms_dialogs/setting_profiles.py:290
 msgid "Incomplete profile assignments"
 msgstr "Le assegnazioni del profilo sono incomplete"
 
-#: ../vdms_dialogs/presets_addnew.py:297
+#: ../vdms_dialogs/setting_profiles.py:297
 msgid "Formats must be comma-separated"
 msgstr "I formati devono essere separati da una virgola"
 
-#: ../vdms_dialogs/presets_addnew.py:313 ../vdms_dialogs/presets_addnew.py:332
+#: ../vdms_dialogs/setting_profiles.py:313 ../vdms_dialogs/setting_profiles.py:332
 msgid "Profile already stored with same name"
 msgstr "Un profilo e già stato salvato con lo stesso nome"
 
-#: ../vdms_dialogs/presets_addnew.py:317
+#: ../vdms_dialogs/setting_profiles.py:317
 msgid "Successful storing!"
 msgstr "Profilo salvato con successo!"
 
-#: ../vdms_dialogs/presets_addnew.py:335
+#: ../vdms_dialogs/setting_profiles.py:335
 msgid "Successful changes!"
 msgstr "Modifiche riuscite!"
 

--- a/videomass/locale/nl_NL/LC_MESSAGES/videomass.po
+++ b/videomass/locale/nl_NL/LC_MESSAGES/videomass.po
@@ -909,7 +909,7 @@ msgid "Cross-platform graphical user interface for FFmpeg and yt-dlp.\n"
 msgstr ""
 "Multiplatform grafische gebruikersomgeving voor FFmpeg en youtube-dl.\n"
 
-#: ../vdms_dialogs/presets_addnew.py:39
+#: ../vdms_dialogs/setting_profiles.py:39
 msgid ""
 "One-Pass, Do not start with `ffmpeg -i filename`; do not end with `output-"
 "filename`"
@@ -917,7 +917,7 @@ msgstr ""
 "One-Pass, begin niet met `ffmpeg -i filename`; eindig niet met `output-"
 "filename`"
 
-#: ../vdms_dialogs/presets_addnew.py:43
+#: ../vdms_dialogs/setting_profiles.py:43
 msgid ""
 "Two-Pass (optional), Do not start with `ffmpeg -i filename`; do not end with "
 "`output-filename`"
@@ -925,41 +925,41 @@ msgstr ""
 "Two-Pass (optioneel), begin niet met `ffmpeg -i filename`; eindig niet met "
 "`output-filename`"
 
-#: ../vdms_dialogs/presets_addnew.py:47
+#: ../vdms_dialogs/setting_profiles.py:47
 msgid "Supported Formats list (optional). Do not include the `.`"
 msgstr "Lijst van ondersteunde formaten (optioneel). Laat de `.` achterwege"
 
-#: ../vdms_dialogs/presets_addnew.py:48
+#: ../vdms_dialogs/setting_profiles.py:48
 msgid "Output Format. Empty to copy format and codec. Do not include the `.`"
 msgstr ""
 "Output formaat. Bij weglaten worden formaat en codec gekopieerd. Laat de `.` "
 "achterwege"
 
-#: ../vdms_dialogs/presets_addnew.py:75
+#: ../vdms_dialogs/setting_profiles.py:75
 msgid "Profile Name"
 msgstr "Profiel Naam"
 
-#: ../vdms_dialogs/presets_addnew.py:81 ../vdms_panels/presets_manager.py:433
+#: ../vdms_dialogs/setting_profiles.py:81 ../vdms_panels/presets_manager.py:433
 msgid "Description"
 msgstr "Beschrijving"
 
-#: ../vdms_dialogs/presets_addnew.py:165
+#: ../vdms_dialogs/setting_profiles.py:165
 msgid "A short profile name"
 msgstr "Een korte profiel naam"
 
-#: ../vdms_dialogs/presets_addnew.py:166
+#: ../vdms_dialogs/setting_profiles.py:166
 msgid "A long description of the profile"
 msgstr "Een uitgebreide beschrijving van het profiel"
 
-#: ../vdms_dialogs/presets_addnew.py:167 ../vdms_panels/presets_manager.py:306
+#: ../vdms_dialogs/setting_profiles.py:167 ../vdms_panels/presets_manager.py:306
 msgid "FFmpeg arguments code for one-pass encoding"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:169 ../vdms_panels/presets_manager.py:308
+#: ../vdms_dialogs/setting_profiles.py:169 ../vdms_panels/presets_manager.py:308
 msgid "FFmpeg arguments code for two-pass encoding"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:171
+#: ../vdms_dialogs/setting_profiles.py:171
 #, fuzzy
 #| msgid "One or more comma-separated format names to include in the profile"
 msgid ""
@@ -967,13 +967,13 @@ msgid ""
 "profile."
 msgstr "Een of meerdere komma-gescheiden formaat namen voor het profiel"
 
-#: ../vdms_dialogs/presets_addnew.py:174
+#: ../vdms_dialogs/setting_profiles.py:174
 msgid "Output format extension. Leave empty to copy codec and format"
 msgstr ""
 "Bestandsextensie van output formaat. Laat leeg om codec en bestandsformaat "
 "te kopiëren"
 
-#: ../vdms_dialogs/presets_addnew.py:177 ../vdms_dialogs/presets_addnew.py:181
+#: ../vdms_dialogs/setting_profiles.py:177 ../vdms_dialogs/setting_profiles.py:181
 #: ../vdms_panels/presets_manager.py:314
 msgid ""
 "Any optional arguments to add before input file on the two-pass encoding, e."
@@ -981,23 +981,23 @@ msgid ""
 "CUDA."
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:290
+#: ../vdms_dialogs/setting_profiles.py:290
 msgid "Incomplete profile assignments"
 msgstr "Onvolledige profiel-toewijzingen"
 
-#: ../vdms_dialogs/presets_addnew.py:297
+#: ../vdms_dialogs/setting_profiles.py:297
 msgid "Formats must be comma-separated"
 msgstr "Formaten moeten gescheiden zijn door komma's"
 
-#: ../vdms_dialogs/presets_addnew.py:313 ../vdms_dialogs/presets_addnew.py:332
+#: ../vdms_dialogs/setting_profiles.py:313 ../vdms_dialogs/setting_profiles.py:332
 msgid "Profile already stored with same name"
 msgstr "Profiel reeds opgeslagen onder dezelfde naam"
 
-#: ../vdms_dialogs/presets_addnew.py:317
+#: ../vdms_dialogs/setting_profiles.py:317
 msgid "Successful storing!"
 msgstr "Opslag was succesvol!"
 
-#: ../vdms_dialogs/presets_addnew.py:335
+#: ../vdms_dialogs/setting_profiles.py:335
 msgid "Successful changes!"
 msgstr "Veranderingen waren succesvol!"
 

--- a/videomass/locale/pt_BR/LC_MESSAGES/videomass.po
+++ b/videomass/locale/pt_BR/LC_MESSAGES/videomass.po
@@ -897,7 +897,7 @@ msgstr "Concluído!"
 msgid "Cross-platform graphical user interface for FFmpeg and yt-dlp.\n"
 msgstr "Interface gráfica multiplataforma para FFmpeg e youtube-dl.\n"
 
-#: ../vdms_dialogs/presets_addnew.py:39
+#: ../vdms_dialogs/setting_profiles.py:39
 msgid ""
 "One-Pass, Do not start with `ffmpeg -i filename`; do not end with `output-"
 "filename`"
@@ -905,7 +905,7 @@ msgstr ""
 "Primeira passagem, não comece com `ffmpeg -i filename`; não termine com "
 "`output-filename"
 
-#: ../vdms_dialogs/presets_addnew.py:43
+#: ../vdms_dialogs/setting_profiles.py:43
 msgid ""
 "Two-Pass (optional), Do not start with `ffmpeg -i filename`; do not end with "
 "`output-filename`"
@@ -913,40 +913,40 @@ msgstr ""
 "Segunda passagem (opcional), não comece com `ffmpeg -i filename`; não "
 "termine com `output-filename"
 
-#: ../vdms_dialogs/presets_addnew.py:47
+#: ../vdms_dialogs/setting_profiles.py:47
 msgid "Supported Formats list (optional). Do not include the `.`"
 msgstr "Lista de formatos suportados (opcional). Não inclua o `.`"
 
-#: ../vdms_dialogs/presets_addnew.py:48
+#: ../vdms_dialogs/setting_profiles.py:48
 msgid "Output Format. Empty to copy format and codec. Do not include the `.`"
 msgstr ""
 "Formato de saída. Vazio para copiar o formato e o codec. Não inclua o `.`"
 
-#: ../vdms_dialogs/presets_addnew.py:75
+#: ../vdms_dialogs/setting_profiles.py:75
 msgid "Profile Name"
 msgstr "Nome do perfil"
 
-#: ../vdms_dialogs/presets_addnew.py:81 ../vdms_panels/presets_manager.py:433
+#: ../vdms_dialogs/setting_profiles.py:81 ../vdms_panels/presets_manager.py:433
 msgid "Description"
 msgstr "Descrição"
 
-#: ../vdms_dialogs/presets_addnew.py:165
+#: ../vdms_dialogs/setting_profiles.py:165
 msgid "A short profile name"
 msgstr "Um nome de perfil curto"
 
-#: ../vdms_dialogs/presets_addnew.py:166
+#: ../vdms_dialogs/setting_profiles.py:166
 msgid "A long description of the profile"
 msgstr "Uma longa descrição do perfil"
 
-#: ../vdms_dialogs/presets_addnew.py:167 ../vdms_panels/presets_manager.py:306
+#: ../vdms_dialogs/setting_profiles.py:167 ../vdms_panels/presets_manager.py:306
 msgid "FFmpeg arguments code for one-pass encoding"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:169 ../vdms_panels/presets_manager.py:308
+#: ../vdms_dialogs/setting_profiles.py:169 ../vdms_panels/presets_manager.py:308
 msgid "FFmpeg arguments code for two-pass encoding"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:171
+#: ../vdms_dialogs/setting_profiles.py:171
 #, fuzzy
 #| msgid "One or more comma-separated format names to include in the profile"
 msgid ""
@@ -955,12 +955,12 @@ msgid ""
 msgstr ""
 "Um ou mais nomes de formato separados por vírgula para incluir no perfil"
 
-#: ../vdms_dialogs/presets_addnew.py:174
+#: ../vdms_dialogs/setting_profiles.py:174
 msgid "Output format extension. Leave empty to copy codec and format"
 msgstr ""
 "Extensão do formato de saída. Deixe em branco para copiar o codec e formatar"
 
-#: ../vdms_dialogs/presets_addnew.py:177 ../vdms_dialogs/presets_addnew.py:181
+#: ../vdms_dialogs/setting_profiles.py:177 ../vdms_dialogs/setting_profiles.py:181
 #: ../vdms_panels/presets_manager.py:314
 msgid ""
 "Any optional arguments to add before input file on the two-pass encoding, e."
@@ -968,23 +968,23 @@ msgid ""
 "CUDA."
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:290
+#: ../vdms_dialogs/setting_profiles.py:290
 msgid "Incomplete profile assignments"
 msgstr "Atribuições de perfil incompletas"
 
-#: ../vdms_dialogs/presets_addnew.py:297
+#: ../vdms_dialogs/setting_profiles.py:297
 msgid "Formats must be comma-separated"
 msgstr "Os formatos devem ser separados por vírgulas"
 
-#: ../vdms_dialogs/presets_addnew.py:313 ../vdms_dialogs/presets_addnew.py:332
+#: ../vdms_dialogs/setting_profiles.py:313 ../vdms_dialogs/setting_profiles.py:332
 msgid "Profile already stored with same name"
 msgstr "Perfil já armazenado com o mesmo nome"
 
-#: ../vdms_dialogs/presets_addnew.py:317
+#: ../vdms_dialogs/setting_profiles.py:317
 msgid "Successful storing!"
 msgstr "Armazenamento bem-sucedido!"
 
-#: ../vdms_dialogs/presets_addnew.py:335
+#: ../vdms_dialogs/setting_profiles.py:335
 msgid "Successful changes!"
 msgstr "Mudanças bem-sucedidas!"
 

--- a/videomass/locale/ru_RU/LC_MESSAGES/videomass.po
+++ b/videomass/locale/ru_RU/LC_MESSAGES/videomass.po
@@ -873,7 +873,7 @@ msgstr ""
 "Кроссплатформенный графический пользовательский интерфейс для FFmpeg и yt-"
 "dlp.\n"
 
-#: ../vdms_dialogs/presets_addnew.py:39
+#: ../vdms_dialogs/setting_profiles.py:39
 msgid ""
 "One-Pass, Do not start with `ffmpeg -i filename`; do not end with `output-"
 "filename`"
@@ -881,7 +881,7 @@ msgstr ""
 "Первый проход, Не начинайте с: `ffmpeg -i filename`; не заканчивайте `output-"
 "filename`"
 
-#: ../vdms_dialogs/presets_addnew.py:43
+#: ../vdms_dialogs/setting_profiles.py:43
 msgid ""
 "Two-Pass (optional), Do not start with `ffmpeg -i filename`; do not end with "
 "`output-filename`"
@@ -889,41 +889,41 @@ msgstr ""
 "Второй проход (по желанию), Не начинайте с `ffmpeg -i filename`; не "
 "заканчивайте `output-filename`"
 
-#: ../vdms_dialogs/presets_addnew.py:47
+#: ../vdms_dialogs/setting_profiles.py:47
 msgid "Supported Formats list (optional). Do not include the `.`"
 msgstr "Список поддерживаемых форматов (необязательно). Не указывать точку `.`"
 
-#: ../vdms_dialogs/presets_addnew.py:48
+#: ../vdms_dialogs/setting_profiles.py:48
 msgid "Output Format. Empty to copy format and codec. Do not include the `.`"
 msgstr ""
 "Выходной формат. Пусто для копирования формата и кодека. Не указывать точку "
 "`.`"
 
-#: ../vdms_dialogs/presets_addnew.py:75
+#: ../vdms_dialogs/setting_profiles.py:75
 msgid "Profile Name"
 msgstr "Имя профиля"
 
-#: ../vdms_dialogs/presets_addnew.py:81 ../vdms_panels/presets_manager.py:433
+#: ../vdms_dialogs/setting_profiles.py:81 ../vdms_panels/presets_manager.py:433
 msgid "Description"
 msgstr "Описание"
 
-#: ../vdms_dialogs/presets_addnew.py:165
+#: ../vdms_dialogs/setting_profiles.py:165
 msgid "A short profile name"
 msgstr "Краткое имя профиля"
 
-#: ../vdms_dialogs/presets_addnew.py:166
+#: ../vdms_dialogs/setting_profiles.py:166
 msgid "A long description of the profile"
 msgstr "Подробное описание профиля"
 
-#: ../vdms_dialogs/presets_addnew.py:167 ../vdms_panels/presets_manager.py:306
+#: ../vdms_dialogs/setting_profiles.py:167 ../vdms_panels/presets_manager.py:306
 msgid "FFmpeg arguments code for one-pass encoding"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:169 ../vdms_panels/presets_manager.py:308
+#: ../vdms_dialogs/setting_profiles.py:169 ../vdms_panels/presets_manager.py:308
 msgid "FFmpeg arguments code for two-pass encoding"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:171
+#: ../vdms_dialogs/setting_profiles.py:171
 #, fuzzy
 #| msgid "One or more comma-separated format names to include in the profile"
 msgid ""
@@ -933,12 +933,12 @@ msgstr ""
 "Одно или несколько имен форматов, разделенных запятыми, для включения в "
 "профиль"
 
-#: ../vdms_dialogs/presets_addnew.py:174
+#: ../vdms_dialogs/setting_profiles.py:174
 msgid "Output format extension. Leave empty to copy codec and format"
 msgstr ""
 "Расширение формата вывода. Оставьте пустым, чтобы скопировать кодек и формат"
 
-#: ../vdms_dialogs/presets_addnew.py:177 ../vdms_dialogs/presets_addnew.py:181
+#: ../vdms_dialogs/setting_profiles.py:177 ../vdms_dialogs/setting_profiles.py:181
 #: ../vdms_panels/presets_manager.py:314
 msgid ""
 "Any optional arguments to add before input file on the two-pass encoding, e."
@@ -946,23 +946,23 @@ msgid ""
 "CUDA."
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:290
+#: ../vdms_dialogs/setting_profiles.py:290
 msgid "Incomplete profile assignments"
 msgstr "Неполные данные профиля"
 
-#: ../vdms_dialogs/presets_addnew.py:297
+#: ../vdms_dialogs/setting_profiles.py:297
 msgid "Formats must be comma-separated"
 msgstr "Форматы должны быть разделены запятыми"
 
-#: ../vdms_dialogs/presets_addnew.py:313 ../vdms_dialogs/presets_addnew.py:332
+#: ../vdms_dialogs/setting_profiles.py:313 ../vdms_dialogs/setting_profiles.py:332
 msgid "Profile already stored with same name"
 msgstr "Профиль с таким именем уже сохранен"
 
-#: ../vdms_dialogs/presets_addnew.py:317
+#: ../vdms_dialogs/setting_profiles.py:317
 msgid "Successful storing!"
 msgstr "Профиль успешно сохранен!"
 
-#: ../vdms_dialogs/presets_addnew.py:335
+#: ../vdms_dialogs/setting_profiles.py:335
 msgid "Successful changes!"
 msgstr "Успешные изменения!"
 

--- a/videomass/locale/videomass.pot
+++ b/videomass/locale/videomass.pot
@@ -727,61 +727,61 @@ msgstr ""
 msgid "Cross-platform graphical user interface for FFmpeg and yt-dlp.\n"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:39
+#: ../vdms_dialogs/setting_profiles.py:39
 msgid ""
 "One-Pass, Do not start with `ffmpeg -i filename`; do not end with `output-"
 "filename`"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:43
+#: ../vdms_dialogs/setting_profiles.py:43
 msgid ""
 "Two-Pass (optional), Do not start with `ffmpeg -i filename`; do not end with "
 "`output-filename`"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:47
+#: ../vdms_dialogs/setting_profiles.py:47
 msgid "Supported Formats list (optional). Do not include the `.`"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:48
+#: ../vdms_dialogs/setting_profiles.py:48
 msgid "Output Format. Empty to copy format and codec. Do not include the `.`"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:75
+#: ../vdms_dialogs/setting_profiles.py:75
 msgid "Profile Name"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:81 ../vdms_panels/presets_manager.py:433
+#: ../vdms_dialogs/setting_profiles.py:81 ../vdms_panels/presets_manager.py:433
 msgid "Description"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:165
+#: ../vdms_dialogs/setting_profiles.py:165
 msgid "A short profile name"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:166
+#: ../vdms_dialogs/setting_profiles.py:166
 msgid "A long description of the profile"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:167 ../vdms_panels/presets_manager.py:306
+#: ../vdms_dialogs/setting_profiles.py:167 ../vdms_panels/presets_manager.py:306
 msgid "FFmpeg arguments code for one-pass encoding"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:169 ../vdms_panels/presets_manager.py:308
+#: ../vdms_dialogs/setting_profiles.py:169 ../vdms_panels/presets_manager.py:308
 msgid "FFmpeg arguments code for two-pass encoding"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:171
+#: ../vdms_dialogs/setting_profiles.py:171
 msgid ""
 "One or more comma-separated format names that are not compatible with this "
 "profile."
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:174
+#: ../vdms_dialogs/setting_profiles.py:174
 msgid "Output format extension. Leave empty to copy codec and format"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:177 ../vdms_dialogs/presets_addnew.py:181
+#: ../vdms_dialogs/setting_profiles.py:177 ../vdms_dialogs/setting_profiles.py:181
 #: ../vdms_panels/presets_manager.py:314
 msgid ""
 "Any optional arguments to add before input file on the two-pass encoding, e."
@@ -789,23 +789,23 @@ msgid ""
 "CUDA."
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:290
+#: ../vdms_dialogs/setting_profiles.py:290
 msgid "Incomplete profile assignments"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:297
+#: ../vdms_dialogs/setting_profiles.py:297
 msgid "Formats must be comma-separated"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:313 ../vdms_dialogs/presets_addnew.py:332
+#: ../vdms_dialogs/setting_profiles.py:313 ../vdms_dialogs/setting_profiles.py:332
 msgid "Profile already stored with same name"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:317
+#: ../vdms_dialogs/setting_profiles.py:317
 msgid "Successful storing!"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:335
+#: ../vdms_dialogs/setting_profiles.py:335
 msgid "Successful changes!"
 msgstr ""
 

--- a/videomass/locale/zh_CN/LC_MESSAGES/videomass.po
+++ b/videomass/locale/zh_CN/LC_MESSAGES/videomass.po
@@ -900,7 +900,7 @@ msgstr ""
 "用于FFmpeg和youtube-dl.n的跨平台图形界面。\n"
 "\n"
 
-#: ../vdms_dialogs/presets_addnew.py:39
+#: ../vdms_dialogs/setting_profiles.py:39
 #, fuzzy
 msgid ""
 "One-Pass, Do not start with `ffmpeg -i filename`; do not end with `output-"
@@ -908,7 +908,7 @@ msgid ""
 msgstr ""
 "一次性通过，不要以`ffmpeg -i filename`开始；不要以`output-filename`结束。"
 
-#: ../vdms_dialogs/presets_addnew.py:43
+#: ../vdms_dialogs/setting_profiles.py:43
 #, fuzzy
 msgid ""
 "Two-Pass (optional), Do not start with `ffmpeg -i filename`; do not end with "
@@ -917,52 +917,52 @@ msgstr ""
 "两次通过（可选），不要以`ffmpeg -i filename`开始；不要以`output-filename`结"
 "束。"
 
-#: ../vdms_dialogs/presets_addnew.py:47
+#: ../vdms_dialogs/setting_profiles.py:47
 msgid "Supported Formats list (optional). Do not include the `.`"
 msgstr "支持的格式列表（可选）。不要包括\".\""
 
-#: ../vdms_dialogs/presets_addnew.py:48
+#: ../vdms_dialogs/setting_profiles.py:48
 msgid "Output Format. Empty to copy format and codec. Do not include the `.`"
 msgstr "输出格式。清空以复制格式和编解码器。不要包括\".\""
 
-#: ../vdms_dialogs/presets_addnew.py:75
+#: ../vdms_dialogs/setting_profiles.py:75
 msgid "Profile Name"
 msgstr "配置文件名称"
 
-#: ../vdms_dialogs/presets_addnew.py:81 ../vdms_panels/presets_manager.py:433
+#: ../vdms_dialogs/setting_profiles.py:81 ../vdms_panels/presets_manager.py:433
 msgid "Description"
 msgstr "描述"
 
-#: ../vdms_dialogs/presets_addnew.py:165
+#: ../vdms_dialogs/setting_profiles.py:165
 #, fuzzy
 msgid "A short profile name"
 msgstr "一个简短的个人资料名称"
 
-#: ../vdms_dialogs/presets_addnew.py:166
+#: ../vdms_dialogs/setting_profiles.py:166
 #, fuzzy
 msgid "A long description of the profile"
 msgstr "对简介的长篇描述"
 
-#: ../vdms_dialogs/presets_addnew.py:167 ../vdms_panels/presets_manager.py:306
+#: ../vdms_dialogs/setting_profiles.py:167 ../vdms_panels/presets_manager.py:306
 msgid "FFmpeg arguments code for one-pass encoding"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:169 ../vdms_panels/presets_manager.py:308
+#: ../vdms_dialogs/setting_profiles.py:169 ../vdms_panels/presets_manager.py:308
 msgid "FFmpeg arguments code for two-pass encoding"
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:171
+#: ../vdms_dialogs/setting_profiles.py:171
 #, fuzzy
 msgid ""
 "One or more comma-separated format names that are not compatible with this "
 "profile."
 msgstr "一个或多个逗号分隔的格式名称，以包括在简介中。"
 
-#: ../vdms_dialogs/presets_addnew.py:174
+#: ../vdms_dialogs/setting_profiles.py:174
 msgid "Output format extension. Leave empty to copy codec and format"
 msgstr "输出格式的扩展名。留空以复制编解码器和格式"
 
-#: ../vdms_dialogs/presets_addnew.py:177 ../vdms_dialogs/presets_addnew.py:181
+#: ../vdms_dialogs/setting_profiles.py:177 ../vdms_dialogs/setting_profiles.py:181
 #: ../vdms_panels/presets_manager.py:314
 msgid ""
 "Any optional arguments to add before input file on the two-pass encoding, e."
@@ -970,24 +970,24 @@ msgid ""
 "CUDA."
 msgstr ""
 
-#: ../vdms_dialogs/presets_addnew.py:290
+#: ../vdms_dialogs/setting_profiles.py:290
 #, fuzzy
 msgid "Incomplete profile assignments"
 msgstr "不完整的个人资料分配"
 
-#: ../vdms_dialogs/presets_addnew.py:297
+#: ../vdms_dialogs/setting_profiles.py:297
 msgid "Formats must be comma-separated"
 msgstr "格式必须是以逗号分隔的"
 
-#: ../vdms_dialogs/presets_addnew.py:313 ../vdms_dialogs/presets_addnew.py:332
+#: ../vdms_dialogs/setting_profiles.py:313 ../vdms_dialogs/setting_profiles.py:332
 msgid "Profile already stored with same name"
 msgstr "已有相同名称的配置文件"
 
-#: ../vdms_dialogs/presets_addnew.py:317
+#: ../vdms_dialogs/setting_profiles.py:317
 msgid "Successful storing!"
 msgstr "储存成功!"
 
-#: ../vdms_dialogs/presets_addnew.py:335
+#: ../vdms_dialogs/setting_profiles.py:335
 msgid "Successful changes!"
 msgstr "成功更改!"
 

--- a/videomass/vdms_dialogs/presets_addnew.py
+++ b/videomass/vdms_dialogs/presets_addnew.py
@@ -75,14 +75,14 @@ class MemPresets(wx.Dialog):
                                                   _("Profile Name")),
                                      wx.VERTICAL)
         size_namedescr.Add(box_name, 1, wx.ALL | wx.EXPAND, 5)
-        self.txt_name = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.HSCROLL)
+        self.txt_name = wx.TextCtrl(self, wx.ID_ANY, "")
         box_name.Add(self.txt_name, 0, wx.ALL | wx.EXPAND, 5)
         box_descr = wx.StaticBoxSizer(wx.StaticBox(self, wx.ID_ANY,
                                                    _("Description")),
                                       wx.VERTICAL
                                       )
         size_namedescr.Add(box_descr, 1, wx.ALL | wx.EXPAND, 5)
-        self.txt_descript = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.HSCROLL)
+        self.txt_descript = wx.TextCtrl(self, wx.ID_ANY, "")
         box_descr.Add(self.txt_descript, 0, wx.ALL | wx.EXPAND, 5)
         box_pass1 = wx.StaticBoxSizer(wx.StaticBox(self, wx.ID_ANY,
                                                    MemPresets.PASS_1),
@@ -93,9 +93,7 @@ class MemPresets(wx.Dialog):
                                       style=wx.TE_MULTILINE
                                       )
         box_pass1.Add(self.pass_1_cmd, 1, wx.ALL | wx.EXPAND, 5)
-        self.pass_1_pre = wx.TextCtrl(self, wx.ID_ANY, "",
-                                      style=wx.HSCROLL
-                                      )
+        self.pass_1_pre = wx.TextCtrl(self, wx.ID_ANY, "")
         box_pass1.Add(self.pass_1_pre, 0, wx.ALL | wx.EXPAND, 5)
         box_pass2 = wx.StaticBoxSizer(wx.StaticBox(self, wx.ID_ANY,
                                                    MemPresets.PASS_2),
@@ -106,9 +104,7 @@ class MemPresets(wx.Dialog):
                                       style=wx.TE_MULTILINE
                                       )
         box_pass2.Add(self.pass_2_cmd, 1, wx.ALL | wx.EXPAND, 5)
-        self.pass_2_pre = wx.TextCtrl(self, wx.ID_ANY, "",
-                                      style=wx.HSCROLL
-                                      )
+        self.pass_2_pre = wx.TextCtrl(self, wx.ID_ANY, "")
         box_pass2.Add(self.pass_2_pre, 0, wx.ALL | wx.EXPAND, 5)
         size_formats = wx.BoxSizer(wx.HORIZONTAL)
         size_base.Add(size_formats, 0, wx.ALL | wx.EXPAND, 0)

--- a/videomass/vdms_dialogs/setting_profiles.py
+++ b/videomass/vdms_dialogs/setting_profiles.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 """
-Name: presets_addnew.py
+Name: setting_profiles.py
 Porpose: profiles storing and profiles editing dialog
 Compatibility: Python3, wxPython Phoenix
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
@@ -31,7 +31,7 @@ from videomass.vdms_io.presets_manager_prop import write_new_profile
 from videomass.vdms_io.presets_manager_prop import edit_existing_profile
 
 
-class MemPresets(wx.Dialog):
+class SettingProfile(wx.Dialog):
     """
     Show dialog to store and edit profiles of a selected preset.
 
@@ -85,7 +85,7 @@ class MemPresets(wx.Dialog):
         self.txt_descript = wx.TextCtrl(self, wx.ID_ANY, "")
         box_descr.Add(self.txt_descript, 0, wx.ALL | wx.EXPAND, 5)
         box_pass1 = wx.StaticBoxSizer(wx.StaticBox(self, wx.ID_ANY,
-                                                   MemPresets.PASS_1),
+                                                   SettingProfile.PASS_1),
                                       wx.VERTICAL
                                       )
         size_base.Add(box_pass1, 1, wx.ALL | wx.EXPAND, 5)
@@ -96,7 +96,7 @@ class MemPresets(wx.Dialog):
         self.pass_1_pre = wx.TextCtrl(self, wx.ID_ANY, "")
         box_pass1.Add(self.pass_1_pre, 0, wx.ALL | wx.EXPAND, 5)
         box_pass2 = wx.StaticBoxSizer(wx.StaticBox(self, wx.ID_ANY,
-                                                   MemPresets.PASS_2),
+                                                   SettingProfile.PASS_2),
                                       wx.VERTICAL
                                       )
         size_base.Add(box_pass2, 1, wx.ALL | wx.EXPAND, 5)
@@ -109,7 +109,7 @@ class MemPresets(wx.Dialog):
         size_formats = wx.BoxSizer(wx.HORIZONTAL)
         size_base.Add(size_formats, 0, wx.ALL | wx.EXPAND, 0)
         box_supp = wx.StaticBoxSizer(wx.StaticBox(self, wx.ID_ANY,
-                                                  MemPresets.SUPFORMAT),
+                                                  SettingProfile.SUPFORMAT),
                                      wx.VERTICAL
                                      )
         size_formats.Add(box_supp, 1, wx.ALL | wx.EXPAND, 5)
@@ -117,7 +117,7 @@ class MemPresets(wx.Dialog):
         self.txt_supp = wx.TextCtrl(self, wx.ID_ANY, "")
         box_supp.Add(self.txt_supp, 0, wx.ALL | wx.EXPAND, 5)
         box_format = wx.StaticBoxSizer(wx.StaticBox(self, wx.ID_ANY,
-                                                    MemPresets.OUTFORMAT),
+                                                    SettingProfile.OUTFORMAT),
                                        wx.VERTICAL
                                        )
         size_formats.Add(box_format, 1, wx.ALL | wx.EXPAND, 5)

--- a/videomass/vdms_main/main_frame.py
+++ b/videomass/vdms_main/main_frame.py
@@ -449,7 +449,7 @@ class MainFrame(wx.Frame):
         # ------------------ Edit menu
         editButton = wx.Menu()
         dscrp = (_("Rename selected entry\tCtrl+R"),
-                 _("Rename the output file name"))
+                 _("Rename the output file"))
         self.rename = editButton.Append(wx.ID_ANY, dscrp[0], dscrp[1])
         self.rename.Enable(False)
         dscrp = (_("Batch renaming\tCtrl+B"),

--- a/videomass/vdms_panels/av_conversions.py
+++ b/videomass/vdms_panels/av_conversions.py
@@ -33,7 +33,7 @@ from videomass.vdms_utils.get_bmpfromsvg import get_bmp
 from videomass.vdms_io.io_tools import stream_play
 from videomass.vdms_io.checkup import check_files
 from videomass.vdms_dialogs.epilogue import Formula
-from videomass.vdms_dialogs import presets_addnew
+from videomass.vdms_dialogs import setting_profiles
 from videomass.vdms_dialogs.filter_crop import Crop
 from videomass.vdms_dialogs.filter_transpose import Transpose
 from videomass.vdms_dialogs.filter_denoisers import Denoisers
@@ -1292,7 +1292,7 @@ class AV_Conv(wx.Panel):
 
             title = _('New Profile - Preset "{0}"').format(basename)
 
-        with presets_addnew.MemPresets(self, 'addprofile',
+        with setting_profiles.SettingProfile(self, 'addprofile',
                                        basename,
                                        parameters,
                                        title,

--- a/videomass/vdms_panels/presets_manager.py
+++ b/videomass/vdms_panels/presets_manager.py
@@ -41,7 +41,7 @@ from videomass.vdms_utils.utils import copy_on
 from videomass.vdms_utils.utils import copydir_recursively
 from videomass.vdms_utils.utils import copy_missing_data
 from videomass.vdms_io.checkup import check_files
-from videomass.vdms_dialogs import presets_addnew
+from videomass.vdms_dialogs import setting_profiles
 from videomass.vdms_dialogs.epilogue import Formula
 
 
@@ -830,12 +830,12 @@ class PrstPan(wx.Panel):
         """
         filename = self.cmbx_prst.GetValue()
         title = _('New Profile - Preset "{}"').format(filename)
-        prstdialog = presets_addnew.MemPresets(self,
-                                               'newprofile',
-                                               filename,
-                                               None,
-                                               title,
-                                               )
+        prstdialog = setting_profiles.SettingProfile(self,
+                                                     'newprofile',
+                                                     filename,
+                                                     None,
+                                                     title,
+                                                     )
         ret = prstdialog.ShowModal()
         if ret == wx.ID_OK:
             self.reset_list()  # re-charging lctrl with newer
@@ -848,11 +848,11 @@ class PrstPan(wx.Panel):
         """
         filename = self.cmbx_prst.GetValue()
         title = _('*Edit Profile - Preset "{}"').format(filename)
-        prstdialog = presets_addnew.MemPresets(self,
-                                               'edit',
-                                               filename,
-                                               self.array,
-                                               title)
+        prstdialog = setting_profiles.SettingProfile(self,
+                                                     'edit',
+                                                     filename,
+                                                     self.array,
+                                                     title)
         ret = prstdialog.ShowModal()
         if ret == wx.ID_OK:
             self.reset_list()  # re-charging lctrl with newer


### PR DESCRIPTION
This PR removes the `wx.HSCROLL` style of `wx.TextCtrl` on `SettingProfile` dialog, as it causes display problems in some text fields on MS-Windows. This style probably requires you to specify a given `size` which is not desirable in this dialog.