### PR TITLE
fix audio/video qualities for YouTube DL

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,13 +7,14 @@ License: GPL3
 Change Log:
 
 +------------------------------------+
-Thu, 09 May 2024 V.5.0.13
+Thu, 10 May 2024 V.5.0.13
 
   * [YouTube Downloader] Fix `--playlist-items` using executable.
   * [YouTube Downloader] Improved playlists/channels check before start
     download.
   * Update english user guide documentation (pdf docs) and related references.
   * Fixed wrong deinterlace command option using w3fdif filter.
+  * [YouTube Downloader] Fixed audio/video qualities (see #305 #307)
 
 +------------------------------------+
 Mon, 29 Apr 2024 V.5.0.12

--- a/debian/changelog
+++ b/debian/changelog
@@ -5,8 +5,9 @@ videomass (5.0.13-1) UNRELEASED; urgency=medium
     download.
   * Update english user guide documentation (pdf docs) and related references.
   * Fixed wrong deinterlace command option using w3fdif filter.
+  * [YouTube Downloader] Fixed audio/video qualities (see #305 #307)
 
- -- Gianluca Pernigotto <jeanlucperni@gmail.com>  Thu, 09 May 2024 00:00:00 +0200
+ -- Gianluca Pernigotto <jeanlucperni@gmail.com>  Fri, 10 May 2024 13:00:00 +0200
 
 videomass (5.0.12-1) UNRELEASED; urgency=medium
 


### PR DESCRIPTION
Closes #305 
Closes #307 

This PR try to fix qualities issues found on various sites other than YouTube.com related to the best and worst quality downloads of audio and video files.

The following options have been changed:

- Download videos by resolution 
  - changed command line parameters according to yt-dlp documentation.
- Download split audio and video
  - The ability to select the file format to download has been removed.
- Download audio only 
  - The ability of selecting the best or worst file has been added and the `bestaudio` arguments have been removed in favor of `bestaudio/worst` or `worstaudio/worst`  (see #307 ).