### PR TITLE
fix yt-dlp preferences issue

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,16 @@ License: GPL3
 Change Log:
 
 +------------------------------------+
+Thu, 20 Mar 2025 V.5.0.26
+
+  * Fixed yt-dlp preferences tab issue (see #372)
+  * Enabled import of the external «yt_dlp» package also on the Videomass
+    standalone executable built with Pyinstaller.
+  * Improved handling of the yt-dlp executable (yt-dlp.exe on Windows) which
+    now provides some automation and useful information for the users.
+
+
++------------------------------------+
 Sat, 18 Jan 2025 V.5.0.25
 
   * Checking the output directories before running processes.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+videomass (5.0.26-1) UNRELEASED; urgency=medium
+
+  * Fixed yt-dlp preferences tab issue (see #372)
+  * Enabled import of the external «yt_dlp» package also on the Videomass
+    standalone executable built with Pyinstaller.
+  * Improved handling of the yt-dlp executable (yt-dlp.exe on Windows) which
+    now provides some automation and useful information for the users.
+
+ -- Gianluca Pernigotto <jeanlucperni@gmail.com>  Thu, 20 Mar 2025 09:00:00 +0200
+
 videomass (5.0.25-1) UNRELEASED; urgency=medium
 
   * Checking the output directories before running processes.

--- a/videomass/vdms_dialogs/wizard_dlg.py
+++ b/videomass/vdms_dialogs/wizard_dlg.py
@@ -6,7 +6,7 @@ Compatibility: Python3, wxPython Phoenix
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
 Copyleft - 2025 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
-Rev: Jan.14.2025
+Rev: March.22.2025
 Code checker: flake8, pylint
 
 This file is part of Videomass.
@@ -51,6 +51,10 @@ def write_changes(ffmpeg, ffplay, ffprobe, youtubedl, binfound):
     dataread['ffprobe_islocal'] = local
     dataread['ffplay_islocal'] = local
     dataread['enable-ytdlp'] = youtubedl
+    ytdlpexec = 'yt-dlp.exe' if appdata['ostype'] == 'Windows' else 'yt-dlp'
+    status = detect_binaries(ytdlpexec)
+    if status[1]:
+        dataread['ytdlp-exec-path'] = appdata['getpath'](status[1])
 
     conf.write_options(**dataread)
 

--- a/videomass/vdms_sys/about_app.py
+++ b/videomass/vdms_sys/about_app.py
@@ -6,7 +6,7 @@ Compatibility: Python3, Python2
 author: Gianluca Pernigotto <jeanlucperni@gmail.com>
 Copyleft - 2025 Gianluca Pernigotto <jeanlucperni@gmail.com>
 lic: GPL3
-Rev: June.26.2024
+Rev: March.22.2025
 Code checker: flake8, pylint
 
 This file is part of Videomass.
@@ -26,7 +26,7 @@ This file is part of Videomass.
 """
 PRGNAME = 'videomass'
 RELNAME = 'Videomass'
-VERSION = '5.0.25'
+VERSION = '5.0.26'
 RELSTATE = 'released'
 COPYRIGHT = '2013-2025'
 WEBSITE = 'http://jeanslack.github.io/Videomass/'

--- a/videomass/vdms_sys/settings_manager.py
+++ b/videomass/vdms_sys/settings_manager.py
@@ -6,7 +6,7 @@ Compatibility: Python3
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
 Copyleft - 2025 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
-Rev: Oct.29.2024
+Rev: March.22.2025
 Code checker: flake8, pylint
 
  This file is part of Videomass.
@@ -155,7 +155,7 @@ class ConfigManager:
         If True, use yt-dlp as executable/binary for downloading
         videos (default). Use yt_dlp as API Otherwise.
 
-    ytdlp-executable-path (str):
+    ytdlp-exec-path (str):
         Path to the yt-dlp or yt-dlp.exe executable.
 
     ytdlp-usemodule (bool):
@@ -221,7 +221,7 @@ class ConfigManager:
         column width in the format code panel (ytdownloader).
 
     """
-    VERSION = 8.0
+    VERSION = 8.1
     DEFAULT_OPTIONS = {"confversion": VERSION,
                        "shutdown": False,
                        "sudo_password": "",
@@ -254,7 +254,7 @@ class ConfigManager:
                        "ydlp-outputdir": f"{os.path.expanduser('~')}",
                        "enable-ytdlp": False,
                        "ytdlp-useexec": True,
-                       "ytdlp-executable-path": "yt-dlp",
+                       "ytdlp-exec-path": "",
                        "ytdlp-usemodule": False,
                        "ytdlp-module-path": "",
                        "playlistsubfolder": True,


### PR DESCRIPTION
Closes #372 

This PR tries to fix some issues with yt-dlp handling, especially in the preferences dialog. It also adds some automation and useful information to the Videomass GUI related to the use of the yt-dlp executable (yt-dlp.exe on Windows).

A significant part of this PR is the ability to enable the external «yt_dlp» module also on the standalone Videomass executable.
