### PR TITLE
Disable SUDO password field for systemd systems

### DIFF
--- a/videomass/vdms_sys/settings_manager.py
+++ b/videomass/vdms_sys/settings_manager.py
@@ -224,7 +224,7 @@ class ConfigManager:
     VERSION = 8.0
     DEFAULT_OPTIONS = {"confversion": VERSION,
                        "shutdown": False,
-                       "sudo_password": "",
+                       "sudo_password": None,
                        "auto_exit": False,
                        "encoding": "utf-8",
                        "outputdir": f"{os.path.expanduser('~')}",


### PR DESCRIPTION
In systemd-init systems, it is possible to shutdown without having to run the shutdown command as `sudo`.

I am making this a draft PR since I haven't tested whether this correctly shutdowns or not, or what happens if there is another user logged in.