### PR TITLE
ytdlp using importlib

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,13 +7,16 @@ License: GPL3
 Change Log:
 
 +------------------------------------+
-Sat, 15 June 2024 V.5.0.14
+Thu, 20 June 2024 V.5.0.15
 
   * Videomass now uses `hatchling` as the default build backend which replaces
     `setuptools`.
   * Improved startup configuration script.
   * Created a new convenient `__about__` script to store program description
     data which replace `msg_info`.
+  * New feature created that allows you to import the yt_dlp module externally,
+    replacing the one installed on your system or the one on your virtual
+    environment or the one on the standalone application (see #328) .
 
 +------------------------------------+
 Thu, 30 May 2024 V.5.0.14

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,7 +7,7 @@ License: GPL3
 Change Log:
 
 +------------------------------------+
-Thu, 20 June 2024 V.5.0.15
+Thu, 22 June 2024 V.5.0.15
 
   * Videomass now uses `hatchling` as the default build backend which replaces
     `setuptools`.
@@ -16,7 +16,8 @@ Thu, 20 June 2024 V.5.0.15
     data which replace `msg_info`.
   * New feature created that allows you to import the yt_dlp module externally,
     replacing the one installed on your system or the one on your virtual
-    environment or the one on the standalone application (see #328) .
+    environment (see #328). Standalone application are excluded from using this
+    feature.
 
 +------------------------------------+
 Thu, 30 May 2024 V.5.0.14

--- a/README.md
+++ b/README.md
@@ -13,67 +13,11 @@ written in [Python3](https://www.python.org/) using the
 **[Features](https://jeanslack.github.io/Videomass/features.html)**   
 **[Screenshots](https://jeanslack.github.io/Videomass/screenshots.html)**   
 
-# Installing and Dependencies
-
-> ### For regular users (non-developers)   
-> If you are not a programmer or if you are not familiar with the command line 
-you can skip the whole part below and visit the 
-[Download and installation](https://jeanslack.github.io/Videomass/download_installation.html) 
-web page, which provides the information required to install Videomass on 
-each operating system.
-
-### Requirements
-- **[Python >=3.8.0 <=3.12.0](https://www.python.org/)**
-- **[wxPython-Phoenix >=4.0.7](https://wxpython.org/)**
-- **[PyPubSub >=4.0.3](https://pypi.org/project/PyPubSub/)**
-- **[requests >=2.26.0](https://pypi.org/project/requests/)**
-- **[ffmpeg >=5.1](https://ffmpeg.org/)**
-- **[ffprobe >=5.1](https://ffmpeg.org/ffprobe.html)** (usually bundled with ffmpeg)
-- **[ffplay >=5.1](http://ffmpeg.org/ffplay.html)** (usually bundled with ffmpeg)
-
-### Optionals
-- **[yt-dlp](https://github.com/yt-dlp/yt-dlp)**
-- **[atomicparsley](http://atomicparsley.sourceforge.net/)**
-
-### Install basic dependencies for your OS
-
-| **OS**           | **Basic Dependencies**                              |
-|:-----------------|:----------------------------------------------------|
-|Linux/FreeBSD     |*python3, wxpython-phoenix, pip, ffmpeg* |
-|MS Windows        |*python3, ffmpeg*                                    |
-|MacOs             |*python3, pip, ffmpeg*                   |
-
-### Install Videomass using pip
-
-Please Visit [Installing dependencies](https://github.com/jeanslack/Videomass/wiki/Installing-dependencies) 
-wiki page.
-
-# Execute Videomass from source code
-
-Videomass can be run without installing it, just download and unzip the 
-[source code](https://github.com/jeanslack/Videomass/releases) archive and 
-executing the "launcher" script inside the directory:   
-
-`python3 launcher`   
-
-> First, make sure you have installed at least all the above required 
-dependencies.   
-
-Please Visit [Installing dependencies](https://github.com/jeanslack/Videomass/wiki/Installing-dependencies) 
-wiki page.
-
-Videomass can also be run in interactive mode with the Python interpreter, 
-always within the same unpacked directory:   
-
-```Python
->>> from videomass import gui_app
->>> gui_app.main()
-```
-
 # Resources
 
-* [Support Page and Documentation](http://jeanslack.github.io/Videomass)
+* [Official Page](http://jeanslack.github.io/Videomass)
+* [Documentations](https://jeanslack.github.io/Videomass/videomass_use.html)
 * [Wiki page](https://github.com/jeanslack/Videomass/wiki)
 * [Videomass on PyPi](https://pypi.org/project/videomass/)
 * [Development](https://github.com/jeanslack/Videomass)
-* [Official download page](https://github.com/jeanslack/Videomass/releases)
+* [Downloads](https://github.com/jeanslack/Videomass/releases)

--- a/debian/changelog
+++ b/debian/changelog
@@ -7,9 +7,10 @@ videomass (5.0.15-1) UNRELEASED; urgency=medium
     data which replace `msg_info`.
   * New feature created that allows you to import the yt_dlp module externally,
     replacing the one installed on your system or the one on your virtual
-    environment or the one on the standalone application (see #328) .
+    environment (see #328). Standalone application are excluded from using this
+    feature.
 
- -- Gianluca Pernigotto <jeanlucperni@gmail.com>  Thu, 20 Jun 2024 17:00:00 +0200
+ -- Gianluca Pernigotto <jeanlucperni@gmail.com>  Sat, 22 Jun 2024 15:00:00 +0200
 
 videomass (5.0.14-1) UNRELEASED; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -5,8 +5,11 @@ videomass (5.0.15-1) UNRELEASED; urgency=medium
   * Improved startup configuration script.
   * Created a new convenient `__about__` script to store program description
     data which replace `msg_info`.
+  * New feature created that allows you to import the yt_dlp module externally,
+    replacing the one installed on your system or the one on your virtual
+    environment or the one on the standalone application (see #328) .
 
- -- Gianluca Pernigotto <jeanlucperni@gmail.com>  Sat, 15 Jun 2024 14:00:00 +0200
+ -- Gianluca Pernigotto <jeanlucperni@gmail.com>  Thu, 20 Jun 2024 17:00:00 +0200
 
 videomass (5.0.14-1) UNRELEASED; urgency=medium
 

--- a/videomass/gui_app.py
+++ b/videomass/gui_app.py
@@ -127,9 +127,9 @@ class Videomass(wx.App):
             if (self.appset['ytdlp-module-path']
                     and self.appset['ytdlp-usemodule']):
                 check = importer_init_file(self.appset['ytdlp-module-path'],
-                                          test=['yt_dlp.YoutubeDL',
-                                                'yt_dlp.version']
-                                          )
+                                           test=['yt_dlp.YoutubeDL',
+                                                 'yt_dlp.version']
+                                           )
                 if check:
                     wx.MessageBox(f"ERROR: {check}\n\n{msg}",
                                   _('Videomass - Error!'), wx.ICON_ERROR)

--- a/videomass/gui_app.py
+++ b/videomass/gui_app.py
@@ -6,7 +6,7 @@ Compatibility: Python3, wxPython Phoenix
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
 Copyleft - 2024 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
-Rev: Jan.13.2023
+Rev: June.19.2024
 Code checker: flake8, pylint
 
 This file is part of Videomass.
@@ -37,6 +37,7 @@ from videomass.vdms_sys.argparser import arguments
 from videomass.vdms_sys.configurator import DataSource
 from videomass.vdms_sys import app_const as appC
 from videomass.vdms_utils.utils import del_filecontents
+from videomass.vdms_sys.external_package import importer
 
 # add translation macro to builtin similar to what gettext does
 builtins.__dict__['_'] = wx.GetTranslation
@@ -121,7 +122,15 @@ class Videomass(wx.App):
         """
         msg = (_("To suppress this message on startup, please install "
                  "yt-dlp or disable it from the preferences."))
-        if self.appset['use-downloader']:
+
+        if self.appset['enable-ytdlp']:
+            if (self.appset['ytdlp-module-path']
+                    and self.appset['ytdlp-usemodule']):
+                test = importer("yt_dlp", self.appset['ytdlp-module-path'])
+                if test:
+                    wx.MessageBox(f"ERROR: {test}\n\n{msg}",
+                                  _('Videomass - Error!'), wx.ICON_ERROR)
+                    return False
             try:
                 import yt_dlp
                 self.appset['yt_dlp'] = True

--- a/videomass/gui_app.py
+++ b/videomass/gui_app.py
@@ -37,7 +37,7 @@ from videomass.vdms_sys.argparser import arguments
 from videomass.vdms_sys.configurator import DataSource
 from videomass.vdms_sys import app_const as appC
 from videomass.vdms_utils.utils import del_filecontents
-from videomass.vdms_sys.external_package import importer
+from videomass.vdms_sys.external_package import importer_init_file
 
 # add translation macro to builtin similar to what gettext does
 builtins.__dict__['_'] = wx.GetTranslation
@@ -126,9 +126,12 @@ class Videomass(wx.App):
         if self.appset['enable-ytdlp']:
             if (self.appset['ytdlp-module-path']
                     and self.appset['ytdlp-usemodule']):
-                test = importer("yt_dlp", self.appset['ytdlp-module-path'])
-                if test:
-                    wx.MessageBox(f"ERROR: {test}\n\n{msg}",
+                check = importer_init_file(self.appset['ytdlp-module-path'],
+                                          test=['yt_dlp.YoutubeDL',
+                                                'yt_dlp.version']
+                                          )
+                if check:
+                    wx.MessageBox(f"ERROR: {check}\n\n{msg}",
                                   _('Videomass - Error!'), wx.ICON_ERROR)
                     return False
             try:

--- a/videomass/vdms_dialogs/preferences.py
+++ b/videomass/vdms_dialogs/preferences.py
@@ -6,7 +6,7 @@ Compatibility: Python3, wxPython Phoenix
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
 Copyleft - 2024 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
-Rev: Apr.19.2024
+Rev: June.20.2024
 Code checker: flake8, pylint
 
 This file is part of Videomass.
@@ -28,6 +28,7 @@ import os
 import sys
 import webbrowser
 import wx
+import wx.lib.agw.hyperlink as hpl
 from videomass.vdms_utils.utils import detect_binaries
 from videomass.vdms_io import io_tools
 from videomass.vdms_sys.settings_manager import ConfigManager
@@ -208,17 +209,40 @@ class SetUp(wx.Dialog):
         labytexec = wx.StaticText(tabThree, wx.ID_ANY, msg)
         sizerytdlp.Add(labytexec, 0, wx.ALL | wx.EXPAND, 5)
         msg = _('Use the executable for downloads rather than API')
-        self.ckbx_dlexe = wx.CheckBox(tabThree, wx.ID_ANY, (msg))
-        sizerytdlp.Add(self.ckbx_dlexe, 0, wx.LEFT | wx.TOP, 5)
+        self.ckbx_ytexe = wx.CheckBox(tabThree, wx.ID_ANY, (msg))
+        sizerytdlp.Add(self.ckbx_ytexe, 0, wx.LEFT | wx.TOP, 5)
 
-        self.btn_ytdlp = wx.Button(tabThree, wx.ID_ANY, _('Change'))
-        self.txtctrl_ytdlp = wx.TextCtrl(tabThree, wx.ID_ANY, "",
-                                         style=wx.TE_READONLY
-                                         )
+        self.btn_ytexec = wx.Button(tabThree, wx.ID_ANY, _('Change'))
+        self.txtctrl_ytexec = wx.TextCtrl(tabThree, wx.ID_ANY, "",
+                                          style=wx.TE_READONLY
+                                          )
         gridytdlp = wx.BoxSizer(wx.HORIZONTAL)
         sizerytdlp.Add(gridytdlp, 0, wx.EXPAND)
-        gridytdlp.Add(self.txtctrl_ytdlp, 1, wx.ALL, 5)
-        gridytdlp.Add(self.btn_ytdlp, 0, wx.RIGHT | wx.CENTER, 5)
+        gridytdlp.Add(self.txtctrl_ytexec, 1, wx.ALL, 5)
+        gridytdlp.Add(self.btn_ytexec, 0, wx.RIGHT | wx.CENTER, 5)
+        sizerytdlp.Add((0, 20))
+        msg = (_('Import module externally. The appropriate source directory '
+                 'is required. Click on the link below\nto directly download '
+                 'the latest version, then extract the tarball archive and '
+                 'indicate the path to\nthe extracted directory here.'))
+        labytmod = wx.StaticText(tabThree, wx.ID_ANY, msg)
+        sizerytdlp.Add(labytmod, 0, wx.ALL | wx.EXPAND, 5)
+        url1 = ("https://github.com/yt-dlp/yt-dlp/releases/latest/"
+                "download/yt-dlp.tar.gz")
+        link1 = hpl.HyperLinkCtrl(tabThree, -1, url1, URL=(url1))
+        sizerytdlp.Add(link1, 0, wx.LEFT | wx.EXPAND, 15)
+        msg = _('Import yt-dlp externally')
+        self.ckbx_ytmod = wx.CheckBox(tabThree, wx.ID_ANY, (msg))
+        sizerytdlp.Add(self.ckbx_ytmod, 0, wx.LEFT | wx.TOP, 5)
+
+        self.btn_ytmod = wx.Button(tabThree, wx.ID_ANY, _('Change'))
+        self.txtctrl_ytmod = wx.TextCtrl(tabThree, wx.ID_ANY, "",
+                                         style=wx.TE_READONLY
+                                         )
+        gridytmod = wx.BoxSizer(wx.HORIZONTAL)
+        sizerytdlp.Add(gridytmod, 0, wx.EXPAND)
+        gridytmod.Add(self.txtctrl_ytmod, 1, wx.ALL, 5)
+        gridytmod.Add(self.btn_ytmod, 0, wx.RIGHT | wx.CENTER, 5)
         tabThree.SetSizer(sizerytdlp)
         notebook.AddPage(tabThree, "yt-dlp")
 
@@ -457,6 +481,7 @@ class SetUp(wx.Dialog):
             labytdlp.SetFont(wx.Font(13, wx.DEFAULT, wx.NORMAL, wx.BOLD))
             labytdescr.SetFont(wx.Font(11, wx.SWISS, wx.NORMAL, wx.NORMAL))
             labytexec.SetFont(wx.Font(11, wx.SWISS, wx.NORMAL, wx.NORMAL))
+            labytmod.SetFont(wx.Font(11, wx.SWISS, wx.NORMAL, wx.NORMAL))
             labappe.SetFont(wx.Font(13, wx.DEFAULT, wx.NORMAL, wx.BOLD))
             labLog.SetFont(wx.Font(11, wx.SWISS, wx.NORMAL, wx.NORMAL))
             labrem.SetFont(wx.Font(13, wx.DEFAULT, wx.NORMAL, wx.BOLD))
@@ -474,6 +499,7 @@ class SetUp(wx.Dialog):
             labytdlp.SetFont(wx.Font(10, wx.DEFAULT, wx.NORMAL, wx.BOLD))
             labytdescr.SetFont(wx.Font(8, wx.SWISS, wx.NORMAL, wx.NORMAL))
             labytexec.SetFont(wx.Font(8, wx.SWISS, wx.NORMAL, wx.NORMAL))
+            labytmod.SetFont(wx.Font(8, wx.SWISS, wx.NORMAL, wx.NORMAL))
             labappe.SetFont(wx.Font(10, wx.DEFAULT, wx.NORMAL, wx.BOLD))
             labLog.SetFont(wx.Font(8, wx.SWISS, wx.NORMAL, wx.NORMAL))
             labrem.SetFont(wx.Font(10, wx.DEFAULT, wx.NORMAL, wx.BOLD))
@@ -513,8 +539,10 @@ class SetUp(wx.Dialog):
         self.Bind(wx.EVT_CHECKBOX, self.exeFFplay, self.ckbx_exeFFplay)
         self.Bind(wx.EVT_BUTTON, self.open_path_ffplay, self.btn_ffplay)
         self.Bind(wx.EVT_CHECKBOX, self.on_ytdlp_pref, self.ckbx_ytdlp)
-        self.Bind(wx.EVT_CHECKBOX, self.on_ytdlp_exec, self.ckbx_dlexe)
-        self.Bind(wx.EVT_BUTTON, self.open_path_ytdlp, self.btn_ytdlp)
+        self.Bind(wx.EVT_CHECKBOX, self.on_ytdlp_exec, self.ckbx_ytexe)
+        self.Bind(wx.EVT_BUTTON, self.open_path_ytdlp, self.btn_ytexec)
+        self.Bind(wx.EVT_CHECKBOX, self.on_ytdlp_module, self.ckbx_ytmod)
+        self.Bind(wx.EVT_BUTTON, self.open_path_ytmodule, self.btn_ytmod)
         self.Bind(wx.EVT_COMBOBOX, self.on_Iconthemes, self.cmbx_icons)
         self.Bind(wx.EVT_RADIOBOX, self.on_toolbarPos, self.rdbTBpref)
         self.Bind(wx.EVT_COMBOBOX, self.on_toolbarSize, self.cmbx_iconsSize)
@@ -546,9 +574,11 @@ class SetUp(wx.Dialog):
         self.ckbx_exitconfirm.SetValue(self.appdata['warnexiting'])
         self.ckbx_logclr.SetValue(self.appdata['clearlogfiles'])
         self.ckbx_trash.SetValue(self.settings['move_file_to_trash'])
-        self.ckbx_ytdlp.SetValue(self.settings['use-downloader'])
-        self.ckbx_dlexe.SetValue(self.settings['download-using-exec'])
-        self.txtctrl_ytdlp.SetValue(self.appdata['yt-dlp-executable-path'])
+        self.ckbx_ytdlp.SetValue(self.settings['enable-ytdlp'])
+        self.ckbx_ytexe.SetValue(self.settings['ytdlp-useexec'])
+        self.txtctrl_ytexec.SetValue(self.appdata['ytdlp-executable-path'])
+        self.ckbx_ytmod.SetValue(self.settings['ytdlp-usemodule'])
+        self.txtctrl_ytmod.SetValue(self.appdata['ytdlp-module-path'])
         self.ckbx_exitapp.SetValue(self.appdata["auto_exit"])
         self.ckbx_turnoff.SetValue(self.appdata["shutdown"])
         self.txtctrl_sudo.SetValue(self.appdata.get("sudo_password", ''))
@@ -556,8 +586,11 @@ class SetUp(wx.Dialog):
             if self.appdata['ostype'] != 'Windows':
                 self.labsudo.Enable(), self.txtctrl_sudo.Enable()
 
-        if not self.settings['download-using-exec']:
-            self.txtctrl_ytdlp.Disable(), self.btn_ytdlp.Disable()
+        if not self.settings['ytdlp-useexec']:
+            self.txtctrl_ytexec.Disable(), self.btn_ytexec.Disable()
+
+        if not self.settings['ytdlp-usemodule']:
+            self.txtctrl_ytmod.Disable(), self.btn_ytmod.Disable()
 
         if not self.settings['move_file_to_trash']:
             self.txtctrl_trash.Disable()
@@ -871,7 +904,7 @@ class SetUp(wx.Dialog):
         """
         set yt-dlp preferences
         """
-        self.settings['use-downloader'] = self.ckbx_ytdlp.GetValue()
+        self.settings['enable-ytdlp'] = self.ckbx_ytdlp.GetValue()
         if self.appdata['yt_dlp'] is not True:
             self.appdata['yt_dlp'] = 'reload'
     # --------------------------------------------------------------------#
@@ -881,27 +914,63 @@ class SetUp(wx.Dialog):
         Sets whether to use yt-dlp as a Python
         module or as an executable.
         """
-        self.settings['download-using-exec'] = self.ckbx_dlexe.GetValue()
-        if self.ckbx_dlexe.GetValue():
-            self.txtctrl_ytdlp.Enable(), self.btn_ytdlp.Enable()
+        self.settings['ytdlp-useexec'] = self.ckbx_ytexe.GetValue()
+        if self.ckbx_ytexe.GetValue():
+            self.txtctrl_ytexec.Enable(), self.btn_ytexec.Enable()
         else:
-            self.txtctrl_ytdlp.Disable(), self.btn_ytdlp.Disable()
+            self.txtctrl_ytexec.Disable(), self.btn_ytexec.Disable()
     # --------------------------------------------------------------------#
 
     def open_path_ytdlp(self, event):
-        """Indicates a new yt-dlp path-name"""
-        with wx.FileDialog(self, _("{} location").format(self.ytdlp),
-                           "", "", "yt-dlp binary "
-                           f"(*{self.ytdlp})|*{self.ytdlp}| "
-                           f"All files (*.*)|*.*",
-                           wx.FD_OPEN | wx.FD_FILE_MUST_EXIST) as fdlg:
+        """
+        Indicates a new yt-dlp executable path-name
+        """
+        fmt = (f'*{self.ytdlp};*yt-dlp;')
+        wild = f"yt-dlp executable ({fmt})|{fmt}| All files (*.*)|*.*"
+        msg = _('Location of the «yt-dlp» executable')
+
+        with wx.FileDialog(self, msg, "", "", wildcard=wild,
+                           style=wx.FD_OPEN
+                           | wx.FD_FILE_MUST_EXIST) as fdlg:
 
             if fdlg.ShowModal() == wx.ID_OK:
-                if os.path.basename(fdlg.GetPath()) == self.ytdlp:
-                    self.txtctrl_ytdlp.Clear()
-                    getpath = self.appdata['getpath'](fdlg.GetPath())
-                    self.txtctrl_ytdlp.write(getpath)
-                    self.settings['yt-dlp-executable-path'] = getpath
+                self.txtctrl_ytexec.Clear()
+                getpath = self.appdata['getpath'](fdlg.GetPath())
+                self.txtctrl_ytexec.write(getpath)
+                self.settings['ytdlp-executable-path'] = getpath
+    # --------------------------------------------------------------------#
+
+    def on_ytdlp_module(self, event):
+        """
+        Enables external yt_dlp .
+        """
+        self.settings['ytdlp-usemodule'] = self.ckbx_ytmod.GetValue()
+        if self.ckbx_ytmod.GetValue():
+            self.txtctrl_ytmod.Enable(), self.btn_ytmod.Enable()
+        else:
+            self.txtctrl_ytmod.Disable(), self.btn_ytmod.Disable()
+            self.txtctrl_ytmod.Clear()
+            self.settings['ytdlp-module-path'] = ""
+    # --------------------------------------------------------------------#
+
+    def open_path_ytmodule(self, event):
+        """
+        Sets path to yt-dlp module. Note
+        """
+        dlg = wx.DirDialog(self, _("Open yt-dlp source directory"),
+                           "", wx.DD_DEFAULT_STYLE
+                           )
+        if dlg.ShowModal() == wx.ID_OK:
+            self.txtctrl_ytmod.Clear()
+            getpath = self.appdata['getpath'](dlg.GetPath())
+            self.txtctrl_ytmod.AppendText(getpath)
+            self.settings['ytdlp-module-path'] = getpath
+            ytexec = os.path.join(getpath, 'yt-dlp')
+            if os.path.exists(ytexec) and os.path.isfile(ytexec):
+                self.txtctrl_ytexec.Clear()
+                self.txtctrl_ytexec.write(ytexec)
+                self.settings['ytdlp-executable-path'] = ytexec
+            dlg.Destroy()
     # --------------------------------------------------------------------#
 
     def on_Iconthemes(self, event):
@@ -1006,7 +1075,9 @@ class SetUp(wx.Dialog):
             self.settings['trashdir_loc'] = self.appdata['trashdir_default']
         self.retcode = (
             self.settings['locale_name'] == self.appdata['locale_name'],
-            self.settings['use-downloader'] == self.appdata['use-downloader'],
+            self.settings['enable-ytdlp'] == self.appdata['enable-ytdlp'],
+            (self.settings['ytdlp-module-path']
+             == self.appdata['ytdlp-module-path']),
             self.settings['icontheme'] == self.appdata['icontheme'],
             self.settings['toolbarsize'] == self.appdata['toolbarsize'],
             self.settings['toolbarpos'] == self.appdata['toolbarpos'])

--- a/videomass/vdms_dialogs/preferences.py
+++ b/videomass/vdms_dialogs/preferences.py
@@ -28,7 +28,6 @@ import os
 import sys
 import webbrowser
 import wx
-import wx.lib.agw.hyperlink as hpl
 from videomass.vdms_utils.utils import detect_binaries
 from videomass.vdms_io import io_tools
 from videomass.vdms_sys.settings_manager import ConfigManager
@@ -220,18 +219,8 @@ class SetUp(wx.Dialog):
         sizerytdlp.Add(gridytdlp, 0, wx.EXPAND)
         gridytdlp.Add(self.txtctrl_ytexec, 1, wx.ALL, 5)
         gridytdlp.Add(self.btn_ytexec, 0, wx.RIGHT | wx.CENTER, 5)
-        sizerytdlp.Add((0, 20))
-        msg = (_('Import module externally. The appropriate source directory '
-                 'is required. Click on the link below\nto directly download '
-                 'the latest version, then extract the tarball archive and '
-                 'indicate the path to\nthe extracted directory here.'))
-        labytmod = wx.StaticText(tabThree, wx.ID_ANY, msg)
-        sizerytdlp.Add(labytmod, 0, wx.ALL | wx.EXPAND, 5)
-        url1 = ("https://github.com/yt-dlp/yt-dlp/releases/latest/"
-                "download/yt-dlp.tar.gz")
-        link1 = hpl.HyperLinkCtrl(tabThree, -1, url1, URL=(url1))
-        sizerytdlp.Add(link1, 0, wx.LEFT | wx.EXPAND, 15)
-        msg = _('Import yt-dlp externally')
+        sizerytdlp.Add((0, 15))
+        msg = _('Import «yd_dlp» Python package externally')
         self.ckbx_ytmod = wx.CheckBox(tabThree, wx.ID_ANY, (msg))
         sizerytdlp.Add(self.ckbx_ytmod, 0, wx.LEFT | wx.TOP, 5)
 
@@ -239,6 +228,10 @@ class SetUp(wx.Dialog):
         self.txtctrl_ytmod = wx.TextCtrl(tabThree, wx.ID_ANY, "",
                                          style=wx.TE_READONLY
                                          )
+        if self.appdata['app'] == 'pyinstaller':
+            self.ckbx_ytmod.Hide()
+            self.txtctrl_ytmod.Hide()
+            self.btn_ytmod.Hide()
         gridytmod = wx.BoxSizer(wx.HORIZONTAL)
         sizerytdlp.Add(gridytmod, 0, wx.EXPAND)
         gridytmod.Add(self.txtctrl_ytmod, 1, wx.ALL, 5)
@@ -481,7 +474,6 @@ class SetUp(wx.Dialog):
             labytdlp.SetFont(wx.Font(13, wx.DEFAULT, wx.NORMAL, wx.BOLD))
             labytdescr.SetFont(wx.Font(11, wx.SWISS, wx.NORMAL, wx.NORMAL))
             labytexec.SetFont(wx.Font(11, wx.SWISS, wx.NORMAL, wx.NORMAL))
-            labytmod.SetFont(wx.Font(11, wx.SWISS, wx.NORMAL, wx.NORMAL))
             labappe.SetFont(wx.Font(13, wx.DEFAULT, wx.NORMAL, wx.BOLD))
             labLog.SetFont(wx.Font(11, wx.SWISS, wx.NORMAL, wx.NORMAL))
             labrem.SetFont(wx.Font(13, wx.DEFAULT, wx.NORMAL, wx.BOLD))
@@ -499,7 +491,6 @@ class SetUp(wx.Dialog):
             labytdlp.SetFont(wx.Font(10, wx.DEFAULT, wx.NORMAL, wx.BOLD))
             labytdescr.SetFont(wx.Font(8, wx.SWISS, wx.NORMAL, wx.NORMAL))
             labytexec.SetFont(wx.Font(8, wx.SWISS, wx.NORMAL, wx.NORMAL))
-            labytmod.SetFont(wx.Font(8, wx.SWISS, wx.NORMAL, wx.NORMAL))
             labappe.SetFont(wx.Font(10, wx.DEFAULT, wx.NORMAL, wx.BOLD))
             labLog.SetFont(wx.Font(8, wx.SWISS, wx.NORMAL, wx.NORMAL))
             labrem.SetFont(wx.Font(10, wx.DEFAULT, wx.NORMAL, wx.BOLD))
@@ -540,9 +531,9 @@ class SetUp(wx.Dialog):
         self.Bind(wx.EVT_BUTTON, self.open_path_ffplay, self.btn_ffplay)
         self.Bind(wx.EVT_CHECKBOX, self.on_ytdlp_pref, self.ckbx_ytdlp)
         self.Bind(wx.EVT_CHECKBOX, self.on_ytdlp_exec, self.ckbx_ytexe)
-        self.Bind(wx.EVT_BUTTON, self.open_path_ytdlp, self.btn_ytexec)
-        self.Bind(wx.EVT_CHECKBOX, self.on_ytdlp_module, self.ckbx_ytmod)
-        self.Bind(wx.EVT_BUTTON, self.open_path_ytmodule, self.btn_ytmod)
+        self.Bind(wx.EVT_BUTTON, self.open_ytdlp_exec, self.btn_ytexec)
+        self.Bind(wx.EVT_CHECKBOX, self.on_ytdlp_package, self.ckbx_ytmod)
+        self.Bind(wx.EVT_BUTTON, self.open_ytdlp_package, self.btn_ytmod)
         self.Bind(wx.EVT_COMBOBOX, self.on_Iconthemes, self.cmbx_icons)
         self.Bind(wx.EVT_RADIOBOX, self.on_toolbarPos, self.rdbTBpref)
         self.Bind(wx.EVT_COMBOBOX, self.on_toolbarSize, self.cmbx_iconsSize)
@@ -921,11 +912,11 @@ class SetUp(wx.Dialog):
             self.txtctrl_ytexec.Disable(), self.btn_ytexec.Disable()
     # --------------------------------------------------------------------#
 
-    def open_path_ytdlp(self, event):
+    def open_ytdlp_exec(self, event):
         """
         Indicates a new yt-dlp executable path-name
         """
-        fmt = (f'*{self.ytdlp};*yt-dlp;')
+        fmt = f'*{self.ytdlp};*yt-dlp;'
         wild = f"yt-dlp executable ({fmt})|{fmt}| All files (*.*)|*.*"
         msg = _('Location of the «yt-dlp» executable')
 
@@ -940,7 +931,7 @@ class SetUp(wx.Dialog):
                 self.settings['ytdlp-executable-path'] = getpath
     # --------------------------------------------------------------------#
 
-    def on_ytdlp_module(self, event):
+    def on_ytdlp_package(self, event):
         """
         Enables external yt_dlp .
         """
@@ -953,11 +944,11 @@ class SetUp(wx.Dialog):
             self.settings['ytdlp-module-path'] = ""
     # --------------------------------------------------------------------#
 
-    def open_path_ytmodule(self, event):
+    def open_ytdlp_package(self, event):
         """
         Sets path to yt-dlp module. Note
         """
-        dlg = wx.DirDialog(self, _("Open yt-dlp source directory"),
+        dlg = wx.DirDialog(self, _("Open «yt_dlp» python package directory"),
                            "", wx.DD_DEFAULT_STYLE
                            )
         if dlg.ShowModal() == wx.ID_OK:
@@ -965,7 +956,7 @@ class SetUp(wx.Dialog):
             getpath = self.appdata['getpath'](dlg.GetPath())
             self.txtctrl_ytmod.AppendText(getpath)
             self.settings['ytdlp-module-path'] = getpath
-            ytexec = os.path.join(getpath, 'yt-dlp')
+            ytexec = os.path.join(os.path.dirname(getpath), 'yt-dlp')
             if os.path.exists(ytexec) and os.path.isfile(ytexec):
                 self.txtctrl_ytexec.Clear()
                 self.txtctrl_ytexec.write(ytexec)

--- a/videomass/vdms_dialogs/wizard_dlg.py
+++ b/videomass/vdms_dialogs/wizard_dlg.py
@@ -50,7 +50,7 @@ def write_changes(ffmpeg, ffplay, ffprobe, youtubedl, binfound):
     dataread['ffmpeg_islocal'] = local
     dataread['ffprobe_islocal'] = local
     dataread['ffplay_islocal'] = local
-    dataread['use-downloader'] = youtubedl
+    dataread['enable-ytdlp'] = youtubedl
 
     conf.write_options(**dataread)
 

--- a/videomass/vdms_main/main_frame.py
+++ b/videomass/vdms_main/main_frame.py
@@ -1806,7 +1806,7 @@ class MainFrame(wx.Frame):
         for yt-dlp GUI functionality.
         """
         msg = None
-        if not self.appdata['use-downloader']:
+        if not self.appdata['enable-ytdlp']:
             msg = _("yt-dlp is disabled. Check your preferences.")
 
         elif self.appdata['yt_dlp'] == 'reload':

--- a/videomass/vdms_sys/external_package.py
+++ b/videomass/vdms_sys/external_package.py
@@ -24,13 +24,14 @@ This file is part of Videomass.
    You should have received a copy of the GNU General Public License
    along with Videomass.  If not, see <http://www.gnu.org/licenses/>.
 """
+import os
 import sys
 import importlib
 import importlib.machinery
 import importlib.util
 
 
-def importer(pkg, path):
+def importer_package_dir(pkg, path):
     """
     An object that both finds and loads a module;
     both a finder and loader object.
@@ -43,4 +44,30 @@ def importer(pkg, path):
     sys.modules[pkg] = mod
     spec.loader.exec_module(mod)
     sys.modules[pkg] = importlib.import_module(pkg)
+    return None
+
+
+def importer_init_file(path, test: list = None):
+    """
+    Given a pathname to a python package, import relative
+    `__init__` file.
+    This function implicitly handles some exceptions such as
+    `FileNotFoundError` and `ModuleNotFoundError`. Optionally
+    you can test a list of one or more submodules using the `test`
+    argument.
+    """
+    pkgname = os.path.basename(path)
+    initpath = os.path.join(path, '__init__.py')
+
+    if not os.path.exists(initpath) or not os.path.isfile(initpath):
+        return f'No such file or directory: «{initpath}»'
+
+    spec = importlib.util.spec_from_file_location(pkgname, initpath)
+    newmodule = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = newmodule
+    spec.loader.exec_module(newmodule)
+    if test:
+        for mod in test:
+            if not sys.modules.get(mod, None):
+                return f'Module not found: \'{mod}\''
     return None

--- a/videomass/vdms_sys/external_package.py
+++ b/videomass/vdms_sys/external_package.py
@@ -1,0 +1,46 @@
+# -*- coding: UTF-8 -*-
+"""
+Name: external_package.py
+Porpose: finds and loads a module
+Compatibility: Python3
+Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
+Copyleft - 2024 Gianluca Pernigotto <jeanlucperni@gmail.com>
+license: GPL3
+Rev: June.19.2024
+Code checker: flake8, pylint
+
+This file is part of Videomass.
+
+   Videomass is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Videomass is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Videomass.  If not, see <http://www.gnu.org/licenses/>.
+"""
+import sys
+import importlib
+import importlib.machinery
+import importlib.util
+
+
+def importer(pkg, path):
+    """
+    An object that both finds and loads a module;
+    both a finder and loader object.
+    """
+    spec = importlib.machinery.PathFinder().find_spec(pkg, [path])
+    try:
+        mod = importlib.util.module_from_spec(spec)
+    except AttributeError as err:
+        return err
+    sys.modules[pkg] = mod
+    spec.loader.exec_module(mod)
+    sys.modules[pkg] = importlib.import_module(pkg)
+    return None

--- a/videomass/vdms_sys/settings_manager.py
+++ b/videomass/vdms_sys/settings_manager.py
@@ -146,17 +146,23 @@ class ConfigManager:
     ydlp-outputdir (str):
         file destination path used by the youtube-dl UI
 
-    use-downloader (bool):
+    enable-ytdlp (bool):
         sets the ability to download videos from YouTube.com.
         One of True or False, where True means load/use yt_dlp
         on sturtup.
 
-    download-using-exec (bool):
+    ytdlp-useexec (bool):
         If True, use yt-dlp as executable/binary for downloading
         videos (default). Use yt_dlp as API Otherwise.
 
-    yt-dlp-executable-path (str):
+    ytdlp-executable-path (str):
         Path to the yt-dlp or yt-dlp.exe executable.
+
+    ytdlp-usemodule (bool):
+        If True, allow to open specified yt_dlp module dir
+
+    ytdlp-module-path (str),
+        Path to the yt-dlp dir
 
     playlistsubfolder (bool):
         Auto-create subfolders when download the playlists,
@@ -215,7 +221,7 @@ class ConfigManager:
         column width in the format code panel (ytdownloader).
 
     """
-    VERSION = 7.8
+    VERSION = 8.0
     DEFAULT_OPTIONS = {"confversion": VERSION,
                        "shutdown": False,
                        "sudo_password": "",
@@ -246,9 +252,11 @@ class ConfigManager:
                        "trashdir_loc": "",
                        "locale_name": "Default",
                        "ydlp-outputdir": f"{os.path.expanduser('~')}",
-                       "use-downloader": False,
-                       "download-using-exec": True,
-                       "yt-dlp-executable-path": "yt-dlp",
+                       "enable-ytdlp": False,
+                       "ytdlp-useexec": True,
+                       "ytdlp-executable-path": "yt-dlp",
+                       "ytdlp-usemodule": False,
+                       "ytdlp-module-path": "",
                        "playlistsubfolder": True,
                        "ssl_certificate": False,
                        "add_metadata": False,

--- a/videomass/vdms_ytdlp/long_task_ytdlp.py
+++ b/videomass/vdms_ytdlp/long_task_ytdlp.py
@@ -137,7 +137,7 @@ class LogOut(wx.Panel):
                                          mode="w",
                                          )
         self.btn_viewlog.Disable()
-        if self.appdata['download-using-exec']:
+        if self.appdata['ytdlp-useexec']:
             self.thread_type = YtdlExecDL(args[1], urls, self.logfile)
         else:
             self.thread_type = YdlDownloader(args[1], urls, self.logfile)

--- a/videomass/vdms_ytdlp/youtubedl_ui.py
+++ b/videomass/vdms_ytdlp/youtubedl_ui.py
@@ -826,9 +826,9 @@ class Downloader(wx.Panel):
         """
         Call `main_ytdlp.switch_to_processing`
         """
-        if self.appdata['download-using-exec']:
+        if self.appdata['ytdlp-useexec']:
             execlist = []
-            execpath = self.appdata['yt-dlp-executable-path']
+            execpath = self.appdata['ytdlp-executable-path']
             for args in datalist:
                 execlist.append(from_api_to_cli(args, execpath))
             self.parent.switch_to_processing('YouTube Downloader', execlist)


### PR DESCRIPTION
Closes #328 

This PR implements a new feature to import the yt_dlp Python package externally and use it instead of the one installed on your system or the one on your virtual environment. Note that **standalone application** build using `pyinstaller` are excluded from using this feature.
By external import we mean that it is possible to import the package also from other virtual environments as well as from the specific unzipped source tarball: https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#misc