### PR TITLE
improve yt-dlp interface + remove rotation from log monitoring

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,16 +7,25 @@ License: GPL3
 Change Log:
 
 +------------------------------------+
-Thu, 20 Mar 2025 V.5.0.26
+Fri, 05 Jun 2025 V.5.0.26
 
   * Fixed yt-dlp preferences tab issue (see #372)
   * [YouTube Downloader] Enabled import of the external «yt_dlp» package also
-    on the Videomass standalone executable built with Pyinstaller.
+    on the Videomass standalone executable built by Pyinstaller.
   * [YouTube Downloader] Improved handling of the yt-dlp executable
     (yt-dlp.exe on Windows) which now provides some automation and useful
     information for the users.
   * [YouTube Downloader] Added «Whale» browser to the supported browser list for
     cookie automations.
+  * Update zh_CN i18n, thanks to @userwljs
+  * [YouTube Downloader] Removed API functionality for download operations. Now
+    only the yt-dlp executable is used for download operations. The API is still
+    needed and will only be used for statistics extraction and format code
+    listing.
+  * Fixed #374
+
+
+
 
 +------------------------------------+
 Sat, 18 Jan 2025 V.5.0.25

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,15 +17,13 @@ Fri, 05 Jun 2025 V.5.0.26
     information for the users.
   * [YouTube Downloader] Added «Whale» browser to the supported browser list for
     cookie automations.
+  * Update it_IT i18n, thanks to @bovirus
   * Update zh_CN i18n, thanks to @userwljs
   * [YouTube Downloader] Removed API functionality for download operations. Now
     only the yt-dlp executable is used for download operations. The API is still
     needed and will only be used for statistics extraction and format code
     listing.
   * Fixed #374
-
-
-
 
 +------------------------------------+
 Sat, 18 Jan 2025 V.5.0.25

--- a/debian/changelog
+++ b/debian/changelog
@@ -8,6 +8,7 @@ videomass (5.0.26-1) UNRELEASED; urgency=medium
     information for the users.
   * [YouTube Downloader] Added «Whale» browser to the supported browser list for
     cookie automations.
+  * Update it_IT i18n, thanks to @bovirus
   * Update zh_CN i18n, thanks to @userwljs
   * [YouTube Downloader] Removed API functionality for download operations. Now
     only the yt-dlp executable is used for download operations. The API is still

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,14 +2,20 @@ videomass (5.0.26-1) UNRELEASED; urgency=medium
 
   * Fixed yt-dlp preferences tab issue (see #372)
   * [YouTube Downloader] Enabled import of the external «yt_dlp» package also
-    on the Videomass standalone executable built with Pyinstaller.
+    on the Videomass standalone executable built by Pyinstaller.
   * [YouTube Downloader] Improved handling of the yt-dlp executable
     (yt-dlp.exe on Windows) which now provides some automation and useful
     information for the users.
   * [YouTube Downloader] Added «Whale» browser to the supported browser list for
     cookie automations.
+  * Update zh_CN i18n, thanks to @userwljs
+  * [YouTube Downloader] Removed API functionality for download operations. Now
+    only the yt-dlp executable is used for download operations. The API is still
+    needed and will only be used for statistics extraction and format code
+    listing.
+  * Fixed #374
 
- -- Gianluca Pernigotto <jeanlucperni@gmail.com>  Tue, 25 Mar 2025 09:00:00 +0200
+ -- Gianluca Pernigotto <jeanlucperni@gmail.com>  Fri, 06 Jun 2025 13:00:00 +0200
 
 videomass (5.0.25-1) UNRELEASED; urgency=medium
 

--- a/videomass/vdms_dialogs/preferences.py
+++ b/videomass/vdms_dialogs/preferences.py
@@ -6,7 +6,7 @@ Compatibility: Python3, wxPython Phoenix
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
 Copyleft - 2025 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
-Rev: March.20.2025
+Rev: June.05.2025
 Code checker: flake8, pylint
 
 This file is part of Videomass.
@@ -192,22 +192,20 @@ class SetUp(wx.Dialog):
                  '(requires application restart)'))
         labytdlp = wx.StaticText(tabThree, wx.ID_ANY, msg)
         sizerytdlp.Add(labytdlp, 0, wx.ALL | wx.EXPAND, 5)
-        msg = (_('Videomass uses the yt-dlp API which can be activated by '
-                 'selecting the checkbox below.\nThe next time you restart '
-                 'the application, the yt_dlp module will be loaded into '
-                 'memory.'))
+        msg = (_('By selecting the checkbox below you will be able to '
+                 'download videos and audio from the net.'))
         labytdescr = wx.StaticText(tabThree, wx.ID_ANY, msg)
         sizerytdlp.Add(labytdescr, 0, wx.ALL | wx.EXPAND, 5)
         msg = _("Enable yt-dlp")
         self.ckbx_ytdlp = wx.CheckBox(tabThree, wx.ID_ANY, (msg))
         sizerytdlp.Add(self.ckbx_ytdlp, 0, wx.ALL, 5)
         sizerytdlp.Add((0, 20))
-        msg = (_('Enabling a specific location of the yt-dlp executable will '
-                 'give you more control over downloads\nstop actions and the '
-                 'ability to provide other backend locations.'))
+        msg = (_('Here you can provide the path to the latest version of the '
+                 '{0} executable, this allows you\nto always keep it up to '
+                 'date.').format(self.ytdlp))
         labytexec = wx.StaticText(tabThree, wx.ID_ANY, msg)
         sizerytdlp.Add(labytexec, 0, wx.ALL | wx.EXPAND, 5)
-        msg = _('Use the executable for downloads rather than API')
+        msg = _('Enable a custom location to run yt-dlp executable.')
         self.ckbx_ytexe = wx.CheckBox(tabThree, wx.ID_ANY, (msg))
         sizerytdlp.Add(self.ckbx_ytexe, 0, wx.LEFT | wx.TOP, 5)
 
@@ -552,7 +550,8 @@ class SetUp(wx.Dialog):
         self.Bind(wx.EVT_BUTTON, self.on_ok, btn_ok)
         # --------------------------------------------#
 
-        self.general_current_settings(), self.yt_dlp_current_settings()
+        self.general_current_settings()
+        self.yt_dlp_current_settings()
         self.ffmpeg_current_settings()
 
     def general_current_settings(self):
@@ -604,7 +603,7 @@ class SetUp(wx.Dialog):
         the preferences dialog
         """
         self.ckbx_ytdlp.SetValue(self.settings['enable-ytdlp'])
-        self.ckbx_ytexe.SetValue(self.settings['ytdlp-useexec'])
+        self.ckbx_ytexe.SetValue(self.appdata['ytdlp-enable-exec'])
         execstr = ('Not found' if self.appdata['ytdlp-exec-path'] == ''
                    else self.appdata['ytdlp-exec-path'])
         self.txtctrl_ytexec.SetValue(execstr)
@@ -954,21 +953,22 @@ class SetUp(wx.Dialog):
         """
         if self.ckbx_ytexe.GetValue():
             self.txtctrl_ytexec.Enable(), self.btn_ytexec.Enable()
+            self.settings['ytdlp-enable-exec'] = True
         else:
             self.txtctrl_ytexec.Disable(), self.btn_ytexec.Disable()
             self.txtctrl_ytexec.Clear()
-            status = detect_binaries(self.ytdlp)
-            if status[0] == 'not installed':
-                self.txtctrl_ytexec.Clear()
-                self.txtctrl_ytexec.write('Not found')
-                self.settings['ytdlp-exec-path'] = ''
-            else:
-                self.txtctrl_ytexec.Clear()
-                getpath = self.appdata['getpath'](status[1])
-                self.txtctrl_ytexec.write(getpath)
-                self.settings['ytdlp-exec-path'] = getpath
+            self.settings['ytdlp-enable-exec'] = False
 
-            self.settings['ytdlp-useexec'] = self.ckbx_ytexe.GetValue()
+        status = detect_binaries(self.ytdlp)
+        if status[0] == 'not installed':
+            self.txtctrl_ytexec.Clear()
+            self.txtctrl_ytexec.write('Not found')
+            self.settings['ytdlp-exec-path'] = ''
+        else:
+            self.txtctrl_ytexec.Clear()
+            getpath = self.appdata['getpath'](status[1])
+            self.txtctrl_ytexec.write(getpath)
+            self.settings['ytdlp-exec-path'] = getpath
     # --------------------------------------------------------------------#
 
     def open_ytdlp_exec(self, event):
@@ -987,7 +987,6 @@ class SetUp(wx.Dialog):
                 getpath = self.appdata['getpath'](fdlg.GetPath())
                 self.txtctrl_ytexec.write(getpath)
                 self.settings['ytdlp-exec-path'] = getpath
-                self.settings['ytdlp-useexec'] = self.ckbx_ytexe.GetValue()
     # --------------------------------------------------------------------#
 
     def on_ytdlp_package(self, event):

--- a/videomass/vdms_io/io_tools.py
+++ b/videomass/vdms_io/io_tools.py
@@ -6,7 +6,7 @@ Compatibility: Python3, wxPython4 Phoenix
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
 Copyleft - 2025 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
-Rev: Apr.20.2024
+Rev: June.06.2025
 Code checker: flake8, pylint
 
 This file is part of Videomass.
@@ -33,6 +33,7 @@ from videomass.vdms_threads.check_bin import (ff_conf,
                                               ff_formats,
                                               ff_codecs,
                                               ff_topics,
+                                              subp,
                                               )
 from videomass.vdms_utils.utils import open_default_application
 from videomass.vdms_dialogs.widget_utils import PopupDialog
@@ -61,6 +62,16 @@ def youtubedl_getstatistics(url, kwargs, parent=None):
     data = thread.data
     dlgload.Destroy()
     yield data
+# --------------------------------------------------------------------------#
+
+
+def youtubedl_get_executable_version(execpath):
+    """
+    Call `check_bin.subp` to get yt-dlp executable version.
+    """
+    get = wx.GetApp()
+    res = subp([execpath, '--version'], get.appset['ostype'])
+    return res[1] if res[0] == 'None' else f'{res[0]} [ERROR]\n'
 # --------------------------------------------------------------------------#
 
 

--- a/videomass/vdms_panels/long_processing_task.py
+++ b/videomass/vdms_panels/long_processing_task.py
@@ -6,7 +6,7 @@ Compatibility: Python3, wxPython4 Phoenix
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
 Copyleft - 2025 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
-Rev: Apr.20.2024
+Rev: March.28.2025
 Code checker: flake8, pylint
 
 This file is part of Videomass.
@@ -141,7 +141,6 @@ class LogOut(wx.Panel):
         self.logfile = None  # log pathname, None otherwise
         self.result = []  # result of the final process
         self.count = 0  # keeps track of the counts (see `update_count`)
-        self.maxrotate = 0  # max num text rotation (see `update_count`)
         self.clr = self.appdata['colorscheme']
 
         wx.Panel.__init__(self, parent=parent)
@@ -219,15 +218,15 @@ class LogOut(wx.Panel):
             self.thread_type = FFmpeg(self.logfile, data)
 
         elif args[0] == 'video_to_sequence':
-            self.with_eta, self.maxrotate = False, None
+            self.with_eta = False
             self.thread_type = PicturesFromVideo(self.logfile, **data)
 
         elif args[0] == 'sequence_to_video':
-            self.with_eta, self.maxrotate = False, None
+            self.with_eta = False
             self.thread_type = SlideshowMaker(self.logfile, **data)
 
         elif args[0] == 'concat_demuxer':
-            self.with_eta, self.maxrotate = False, None
+            self.with_eta = False
             self.thread_type = ConcatDemuxer(self.logfile, **data)
     # ----------------------------------------------------------------------
 
@@ -338,11 +337,6 @@ class LogOut(wx.Panel):
             self.txtout.AppendText(f'\nERROR: {count}\n')
             self.error = True
         else:
-            if self.maxrotate is not None:
-                if self.maxrotate == 1:
-                    self.maxrotate = 0
-                    self.txtout.Clear()
-                self.maxrotate += 1
             self.barprog.SetRange(duration)  # set overall duration range
             self.barprog.SetValue(0)  # reset bar progress
             self.txtout.SetDefaultStyle(wx.TextAttr(self.clr['TXT0']))
@@ -419,7 +413,6 @@ class LogOut(wx.Panel):
         self.error = False
         self.result.clear()
         self.count = 0
-        self.maxrotate = 0
         self.with_eta = True  # restoring time remaining display
         self.btn_viewlog.Enable()
     # ----------------------------------------------------------------------

--- a/videomass/vdms_sys/settings_manager.py
+++ b/videomass/vdms_sys/settings_manager.py
@@ -6,7 +6,7 @@ Compatibility: Python3
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
 Copyleft - 2025 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
-Rev: March.22.2025
+Rev: June.05.2025
 Code checker: flake8, pylint
 
  This file is part of Videomass.
@@ -151,9 +151,9 @@ class ConfigManager:
         One of True or False, where True means load/use yt_dlp
         on sturtup.
 
-    ytdlp-useexec (bool):
-        If True, use yt-dlp as executable/binary for downloading
-        videos (default). Use yt_dlp as API Otherwise.
+    ytdlp-enable-exec (bool):
+        If `True`, the user enable a custom location (pathname) for
+        yt-dlp executable. Default is `False`.
 
     ytdlp-exec-path (str):
         Path to the yt-dlp (yt-dlp.exe on Windows) executable.
@@ -221,7 +221,7 @@ class ConfigManager:
         column width in the format code panel (ytdownloader).
 
     """
-    VERSION = 8.1
+    VERSION = 8.3
     DEFAULT_OPTIONS = {"confversion": VERSION,
                        "shutdown": False,
                        "sudo_password": "",
@@ -253,7 +253,7 @@ class ConfigManager:
                        "locale_name": "Default",
                        "ydlp-outputdir": f"{os.path.expanduser('~')}",
                        "enable-ytdlp": False,
-                       "ytdlp-useexec": True,
+                       "ytdlp-enable-exec": False,
                        "ytdlp-exec-path": "",
                        "ytdlp-usemodule": False,
                        "ytdlp-module-path": "",

--- a/videomass/vdms_threads/check_bin.py
+++ b/videomass/vdms_threads/check_bin.py
@@ -57,7 +57,7 @@ def subp(args, ostype):
             if proc.returncode:  # if returncode == 1
                 return ('Not found', out[0])
 
-    except (OSError, FileNotFoundError) as oserr:  # if ffmpeg do not exist
+    except (OSError, FileNotFoundError) as oserr:  # no executable found
         return ('Not found', oserr)
 
     return ('None', out[0])

--- a/videomass/vdms_ytdlp/youtubedl_ui.py
+++ b/videomass/vdms_ytdlp/youtubedl_ui.py
@@ -6,7 +6,7 @@ Compatibility: Python3, wxPython Phoenix
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
 Copyleft - 2025 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
-Rev: March.22.2025
+Rev: June.05.2025
 Code checker: flake8, pylint
 
 This file is part of Videomass.
@@ -822,20 +822,17 @@ class Downloader(wx.Panel):
         """
         Call `main_ytdlp.switch_to_processing`
         """
-        if self.appdata['ytdlp-useexec']:
-            execlist = []
-            execpath = self.appdata['ytdlp-exec-path']
-            if (not execpath.strip().endswith(self.execname)
-                    or not shutil.which(execpath)):
-                wx.MessageBox(_('Missing executable: «{0}».\nBefore '
-                                'continuing, be sure to make the correct '
-                                'settings in the preferences dialog.'
-                                ).format(self.execname),
-                              _('Videomass - Warning!'), wx.ICON_WARNING, self)
-                return
+        execlist = []
+        execpath = self.appdata['ytdlp-exec-path']
+        if (not execpath.strip().endswith(self.execname)
+                or not shutil.which(execpath)):
+            wx.MessageBox(_('Missing executable: «{0}».\nBefore '
+                            'continuing, be sure to make the correct '
+                            'settings in the preferences dialog.'
+                            ).format(self.execname),
+                          _('Videomass - Warning!'), wx.ICON_WARNING, self)
+            return
 
-            for args in datalist:
-                execlist.append(from_api_to_cli(args, execpath))
-            self.parent.switch_to_processing('YouTube Downloader', execlist)
-        else:
-            self.parent.switch_to_processing('YouTube Downloader', datalist)
+        for args in datalist:
+            execlist.append(from_api_to_cli(args, execpath))
+        self.parent.switch_to_processing('YouTube Downloader', execlist)


### PR DESCRIPTION
Closes #374 
This PR removes API functionality for download operations. Now only the yt-dlp (or yt-dlp.exe) executable is used for download operations. The API is still needed and will only be used for statistics extraction and format code listing.

Additionally this same PR restores the old functionality of the log list on the monitoring window.