### PR TITLE
Fix inconsistencies

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,16 +7,25 @@ License: GPL3
 Change Log:
 
 +------------------------------------+
-Tue, 22 July 2025 v6.1.13
+Sat, 26 July 2025 v6.1.13
 
   * Fixed "Go" menu item that was incorrectly left enabled on "Output Monitor"
     during transcoding processes, leaving the user able to click on it, leading
     to unexpected interface behavior.
+  * Fixed "Edit" menu subitems according to user actions.
+  * Fixed the popup menu (aka context menu) items displayed when right-clicking
+    in the "File List" panel. Enabling/disabling items depends on user actions.
   * Fixed some typos.
   * [AV/CONVERSIONS] Fixed static text allignements on Audio tab and
     Miscellaneous tab.
   * [STILL IMAGE MAKER] Improved UI layout adding spaces between the widgets.
-  * Fix compatibility issues between versions of the Python requests #15 .
+  * Fixed compatibility issues between versions of the Python requests #15 .
+  * Removed unnecessary log file names from showlogs dialog.
+  * [AV/CONVERSIONS] Fixed `IndexError: list index out of range` stack-traces
+    raised with audio volumedetect list while the user import new files and Run
+    transcoding process.
+  * Improved text formatting on volumedetected.log file.
+  * [AV/CONVERSIONS] Volume detect requires at least one file, not a selection.
 
 +------------------------------------+
 Tue, 15 July 2025 v6.1.12

--- a/videomass/data/locale/ar_SA/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/ar_SA/LC_MESSAGES/videomass.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-22 23:33+0200\n"
+"POT-Creation-Date: 2025-07-26 15:04+0200\n"
 "PO-Revision-Date: 2024-07-17 16:34+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ar_SA\n"
@@ -936,7 +936,7 @@ msgid "Change"
 msgstr ""
 
 #: ../../vdms_dialogs/preferences.py:103
-#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:574
+#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:602
 #: ../../vdms_panels/presets_manager.py:1050
 msgid "Same destination paths as source files"
 msgstr ""
@@ -1359,33 +1359,33 @@ msgstr ""
 msgid "Profile change successful!"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:81
+#: ../../vdms_dialogs/showlogs.py:80
 msgid "Log file list"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:83 ../../vdms_dialogs/showlogs.py:117
+#: ../../vdms_dialogs/showlogs.py:82 ../../vdms_dialogs/showlogs.py:116
 msgid "Log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:106
+#: ../../vdms_dialogs/showlogs.py:105
 msgid "Refresh log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:108
+#: ../../vdms_dialogs/showlogs.py:107
 msgid "Clear log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:161
+#: ../../vdms_dialogs/showlogs.py:160
 msgid "Select a log file"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:168
+#: ../../vdms_dialogs/showlogs.py:167
 msgid "Are you sure you want to clear the selected log file?"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:169 ../../vdms_dialogs/wizard_dlg.py:251
+#: ../../vdms_dialogs/showlogs.py:168 ../../vdms_dialogs/wizard_dlg.py:251
 #: ../../vdms_io/checkup.py:68 ../../vdms_main/main_frame.py:205
-#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1669
+#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1685
 #: ../../vdms_panels/presets_manager.py:349
 #: ../../vdms_panels/presets_manager.py:550
 #: ../../vdms_panels/presets_manager.py:590
@@ -1662,8 +1662,8 @@ msgstr ""
 msgid "Videomass - Downloading..."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1407
-#: ../../vdms_main/main_frame.py:1435
+#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1409
+#: ../../vdms_main/main_frame.py:1441
 msgid "Ready"
 msgstr ""
 
@@ -1740,7 +1740,7 @@ msgid "File"
 msgstr ""
 
 #: ../../vdms_main/main_frame.py:486 ../../vdms_panels/filedrop.py:340
-#: ../../vdms_panels/filedrop.py:359
+#: ../../vdms_panels/filedrop.py:381
 msgid "Rename selected file\tCtrl+R"
 msgstr ""
 
@@ -1749,7 +1749,7 @@ msgid "Rename the destination of the selected file"
 msgstr ""
 
 #: ../../vdms_main/main_frame.py:490 ../../vdms_panels/filedrop.py:341
-#: ../../vdms_panels/filedrop.py:362
+#: ../../vdms_panels/filedrop.py:384
 msgid "Batch rename files\tCtrl+B"
 msgstr ""
 
@@ -1758,7 +1758,7 @@ msgid "Numerically renames the destination of all items in the list"
 msgstr ""
 
 #: ../../vdms_main/main_frame.py:496 ../../vdms_panels/filedrop.py:343
-#: ../../vdms_panels/filedrop.py:366
+#: ../../vdms_panels/filedrop.py:388
 msgid "Remove selected entry\tDEL"
 msgstr ""
 
@@ -1767,7 +1767,7 @@ msgid "Remove the selected file from the list"
 msgstr ""
 
 #: ../../vdms_main/main_frame.py:500 ../../vdms_panels/filedrop.py:344
-#: ../../vdms_panels/filedrop.py:369
+#: ../../vdms_panels/filedrop.py:391
 msgid "Clear list\tShift+DEL"
 msgstr ""
 
@@ -2133,73 +2133,72 @@ msgstr ""
 msgid "Show queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1406 ../../vdms_panels/presets_manager.py:569
+#: ../../vdms_main/main_frame.py:1408 ../../vdms_panels/presets_manager.py:569
 msgid "Videomass"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1436
+#: ../../vdms_main/main_frame.py:1442
 msgid "Videomass - File List"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1453
+#: ../../vdms_main/main_frame.py:1459
 msgid "Videomass - AV Conversions"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1480
+#: ../../vdms_main/main_frame.py:1488
 msgid "Videomass - Presets Manager"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1508
+#: ../../vdms_main/main_frame.py:1518
 msgid "Videomass - Concatenate Demuxer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1535
+#: ../../vdms_main/main_frame.py:1547
 msgid "Videomass - From Movie to Pictures"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1562
+#: ../../vdms_main/main_frame.py:1576
 msgid "Videomass - Still Image Maker"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1644
-#: ../../vdms_panels/audio_encoders/acodecs.py:789
-#: ../../vdms_panels/av_conversions.py:577 ../../vdms_panels/filedrop.py:475
-#: ../../vdms_panels/filedrop.py:588 ../../vdms_panels/sequence_to_video.py:322
+#: ../../vdms_main/main_frame.py:1660 ../../vdms_panels/av_conversions.py:577
+#: ../../vdms_panels/filedrop.py:500 ../../vdms_panels/filedrop.py:616
+#: ../../vdms_panels/sequence_to_video.py:322
 #: ../../vdms_panels/video_to_sequence.py:369
 #: ../../vdms_panels/video_to_sequence.py:501
 msgid "Have to select an item in the file list first"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1666
+#: ../../vdms_main/main_frame.py:1682
 msgid ""
 "An item with the same destination file already exists.\n"
 "\n"
 "Do you want to replace it by adding the new item to the queue?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1687
+#: ../../vdms_main/main_frame.py:1703
 msgid "Videomass - FFmpeg Message Monitoring"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1814
+#: ../../vdms_main/main_frame.py:1828
 #, python-brace-format
 msgid "The system will turn off in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1815
+#: ../../vdms_main/main_frame.py:1829
 msgid "Videomass - Shutdown!"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1822
+#: ../../vdms_main/main_frame.py:1836
 msgid "Error while shutting down. Please see file log for details."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1834
+#: ../../vdms_main/main_frame.py:1848
 #, python-brace-format
 msgid "Exiting the application in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1835
+#: ../../vdms_main/main_frame.py:1849
 msgid "Videomass - Exiting!"
 msgstr ""
 
@@ -2589,7 +2588,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:383
+#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:405
 msgid "Drag one or more files below"
 msgstr ""
 
@@ -2605,45 +2604,45 @@ msgstr ""
 msgid "Encodings destination folder"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:372
+#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:394
 msgid "Play file"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:386
+#: ../../vdms_panels/filedrop.py:408
 msgid "Drag two or more Audio/Video files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:390
+#: ../../vdms_panels/filedrop.py:412
 msgid "Drag one or more Image files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:393
+#: ../../vdms_panels/filedrop.py:415
 msgid "Drag one or more Video files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:595
+#: ../../vdms_panels/filedrop.py:623
 msgid "Rename the file destination"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:596
+#: ../../vdms_panels/filedrop.py:624
 msgid "Rename the selected file to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:610 ../../vdms_panels/filedrop.py:620
-#: ../../vdms_panels/filedrop.py:651
+#: ../../vdms_panels/filedrop.py:638 ../../vdms_panels/filedrop.py:648
+#: ../../vdms_panels/filedrop.py:679
 msgid "Add Files"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:627
+#: ../../vdms_panels/filedrop.py:655
 msgid "Rename in batch"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:628
+#: ../../vdms_panels/filedrop.py:656
 #, python-brace-format
 msgid "Rename the {0} items to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:630
+#: ../../vdms_panels/filedrop.py:658
 msgid "New Name #"
 msgstr ""
 
@@ -3240,6 +3239,10 @@ msgstr ""
 msgid ""
 "High-quality two-pass Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements\n"
 "the EBU R128 algorithm. Ideal for postprocessing."
+msgstr ""
+
+#: ../../vdms_panels/audio_encoders/acodecs.py:789
+msgid "You need to import at least one file"
 msgstr ""
 
 #: ../../vdms_panels/miscellaneous/miscell.py:63

--- a/videomass/data/locale/cs_CZ/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/cs_CZ/LC_MESSAGES/videomass.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-22 23:33+0200\n"
+"POT-Creation-Date: 2025-07-26 15:04+0200\n"
 "PO-Revision-Date: 2024-07-17 16:33+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: cs_CZ\n"
@@ -936,7 +936,7 @@ msgid "Change"
 msgstr ""
 
 #: ../../vdms_dialogs/preferences.py:103
-#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:574
+#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:602
 #: ../../vdms_panels/presets_manager.py:1050
 msgid "Same destination paths as source files"
 msgstr ""
@@ -1359,33 +1359,33 @@ msgstr ""
 msgid "Profile change successful!"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:81
+#: ../../vdms_dialogs/showlogs.py:80
 msgid "Log file list"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:83 ../../vdms_dialogs/showlogs.py:117
+#: ../../vdms_dialogs/showlogs.py:82 ../../vdms_dialogs/showlogs.py:116
 msgid "Log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:106
+#: ../../vdms_dialogs/showlogs.py:105
 msgid "Refresh log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:108
+#: ../../vdms_dialogs/showlogs.py:107
 msgid "Clear log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:161
+#: ../../vdms_dialogs/showlogs.py:160
 msgid "Select a log file"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:168
+#: ../../vdms_dialogs/showlogs.py:167
 msgid "Are you sure you want to clear the selected log file?"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:169 ../../vdms_dialogs/wizard_dlg.py:251
+#: ../../vdms_dialogs/showlogs.py:168 ../../vdms_dialogs/wizard_dlg.py:251
 #: ../../vdms_io/checkup.py:68 ../../vdms_main/main_frame.py:205
-#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1669
+#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1685
 #: ../../vdms_panels/presets_manager.py:349
 #: ../../vdms_panels/presets_manager.py:550
 #: ../../vdms_panels/presets_manager.py:590
@@ -1662,8 +1662,8 @@ msgstr ""
 msgid "Videomass - Downloading..."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1407
-#: ../../vdms_main/main_frame.py:1435
+#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1409
+#: ../../vdms_main/main_frame.py:1441
 msgid "Ready"
 msgstr ""
 
@@ -1740,7 +1740,7 @@ msgid "File"
 msgstr ""
 
 #: ../../vdms_main/main_frame.py:486 ../../vdms_panels/filedrop.py:340
-#: ../../vdms_panels/filedrop.py:359
+#: ../../vdms_panels/filedrop.py:381
 msgid "Rename selected file\tCtrl+R"
 msgstr ""
 
@@ -1749,7 +1749,7 @@ msgid "Rename the destination of the selected file"
 msgstr ""
 
 #: ../../vdms_main/main_frame.py:490 ../../vdms_panels/filedrop.py:341
-#: ../../vdms_panels/filedrop.py:362
+#: ../../vdms_panels/filedrop.py:384
 msgid "Batch rename files\tCtrl+B"
 msgstr ""
 
@@ -1758,7 +1758,7 @@ msgid "Numerically renames the destination of all items in the list"
 msgstr ""
 
 #: ../../vdms_main/main_frame.py:496 ../../vdms_panels/filedrop.py:343
-#: ../../vdms_panels/filedrop.py:366
+#: ../../vdms_panels/filedrop.py:388
 msgid "Remove selected entry\tDEL"
 msgstr ""
 
@@ -1767,7 +1767,7 @@ msgid "Remove the selected file from the list"
 msgstr ""
 
 #: ../../vdms_main/main_frame.py:500 ../../vdms_panels/filedrop.py:344
-#: ../../vdms_panels/filedrop.py:369
+#: ../../vdms_panels/filedrop.py:391
 msgid "Clear list\tShift+DEL"
 msgstr ""
 
@@ -2133,73 +2133,72 @@ msgstr ""
 msgid "Show queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1406 ../../vdms_panels/presets_manager.py:569
+#: ../../vdms_main/main_frame.py:1408 ../../vdms_panels/presets_manager.py:569
 msgid "Videomass"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1436
+#: ../../vdms_main/main_frame.py:1442
 msgid "Videomass - File List"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1453
+#: ../../vdms_main/main_frame.py:1459
 msgid "Videomass - AV Conversions"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1480
+#: ../../vdms_main/main_frame.py:1488
 msgid "Videomass - Presets Manager"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1508
+#: ../../vdms_main/main_frame.py:1518
 msgid "Videomass - Concatenate Demuxer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1535
+#: ../../vdms_main/main_frame.py:1547
 msgid "Videomass - From Movie to Pictures"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1562
+#: ../../vdms_main/main_frame.py:1576
 msgid "Videomass - Still Image Maker"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1644
-#: ../../vdms_panels/audio_encoders/acodecs.py:789
-#: ../../vdms_panels/av_conversions.py:577 ../../vdms_panels/filedrop.py:475
-#: ../../vdms_panels/filedrop.py:588 ../../vdms_panels/sequence_to_video.py:322
+#: ../../vdms_main/main_frame.py:1660 ../../vdms_panels/av_conversions.py:577
+#: ../../vdms_panels/filedrop.py:500 ../../vdms_panels/filedrop.py:616
+#: ../../vdms_panels/sequence_to_video.py:322
 #: ../../vdms_panels/video_to_sequence.py:369
 #: ../../vdms_panels/video_to_sequence.py:501
 msgid "Have to select an item in the file list first"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1666
+#: ../../vdms_main/main_frame.py:1682
 msgid ""
 "An item with the same destination file already exists.\n"
 "\n"
 "Do you want to replace it by adding the new item to the queue?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1687
+#: ../../vdms_main/main_frame.py:1703
 msgid "Videomass - FFmpeg Message Monitoring"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1814
+#: ../../vdms_main/main_frame.py:1828
 #, python-brace-format
 msgid "The system will turn off in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1815
+#: ../../vdms_main/main_frame.py:1829
 msgid "Videomass - Shutdown!"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1822
+#: ../../vdms_main/main_frame.py:1836
 msgid "Error while shutting down. Please see file log for details."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1834
+#: ../../vdms_main/main_frame.py:1848
 #, python-brace-format
 msgid "Exiting the application in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1835
+#: ../../vdms_main/main_frame.py:1849
 msgid "Videomass - Exiting!"
 msgstr ""
 
@@ -2589,7 +2588,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:383
+#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:405
 msgid "Drag one or more files below"
 msgstr ""
 
@@ -2605,45 +2604,45 @@ msgstr ""
 msgid "Encodings destination folder"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:372
+#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:394
 msgid "Play file"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:386
+#: ../../vdms_panels/filedrop.py:408
 msgid "Drag two or more Audio/Video files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:390
+#: ../../vdms_panels/filedrop.py:412
 msgid "Drag one or more Image files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:393
+#: ../../vdms_panels/filedrop.py:415
 msgid "Drag one or more Video files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:595
+#: ../../vdms_panels/filedrop.py:623
 msgid "Rename the file destination"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:596
+#: ../../vdms_panels/filedrop.py:624
 msgid "Rename the selected file to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:610 ../../vdms_panels/filedrop.py:620
-#: ../../vdms_panels/filedrop.py:651
+#: ../../vdms_panels/filedrop.py:638 ../../vdms_panels/filedrop.py:648
+#: ../../vdms_panels/filedrop.py:679
 msgid "Add Files"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:627
+#: ../../vdms_panels/filedrop.py:655
 msgid "Rename in batch"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:628
+#: ../../vdms_panels/filedrop.py:656
 #, python-brace-format
 msgid "Rename the {0} items to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:630
+#: ../../vdms_panels/filedrop.py:658
 msgid "New Name #"
 msgstr ""
 
@@ -3240,6 +3239,10 @@ msgstr ""
 msgid ""
 "High-quality two-pass Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements\n"
 "the EBU R128 algorithm. Ideal for postprocessing."
+msgstr ""
+
+#: ../../vdms_panels/audio_encoders/acodecs.py:789
+msgid "You need to import at least one file"
 msgstr ""
 
 #: ../../vdms_panels/miscellaneous/miscell.py:63

--- a/videomass/data/locale/de_DE/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/de_DE/LC_MESSAGES/videomass.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-22 23:33+0200\n"
+"POT-Creation-Date: 2025-07-26 15:04+0200\n"
 "PO-Revision-Date: 2024-07-17 16:40+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de_DE\n"
@@ -936,7 +936,7 @@ msgid "Change"
 msgstr ""
 
 #: ../../vdms_dialogs/preferences.py:103
-#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:574
+#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:602
 #: ../../vdms_panels/presets_manager.py:1050
 msgid "Same destination paths as source files"
 msgstr ""
@@ -1359,33 +1359,33 @@ msgstr ""
 msgid "Profile change successful!"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:81
+#: ../../vdms_dialogs/showlogs.py:80
 msgid "Log file list"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:83 ../../vdms_dialogs/showlogs.py:117
+#: ../../vdms_dialogs/showlogs.py:82 ../../vdms_dialogs/showlogs.py:116
 msgid "Log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:106
+#: ../../vdms_dialogs/showlogs.py:105
 msgid "Refresh log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:108
+#: ../../vdms_dialogs/showlogs.py:107
 msgid "Clear log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:161
+#: ../../vdms_dialogs/showlogs.py:160
 msgid "Select a log file"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:168
+#: ../../vdms_dialogs/showlogs.py:167
 msgid "Are you sure you want to clear the selected log file?"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:169 ../../vdms_dialogs/wizard_dlg.py:251
+#: ../../vdms_dialogs/showlogs.py:168 ../../vdms_dialogs/wizard_dlg.py:251
 #: ../../vdms_io/checkup.py:68 ../../vdms_main/main_frame.py:205
-#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1669
+#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1685
 #: ../../vdms_panels/presets_manager.py:349
 #: ../../vdms_panels/presets_manager.py:550
 #: ../../vdms_panels/presets_manager.py:590
@@ -1662,8 +1662,8 @@ msgstr ""
 msgid "Videomass - Downloading..."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1407
-#: ../../vdms_main/main_frame.py:1435
+#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1409
+#: ../../vdms_main/main_frame.py:1441
 msgid "Ready"
 msgstr ""
 
@@ -1740,7 +1740,7 @@ msgid "File"
 msgstr ""
 
 #: ../../vdms_main/main_frame.py:486 ../../vdms_panels/filedrop.py:340
-#: ../../vdms_panels/filedrop.py:359
+#: ../../vdms_panels/filedrop.py:381
 msgid "Rename selected file\tCtrl+R"
 msgstr ""
 
@@ -1749,7 +1749,7 @@ msgid "Rename the destination of the selected file"
 msgstr ""
 
 #: ../../vdms_main/main_frame.py:490 ../../vdms_panels/filedrop.py:341
-#: ../../vdms_panels/filedrop.py:362
+#: ../../vdms_panels/filedrop.py:384
 msgid "Batch rename files\tCtrl+B"
 msgstr ""
 
@@ -1758,7 +1758,7 @@ msgid "Numerically renames the destination of all items in the list"
 msgstr ""
 
 #: ../../vdms_main/main_frame.py:496 ../../vdms_panels/filedrop.py:343
-#: ../../vdms_panels/filedrop.py:366
+#: ../../vdms_panels/filedrop.py:388
 msgid "Remove selected entry\tDEL"
 msgstr ""
 
@@ -1767,7 +1767,7 @@ msgid "Remove the selected file from the list"
 msgstr ""
 
 #: ../../vdms_main/main_frame.py:500 ../../vdms_panels/filedrop.py:344
-#: ../../vdms_panels/filedrop.py:369
+#: ../../vdms_panels/filedrop.py:391
 msgid "Clear list\tShift+DEL"
 msgstr ""
 
@@ -2133,73 +2133,72 @@ msgstr ""
 msgid "Show queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1406 ../../vdms_panels/presets_manager.py:569
+#: ../../vdms_main/main_frame.py:1408 ../../vdms_panels/presets_manager.py:569
 msgid "Videomass"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1436
+#: ../../vdms_main/main_frame.py:1442
 msgid "Videomass - File List"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1453
+#: ../../vdms_main/main_frame.py:1459
 msgid "Videomass - AV Conversions"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1480
+#: ../../vdms_main/main_frame.py:1488
 msgid "Videomass - Presets Manager"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1508
+#: ../../vdms_main/main_frame.py:1518
 msgid "Videomass - Concatenate Demuxer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1535
+#: ../../vdms_main/main_frame.py:1547
 msgid "Videomass - From Movie to Pictures"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1562
+#: ../../vdms_main/main_frame.py:1576
 msgid "Videomass - Still Image Maker"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1644
-#: ../../vdms_panels/audio_encoders/acodecs.py:789
-#: ../../vdms_panels/av_conversions.py:577 ../../vdms_panels/filedrop.py:475
-#: ../../vdms_panels/filedrop.py:588 ../../vdms_panels/sequence_to_video.py:322
+#: ../../vdms_main/main_frame.py:1660 ../../vdms_panels/av_conversions.py:577
+#: ../../vdms_panels/filedrop.py:500 ../../vdms_panels/filedrop.py:616
+#: ../../vdms_panels/sequence_to_video.py:322
 #: ../../vdms_panels/video_to_sequence.py:369
 #: ../../vdms_panels/video_to_sequence.py:501
 msgid "Have to select an item in the file list first"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1666
+#: ../../vdms_main/main_frame.py:1682
 msgid ""
 "An item with the same destination file already exists.\n"
 "\n"
 "Do you want to replace it by adding the new item to the queue?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1687
+#: ../../vdms_main/main_frame.py:1703
 msgid "Videomass - FFmpeg Message Monitoring"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1814
+#: ../../vdms_main/main_frame.py:1828
 #, python-brace-format
 msgid "The system will turn off in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1815
+#: ../../vdms_main/main_frame.py:1829
 msgid "Videomass - Shutdown!"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1822
+#: ../../vdms_main/main_frame.py:1836
 msgid "Error while shutting down. Please see file log for details."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1834
+#: ../../vdms_main/main_frame.py:1848
 #, python-brace-format
 msgid "Exiting the application in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1835
+#: ../../vdms_main/main_frame.py:1849
 msgid "Videomass - Exiting!"
 msgstr ""
 
@@ -2589,7 +2588,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:383
+#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:405
 msgid "Drag one or more files below"
 msgstr ""
 
@@ -2605,45 +2604,45 @@ msgstr ""
 msgid "Encodings destination folder"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:372
+#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:394
 msgid "Play file"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:386
+#: ../../vdms_panels/filedrop.py:408
 msgid "Drag two or more Audio/Video files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:390
+#: ../../vdms_panels/filedrop.py:412
 msgid "Drag one or more Image files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:393
+#: ../../vdms_panels/filedrop.py:415
 msgid "Drag one or more Video files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:595
+#: ../../vdms_panels/filedrop.py:623
 msgid "Rename the file destination"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:596
+#: ../../vdms_panels/filedrop.py:624
 msgid "Rename the selected file to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:610 ../../vdms_panels/filedrop.py:620
-#: ../../vdms_panels/filedrop.py:651
+#: ../../vdms_panels/filedrop.py:638 ../../vdms_panels/filedrop.py:648
+#: ../../vdms_panels/filedrop.py:679
 msgid "Add Files"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:627
+#: ../../vdms_panels/filedrop.py:655
 msgid "Rename in batch"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:628
+#: ../../vdms_panels/filedrop.py:656
 #, python-brace-format
 msgid "Rename the {0} items to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:630
+#: ../../vdms_panels/filedrop.py:658
 msgid "New Name #"
 msgstr ""
 
@@ -3240,6 +3239,10 @@ msgstr ""
 msgid ""
 "High-quality two-pass Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements\n"
 "the EBU R128 algorithm. Ideal for postprocessing."
+msgstr ""
+
+#: ../../vdms_panels/audio_encoders/acodecs.py:789
+msgid "You need to import at least one file"
 msgstr ""
 
 #: ../../vdms_panels/miscellaneous/miscell.py:63

--- a/videomass/data/locale/en_US/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/en_US/LC_MESSAGES/videomass.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Videomass 5.0.18\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-22 23:33+0200\n"
+"POT-Creation-Date: 2025-07-26 15:04+0200\n"
 "PO-Revision-Date: 2024-07-03 18:44+0200\n"
 "Last-Translator: \n"
 "Language: en_US\n"
@@ -936,7 +936,7 @@ msgid "Change"
 msgstr ""
 
 #: ../../vdms_dialogs/preferences.py:103
-#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:574
+#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:602
 #: ../../vdms_panels/presets_manager.py:1050
 msgid "Same destination paths as source files"
 msgstr ""
@@ -1359,33 +1359,33 @@ msgstr ""
 msgid "Profile change successful!"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:81
+#: ../../vdms_dialogs/showlogs.py:80
 msgid "Log file list"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:83 ../../vdms_dialogs/showlogs.py:117
+#: ../../vdms_dialogs/showlogs.py:82 ../../vdms_dialogs/showlogs.py:116
 msgid "Log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:106
+#: ../../vdms_dialogs/showlogs.py:105
 msgid "Refresh log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:108
+#: ../../vdms_dialogs/showlogs.py:107
 msgid "Clear log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:161
+#: ../../vdms_dialogs/showlogs.py:160
 msgid "Select a log file"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:168
+#: ../../vdms_dialogs/showlogs.py:167
 msgid "Are you sure you want to clear the selected log file?"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:169 ../../vdms_dialogs/wizard_dlg.py:251
+#: ../../vdms_dialogs/showlogs.py:168 ../../vdms_dialogs/wizard_dlg.py:251
 #: ../../vdms_io/checkup.py:68 ../../vdms_main/main_frame.py:205
-#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1669
+#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1685
 #: ../../vdms_panels/presets_manager.py:349
 #: ../../vdms_panels/presets_manager.py:550
 #: ../../vdms_panels/presets_manager.py:590
@@ -1662,8 +1662,8 @@ msgstr ""
 msgid "Videomass - Downloading..."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1407
-#: ../../vdms_main/main_frame.py:1435
+#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1409
+#: ../../vdms_main/main_frame.py:1441
 msgid "Ready"
 msgstr ""
 
@@ -1740,7 +1740,7 @@ msgid "File"
 msgstr ""
 
 #: ../../vdms_main/main_frame.py:486 ../../vdms_panels/filedrop.py:340
-#: ../../vdms_panels/filedrop.py:359
+#: ../../vdms_panels/filedrop.py:381
 msgid "Rename selected file\tCtrl+R"
 msgstr ""
 
@@ -1749,7 +1749,7 @@ msgid "Rename the destination of the selected file"
 msgstr ""
 
 #: ../../vdms_main/main_frame.py:490 ../../vdms_panels/filedrop.py:341
-#: ../../vdms_panels/filedrop.py:362
+#: ../../vdms_panels/filedrop.py:384
 msgid "Batch rename files\tCtrl+B"
 msgstr ""
 
@@ -1758,7 +1758,7 @@ msgid "Numerically renames the destination of all items in the list"
 msgstr ""
 
 #: ../../vdms_main/main_frame.py:496 ../../vdms_panels/filedrop.py:343
-#: ../../vdms_panels/filedrop.py:366
+#: ../../vdms_panels/filedrop.py:388
 msgid "Remove selected entry\tDEL"
 msgstr ""
 
@@ -1767,7 +1767,7 @@ msgid "Remove the selected file from the list"
 msgstr ""
 
 #: ../../vdms_main/main_frame.py:500 ../../vdms_panels/filedrop.py:344
-#: ../../vdms_panels/filedrop.py:369
+#: ../../vdms_panels/filedrop.py:391
 msgid "Clear list\tShift+DEL"
 msgstr ""
 
@@ -2133,73 +2133,72 @@ msgstr ""
 msgid "Show queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1406 ../../vdms_panels/presets_manager.py:569
+#: ../../vdms_main/main_frame.py:1408 ../../vdms_panels/presets_manager.py:569
 msgid "Videomass"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1436
+#: ../../vdms_main/main_frame.py:1442
 msgid "Videomass - File List"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1453
+#: ../../vdms_main/main_frame.py:1459
 msgid "Videomass - AV Conversions"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1480
+#: ../../vdms_main/main_frame.py:1488
 msgid "Videomass - Presets Manager"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1508
+#: ../../vdms_main/main_frame.py:1518
 msgid "Videomass - Concatenate Demuxer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1535
+#: ../../vdms_main/main_frame.py:1547
 msgid "Videomass - From Movie to Pictures"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1562
+#: ../../vdms_main/main_frame.py:1576
 msgid "Videomass - Still Image Maker"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1644
-#: ../../vdms_panels/audio_encoders/acodecs.py:789
-#: ../../vdms_panels/av_conversions.py:577 ../../vdms_panels/filedrop.py:475
-#: ../../vdms_panels/filedrop.py:588 ../../vdms_panels/sequence_to_video.py:322
+#: ../../vdms_main/main_frame.py:1660 ../../vdms_panels/av_conversions.py:577
+#: ../../vdms_panels/filedrop.py:500 ../../vdms_panels/filedrop.py:616
+#: ../../vdms_panels/sequence_to_video.py:322
 #: ../../vdms_panels/video_to_sequence.py:369
 #: ../../vdms_panels/video_to_sequence.py:501
 msgid "Have to select an item in the file list first"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1666
+#: ../../vdms_main/main_frame.py:1682
 msgid ""
 "An item with the same destination file already exists.\n"
 "\n"
 "Do you want to replace it by adding the new item to the queue?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1687
+#: ../../vdms_main/main_frame.py:1703
 msgid "Videomass - FFmpeg Message Monitoring"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1814
+#: ../../vdms_main/main_frame.py:1828
 #, python-brace-format
 msgid "The system will turn off in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1815
+#: ../../vdms_main/main_frame.py:1829
 msgid "Videomass - Shutdown!"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1822
+#: ../../vdms_main/main_frame.py:1836
 msgid "Error while shutting down. Please see file log for details."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1834
+#: ../../vdms_main/main_frame.py:1848
 #, python-brace-format
 msgid "Exiting the application in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1835
+#: ../../vdms_main/main_frame.py:1849
 msgid "Videomass - Exiting!"
 msgstr ""
 
@@ -2589,7 +2588,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:383
+#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:405
 msgid "Drag one or more files below"
 msgstr ""
 
@@ -2605,45 +2604,45 @@ msgstr ""
 msgid "Encodings destination folder"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:372
+#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:394
 msgid "Play file"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:386
+#: ../../vdms_panels/filedrop.py:408
 msgid "Drag two or more Audio/Video files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:390
+#: ../../vdms_panels/filedrop.py:412
 msgid "Drag one or more Image files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:393
+#: ../../vdms_panels/filedrop.py:415
 msgid "Drag one or more Video files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:595
+#: ../../vdms_panels/filedrop.py:623
 msgid "Rename the file destination"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:596
+#: ../../vdms_panels/filedrop.py:624
 msgid "Rename the selected file to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:610 ../../vdms_panels/filedrop.py:620
-#: ../../vdms_panels/filedrop.py:651
+#: ../../vdms_panels/filedrop.py:638 ../../vdms_panels/filedrop.py:648
+#: ../../vdms_panels/filedrop.py:679
 msgid "Add Files"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:627
+#: ../../vdms_panels/filedrop.py:655
 msgid "Rename in batch"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:628
+#: ../../vdms_panels/filedrop.py:656
 #, python-brace-format
 msgid "Rename the {0} items to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:630
+#: ../../vdms_panels/filedrop.py:658
 msgid "New Name #"
 msgstr ""
 
@@ -3240,6 +3239,10 @@ msgstr ""
 msgid ""
 "High-quality two-pass Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements\n"
 "the EBU R128 algorithm. Ideal for postprocessing."
+msgstr ""
+
+#: ../../vdms_panels/audio_encoders/acodecs.py:789
+msgid "You need to import at least one file"
 msgstr ""
 
 #: ../../vdms_panels/miscellaneous/miscell.py:63

--- a/videomass/data/locale/es_CU/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/es_CU/LC_MESSAGES/videomass.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Videomass 5.0.18\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-22 23:33+0200\n"
+"POT-Creation-Date: 2025-07-26 15:04+0200\n"
 "PO-Revision-Date: 2024-08-26 17:29-0600\n"
 "Last-Translator: José Alberto Valle Cid j.alberto.vc@gmail.com\n"
 "Language: es_CU\n"
@@ -983,7 +983,7 @@ msgid "Change"
 msgstr "Cambiar"
 
 #: ../../vdms_dialogs/preferences.py:103
-#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:574
+#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:602
 #: ../../vdms_panels/presets_manager.py:1050
 msgid "Same destination paths as source files"
 msgstr "Misma carpeta destino que archivos fuente"
@@ -1429,33 +1429,33 @@ msgstr "¡Perfil guardado exitosamente!"
 msgid "Profile change successful!"
 msgstr "¡Cambio de Perfil exitosol!"
 
-#: ../../vdms_dialogs/showlogs.py:81
+#: ../../vdms_dialogs/showlogs.py:80
 msgid "Log file list"
 msgstr "Lista de archivos de registro"
 
-#: ../../vdms_dialogs/showlogs.py:83 ../../vdms_dialogs/showlogs.py:117
+#: ../../vdms_dialogs/showlogs.py:82 ../../vdms_dialogs/showlogs.py:116
 msgid "Log messages"
 msgstr "Registro de mensajes"
 
-#: ../../vdms_dialogs/showlogs.py:106
+#: ../../vdms_dialogs/showlogs.py:105
 msgid "Refresh log messages"
 msgstr "Refrescar mensajes de registro"
 
-#: ../../vdms_dialogs/showlogs.py:108
+#: ../../vdms_dialogs/showlogs.py:107
 msgid "Clear log messages"
 msgstr "Limpiar mensajes de registro"
 
-#: ../../vdms_dialogs/showlogs.py:161
+#: ../../vdms_dialogs/showlogs.py:160
 msgid "Select a log file"
 msgstr "Seleccionar archivo de registro"
 
-#: ../../vdms_dialogs/showlogs.py:168
+#: ../../vdms_dialogs/showlogs.py:167
 msgid "Are you sure you want to clear the selected log file?"
 msgstr "¿Seguro desea limpiar el archivo de registro?"
 
-#: ../../vdms_dialogs/showlogs.py:169 ../../vdms_dialogs/wizard_dlg.py:251
+#: ../../vdms_dialogs/showlogs.py:168 ../../vdms_dialogs/wizard_dlg.py:251
 #: ../../vdms_io/checkup.py:68 ../../vdms_main/main_frame.py:205
-#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1669
+#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1685
 #: ../../vdms_panels/presets_manager.py:349
 #: ../../vdms_panels/presets_manager.py:550
 #: ../../vdms_panels/presets_manager.py:590
@@ -1776,8 +1776,8 @@ msgstr ""
 msgid "Videomass - Downloading..."
 msgstr "Videomass - Descargando..."
 
-#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1407
-#: ../../vdms_main/main_frame.py:1435
+#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1409
+#: ../../vdms_main/main_frame.py:1441
 msgid "Ready"
 msgstr "Listo"
 
@@ -1857,7 +1857,7 @@ msgid "File"
 msgstr "Archivo"
 
 #: ../../vdms_main/main_frame.py:486 ../../vdms_panels/filedrop.py:340
-#: ../../vdms_panels/filedrop.py:359
+#: ../../vdms_panels/filedrop.py:381
 msgid "Rename selected file\tCtrl+R"
 msgstr "Renombrar archivo seleccionado\tCtrl+R"
 
@@ -1866,7 +1866,7 @@ msgid "Rename the destination of the selected file"
 msgstr "Renombra destino de archivo seleccionado"
 
 #: ../../vdms_main/main_frame.py:490 ../../vdms_panels/filedrop.py:341
-#: ../../vdms_panels/filedrop.py:362
+#: ../../vdms_panels/filedrop.py:384
 #, fuzzy
 msgid "Batch rename files\tCtrl+B"
 msgstr "Renombrado en lote\tCtrl+B"
@@ -1876,7 +1876,7 @@ msgid "Numerically renames the destination of all items in the list"
 msgstr "Ennumerar el destino de todas las entradas de la lista"
 
 #: ../../vdms_main/main_frame.py:496 ../../vdms_panels/filedrop.py:343
-#: ../../vdms_panels/filedrop.py:366
+#: ../../vdms_panels/filedrop.py:388
 msgid "Remove selected entry\tDEL"
 msgstr "Quitar entrada seleccionada\tDEL"
 
@@ -1885,7 +1885,7 @@ msgid "Remove the selected file from the list"
 msgstr "Eliminar archivo seleccionado de la lista"
 
 #: ../../vdms_main/main_frame.py:500 ../../vdms_panels/filedrop.py:344
-#: ../../vdms_panels/filedrop.py:369
+#: ../../vdms_panels/filedrop.py:391
 msgid "Clear list\tShift+DEL"
 msgstr "Vaciar lista\tShift+DEL"
 
@@ -2260,44 +2260,43 @@ msgstr "Añadir a la Lista"
 msgid "Show queue"
 msgstr "Mostrar lista"
 
-#: ../../vdms_main/main_frame.py:1406 ../../vdms_panels/presets_manager.py:569
+#: ../../vdms_main/main_frame.py:1408 ../../vdms_panels/presets_manager.py:569
 msgid "Videomass"
 msgstr "Videomass"
 
-#: ../../vdms_main/main_frame.py:1436
+#: ../../vdms_main/main_frame.py:1442
 msgid "Videomass - File List"
 msgstr "Videomass - Lista de Archivos"
 
-#: ../../vdms_main/main_frame.py:1453
+#: ../../vdms_main/main_frame.py:1459
 msgid "Videomass - AV Conversions"
 msgstr "Videomass - Conversiones AV"
 
-#: ../../vdms_main/main_frame.py:1480
+#: ../../vdms_main/main_frame.py:1488
 msgid "Videomass - Presets Manager"
 msgstr "Videomass - Administrador de Presets"
 
-#: ../../vdms_main/main_frame.py:1508
+#: ../../vdms_main/main_frame.py:1518
 msgid "Videomass - Concatenate Demuxer"
 msgstr "Videomass - Encadenar Dezmezcladores"
 
-#: ../../vdms_main/main_frame.py:1535
+#: ../../vdms_main/main_frame.py:1547
 msgid "Videomass - From Movie to Pictures"
 msgstr "Videomass -De Película a Imágenes"
 
-#: ../../vdms_main/main_frame.py:1562
+#: ../../vdms_main/main_frame.py:1576
 msgid "Videomass - Still Image Maker"
 msgstr "Videomass -Productor de Imágenes Fijas"
 
-#: ../../vdms_main/main_frame.py:1644
-#: ../../vdms_panels/audio_encoders/acodecs.py:789
-#: ../../vdms_panels/av_conversions.py:577 ../../vdms_panels/filedrop.py:475
-#: ../../vdms_panels/filedrop.py:588 ../../vdms_panels/sequence_to_video.py:322
+#: ../../vdms_main/main_frame.py:1660 ../../vdms_panels/av_conversions.py:577
+#: ../../vdms_panels/filedrop.py:500 ../../vdms_panels/filedrop.py:616
+#: ../../vdms_panels/sequence_to_video.py:322
 #: ../../vdms_panels/video_to_sequence.py:369
 #: ../../vdms_panels/video_to_sequence.py:501
 msgid "Have to select an item in the file list first"
 msgstr "Primero elija un archivo en la lista"
 
-#: ../../vdms_main/main_frame.py:1666
+#: ../../vdms_main/main_frame.py:1682
 msgid ""
 "An item with the same destination file already exists.\n"
 "\n"
@@ -2307,29 +2306,29 @@ msgstr ""
 "\n"
 "¿Desea reemplazarlo añadiendo la entrada a la lista?"
 
-#: ../../vdms_main/main_frame.py:1687
+#: ../../vdms_main/main_frame.py:1703
 msgid "Videomass - FFmpeg Message Monitoring"
 msgstr "Videomass - Monitor de mensajes de FFmpeg"
 
-#: ../../vdms_main/main_frame.py:1814
+#: ../../vdms_main/main_frame.py:1828
 #, python-brace-format
 msgid "The system will turn off in {0} seconds"
 msgstr "El sistema se apagara en {0} segundos"
 
-#: ../../vdms_main/main_frame.py:1815
+#: ../../vdms_main/main_frame.py:1829
 msgid "Videomass - Shutdown!"
 msgstr "Videomass - ¡Apagando!"
 
-#: ../../vdms_main/main_frame.py:1822
+#: ../../vdms_main/main_frame.py:1836
 msgid "Error while shutting down. Please see file log for details."
 msgstr "Error al apagar. Vea el archivo de registro para detalles."
 
-#: ../../vdms_main/main_frame.py:1834
+#: ../../vdms_main/main_frame.py:1848
 #, python-brace-format
 msgid "Exiting the application in {0} seconds"
 msgstr "La aplicación se cerrara en {0} segundos"
 
-#: ../../vdms_main/main_frame.py:1835
+#: ../../vdms_main/main_frame.py:1849
 msgid "Videomass - Exiting!"
 msgstr "Videomass - ¡Saliendo!"
 
@@ -2770,7 +2769,7 @@ msgstr "Tipo de Medio"
 msgid "Size"
 msgstr "Tamaño"
 
-#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:383
+#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:405
 msgid "Drag one or more files below"
 msgstr "Arrastre uno o más archivos abajo"
 
@@ -2786,46 +2785,46 @@ msgstr "Carpeta destino para codificaciones"
 msgid "Encodings destination folder"
 msgstr "Carpeta destino para codificaciones"
 
-#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:372
+#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:394
 msgid "Play file"
 msgstr "Reproducir archivo"
 
-#: ../../vdms_panels/filedrop.py:386
+#: ../../vdms_panels/filedrop.py:408
 msgid "Drag two or more Audio/Video files below"
 msgstr "Arrastre dos o más archivos Audio/Video abajo"
 
-#: ../../vdms_panels/filedrop.py:390
+#: ../../vdms_panels/filedrop.py:412
 #, fuzzy
 msgid "Drag one or more Image files below"
 msgstr "Arrastre uno o más archivos abajo"
 
-#: ../../vdms_panels/filedrop.py:393
+#: ../../vdms_panels/filedrop.py:415
 msgid "Drag one or more Video files below"
 msgstr "Arrastre uno o más archivos Video abajo"
 
-#: ../../vdms_panels/filedrop.py:595
+#: ../../vdms_panels/filedrop.py:623
 msgid "Rename the file destination"
 msgstr "Renombra archivo destino"
 
-#: ../../vdms_panels/filedrop.py:596
+#: ../../vdms_panels/filedrop.py:624
 msgid "Rename the selected file to:"
 msgstr "Renombrar archivo seleccionado a:"
 
-#: ../../vdms_panels/filedrop.py:610 ../../vdms_panels/filedrop.py:620
-#: ../../vdms_panels/filedrop.py:651
+#: ../../vdms_panels/filedrop.py:638 ../../vdms_panels/filedrop.py:648
+#: ../../vdms_panels/filedrop.py:679
 msgid "Add Files"
 msgstr "Añadir Archivos"
 
-#: ../../vdms_panels/filedrop.py:627
+#: ../../vdms_panels/filedrop.py:655
 msgid "Rename in batch"
 msgstr "Renombrar por lote"
 
-#: ../../vdms_panels/filedrop.py:628
+#: ../../vdms_panels/filedrop.py:656
 #, python-brace-format
 msgid "Rename the {0} items to:"
 msgstr "Renombrar {0} objetos a:"
 
-#: ../../vdms_panels/filedrop.py:630
+#: ../../vdms_panels/filedrop.py:658
 msgid "New Name #"
 msgstr "Nombre Nuevo #"
 
@@ -3542,6 +3541,10 @@ msgid ""
 msgstr ""
 "Normalización de intensidad Alta calidad en dos pasos. Se Normaliza la intensidad percibida utilizando el filtro \"​loudnorm\", el cual\n"
 "implementa el algoritmo EBU R128. Ideal para postprocesado."
+
+#: ../../vdms_panels/audio_encoders/acodecs.py:789
+msgid "You need to import at least one file"
+msgstr ""
 
 #: ../../vdms_panels/miscellaneous/miscell.py:63
 msgid "Subtitle Mapping:"

--- a/videomass/data/locale/es_ES/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/es_ES/LC_MESSAGES/videomass.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Videomass 5.0.18\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-22 23:33+0200\n"
+"POT-Creation-Date: 2025-07-26 15:04+0200\n"
 "PO-Revision-Date: 2024-08-26 17:29-0600\n"
 "Last-Translator: José Alberto Valle Cid j.alberto.vc@gmail.com\n"
 "Language: es_ES\n"
@@ -983,7 +983,7 @@ msgid "Change"
 msgstr "Cambiar"
 
 #: ../../vdms_dialogs/preferences.py:103
-#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:574
+#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:602
 #: ../../vdms_panels/presets_manager.py:1050
 msgid "Same destination paths as source files"
 msgstr "Misma carpeta destino que archivos fuente"
@@ -1429,33 +1429,33 @@ msgstr "¡Perfil guardado exitosamente!"
 msgid "Profile change successful!"
 msgstr "¡Cambio de Perfil exitosol!"
 
-#: ../../vdms_dialogs/showlogs.py:81
+#: ../../vdms_dialogs/showlogs.py:80
 msgid "Log file list"
 msgstr "Lista de archivos de registro"
 
-#: ../../vdms_dialogs/showlogs.py:83 ../../vdms_dialogs/showlogs.py:117
+#: ../../vdms_dialogs/showlogs.py:82 ../../vdms_dialogs/showlogs.py:116
 msgid "Log messages"
 msgstr "Registro de mensajes"
 
-#: ../../vdms_dialogs/showlogs.py:106
+#: ../../vdms_dialogs/showlogs.py:105
 msgid "Refresh log messages"
 msgstr "Refrescar mensajes de registro"
 
-#: ../../vdms_dialogs/showlogs.py:108
+#: ../../vdms_dialogs/showlogs.py:107
 msgid "Clear log messages"
 msgstr "Limpiar mensajes de registro"
 
-#: ../../vdms_dialogs/showlogs.py:161
+#: ../../vdms_dialogs/showlogs.py:160
 msgid "Select a log file"
 msgstr "Seleccionar archivo de registro"
 
-#: ../../vdms_dialogs/showlogs.py:168
+#: ../../vdms_dialogs/showlogs.py:167
 msgid "Are you sure you want to clear the selected log file?"
 msgstr "¿Seguro desea limpiar el archivo de registro?"
 
-#: ../../vdms_dialogs/showlogs.py:169 ../../vdms_dialogs/wizard_dlg.py:251
+#: ../../vdms_dialogs/showlogs.py:168 ../../vdms_dialogs/wizard_dlg.py:251
 #: ../../vdms_io/checkup.py:68 ../../vdms_main/main_frame.py:205
-#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1669
+#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1685
 #: ../../vdms_panels/presets_manager.py:349
 #: ../../vdms_panels/presets_manager.py:550
 #: ../../vdms_panels/presets_manager.py:590
@@ -1776,8 +1776,8 @@ msgstr ""
 msgid "Videomass - Downloading..."
 msgstr "Videomass - Descargando..."
 
-#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1407
-#: ../../vdms_main/main_frame.py:1435
+#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1409
+#: ../../vdms_main/main_frame.py:1441
 msgid "Ready"
 msgstr "Listo"
 
@@ -1857,7 +1857,7 @@ msgid "File"
 msgstr "Archivo"
 
 #: ../../vdms_main/main_frame.py:486 ../../vdms_panels/filedrop.py:340
-#: ../../vdms_panels/filedrop.py:359
+#: ../../vdms_panels/filedrop.py:381
 msgid "Rename selected file\tCtrl+R"
 msgstr "Renombrar archivo seleccionado\tCtrl+R"
 
@@ -1866,7 +1866,7 @@ msgid "Rename the destination of the selected file"
 msgstr "Renombra destino de archivo seleccionado"
 
 #: ../../vdms_main/main_frame.py:490 ../../vdms_panels/filedrop.py:341
-#: ../../vdms_panels/filedrop.py:362
+#: ../../vdms_panels/filedrop.py:384
 #, fuzzy
 msgid "Batch rename files\tCtrl+B"
 msgstr "Renombrado en lote\tCtrl+B"
@@ -1876,7 +1876,7 @@ msgid "Numerically renames the destination of all items in the list"
 msgstr "Ennumerar el destino de todas las entradas de la lista"
 
 #: ../../vdms_main/main_frame.py:496 ../../vdms_panels/filedrop.py:343
-#: ../../vdms_panels/filedrop.py:366
+#: ../../vdms_panels/filedrop.py:388
 msgid "Remove selected entry\tDEL"
 msgstr "Quitar entrada seleccionada\tDEL"
 
@@ -1885,7 +1885,7 @@ msgid "Remove the selected file from the list"
 msgstr "Eliminar archivo seleccionado de la lista"
 
 #: ../../vdms_main/main_frame.py:500 ../../vdms_panels/filedrop.py:344
-#: ../../vdms_panels/filedrop.py:369
+#: ../../vdms_panels/filedrop.py:391
 msgid "Clear list\tShift+DEL"
 msgstr "Vaciar lista\tShift+DEL"
 
@@ -2260,44 +2260,43 @@ msgstr "Añadir a la Lista"
 msgid "Show queue"
 msgstr "Mostrar lista"
 
-#: ../../vdms_main/main_frame.py:1406 ../../vdms_panels/presets_manager.py:569
+#: ../../vdms_main/main_frame.py:1408 ../../vdms_panels/presets_manager.py:569
 msgid "Videomass"
 msgstr "Videomass"
 
-#: ../../vdms_main/main_frame.py:1436
+#: ../../vdms_main/main_frame.py:1442
 msgid "Videomass - File List"
 msgstr "Videomass - Lista de Archivos"
 
-#: ../../vdms_main/main_frame.py:1453
+#: ../../vdms_main/main_frame.py:1459
 msgid "Videomass - AV Conversions"
 msgstr "Videomass - Conversiones AV"
 
-#: ../../vdms_main/main_frame.py:1480
+#: ../../vdms_main/main_frame.py:1488
 msgid "Videomass - Presets Manager"
 msgstr "Videomass - Administrador de Presets"
 
-#: ../../vdms_main/main_frame.py:1508
+#: ../../vdms_main/main_frame.py:1518
 msgid "Videomass - Concatenate Demuxer"
 msgstr "Videomass - Encadenar Dezmezcladores"
 
-#: ../../vdms_main/main_frame.py:1535
+#: ../../vdms_main/main_frame.py:1547
 msgid "Videomass - From Movie to Pictures"
 msgstr "Videomass -De Película a Imágenes"
 
-#: ../../vdms_main/main_frame.py:1562
+#: ../../vdms_main/main_frame.py:1576
 msgid "Videomass - Still Image Maker"
 msgstr "Videomass -Productor de Imágenes Fijas"
 
-#: ../../vdms_main/main_frame.py:1644
-#: ../../vdms_panels/audio_encoders/acodecs.py:789
-#: ../../vdms_panels/av_conversions.py:577 ../../vdms_panels/filedrop.py:475
-#: ../../vdms_panels/filedrop.py:588 ../../vdms_panels/sequence_to_video.py:322
+#: ../../vdms_main/main_frame.py:1660 ../../vdms_panels/av_conversions.py:577
+#: ../../vdms_panels/filedrop.py:500 ../../vdms_panels/filedrop.py:616
+#: ../../vdms_panels/sequence_to_video.py:322
 #: ../../vdms_panels/video_to_sequence.py:369
 #: ../../vdms_panels/video_to_sequence.py:501
 msgid "Have to select an item in the file list first"
 msgstr "Primero elija un archivo en la lista"
 
-#: ../../vdms_main/main_frame.py:1666
+#: ../../vdms_main/main_frame.py:1682
 msgid ""
 "An item with the same destination file already exists.\n"
 "\n"
@@ -2307,29 +2306,29 @@ msgstr ""
 "\n"
 "¿Desea reemplazarlo añadiendo la entrada a la lista?"
 
-#: ../../vdms_main/main_frame.py:1687
+#: ../../vdms_main/main_frame.py:1703
 msgid "Videomass - FFmpeg Message Monitoring"
 msgstr "Videomass - Monitor de mensajes de FFmpeg"
 
-#: ../../vdms_main/main_frame.py:1814
+#: ../../vdms_main/main_frame.py:1828
 #, python-brace-format
 msgid "The system will turn off in {0} seconds"
 msgstr "El sistema se apagara en {0} segundos"
 
-#: ../../vdms_main/main_frame.py:1815
+#: ../../vdms_main/main_frame.py:1829
 msgid "Videomass - Shutdown!"
 msgstr "Videomass - ¡Apagando!"
 
-#: ../../vdms_main/main_frame.py:1822
+#: ../../vdms_main/main_frame.py:1836
 msgid "Error while shutting down. Please see file log for details."
 msgstr "Error al apagar. Vea el archivo de registro para detalles."
 
-#: ../../vdms_main/main_frame.py:1834
+#: ../../vdms_main/main_frame.py:1848
 #, python-brace-format
 msgid "Exiting the application in {0} seconds"
 msgstr "La aplicación se cerrara en {0} segundos"
 
-#: ../../vdms_main/main_frame.py:1835
+#: ../../vdms_main/main_frame.py:1849
 msgid "Videomass - Exiting!"
 msgstr "Videomass - ¡Saliendo!"
 
@@ -2770,7 +2769,7 @@ msgstr "Tipo de Medio"
 msgid "Size"
 msgstr "Tamaño"
 
-#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:383
+#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:405
 msgid "Drag one or more files below"
 msgstr "Arrastre uno o más archivos abajo"
 
@@ -2786,46 +2785,46 @@ msgstr "Carpeta destino para codificaciones"
 msgid "Encodings destination folder"
 msgstr "Carpeta destino para codificaciones"
 
-#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:372
+#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:394
 msgid "Play file"
 msgstr "Reproducir archivo"
 
-#: ../../vdms_panels/filedrop.py:386
+#: ../../vdms_panels/filedrop.py:408
 msgid "Drag two or more Audio/Video files below"
 msgstr "Arrastre dos o más archivos Audio/Video abajo"
 
-#: ../../vdms_panels/filedrop.py:390
+#: ../../vdms_panels/filedrop.py:412
 #, fuzzy
 msgid "Drag one or more Image files below"
 msgstr "Arrastre uno o más archivos abajo"
 
-#: ../../vdms_panels/filedrop.py:393
+#: ../../vdms_panels/filedrop.py:415
 msgid "Drag one or more Video files below"
 msgstr "Arrastre uno o más archivos Video abajo"
 
-#: ../../vdms_panels/filedrop.py:595
+#: ../../vdms_panels/filedrop.py:623
 msgid "Rename the file destination"
 msgstr "Renombra archivo destino"
 
-#: ../../vdms_panels/filedrop.py:596
+#: ../../vdms_panels/filedrop.py:624
 msgid "Rename the selected file to:"
 msgstr "Renombrar archivo seleccionado a:"
 
-#: ../../vdms_panels/filedrop.py:610 ../../vdms_panels/filedrop.py:620
-#: ../../vdms_panels/filedrop.py:651
+#: ../../vdms_panels/filedrop.py:638 ../../vdms_panels/filedrop.py:648
+#: ../../vdms_panels/filedrop.py:679
 msgid "Add Files"
 msgstr "Añadir Archivos"
 
-#: ../../vdms_panels/filedrop.py:627
+#: ../../vdms_panels/filedrop.py:655
 msgid "Rename in batch"
 msgstr "Renombrar por lote"
 
-#: ../../vdms_panels/filedrop.py:628
+#: ../../vdms_panels/filedrop.py:656
 #, python-brace-format
 msgid "Rename the {0} items to:"
 msgstr "Renombrar {0} objetos a:"
 
-#: ../../vdms_panels/filedrop.py:630
+#: ../../vdms_panels/filedrop.py:658
 msgid "New Name #"
 msgstr "Nombre Nuevo #"
 
@@ -3542,6 +3541,10 @@ msgid ""
 msgstr ""
 "Normalización de intensidad Alta calidad en dos pasos. Se Normaliza la intensidad percibida utilizando el filtro \"​loudnorm\", el cual\n"
 "implementa el algoritmo EBU R128. Ideal para postprocesado."
+
+#: ../../vdms_panels/audio_encoders/acodecs.py:789
+msgid "You need to import at least one file"
+msgstr ""
 
 #: ../../vdms_panels/miscellaneous/miscell.py:63
 msgid "Subtitle Mapping:"

--- a/videomass/data/locale/es_MX/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/es_MX/LC_MESSAGES/videomass.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Videomass 5.0.18\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-22 23:33+0200\n"
+"POT-Creation-Date: 2025-07-26 15:04+0200\n"
 "PO-Revision-Date: 2024-08-26 17:29-0600\n"
 "Last-Translator: José Alberto Valle Cid j.alberto.vc@gmail.com\n"
 "Language: es_MX\n"
@@ -983,7 +983,7 @@ msgid "Change"
 msgstr "Cambiar"
 
 #: ../../vdms_dialogs/preferences.py:103
-#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:574
+#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:602
 #: ../../vdms_panels/presets_manager.py:1050
 msgid "Same destination paths as source files"
 msgstr "Misma carpeta destino que archivos fuente"
@@ -1429,33 +1429,33 @@ msgstr "¡Perfil guardado exitosamente!"
 msgid "Profile change successful!"
 msgstr "¡Cambio de Perfil exitosol!"
 
-#: ../../vdms_dialogs/showlogs.py:81
+#: ../../vdms_dialogs/showlogs.py:80
 msgid "Log file list"
 msgstr "Lista de archivos de registro"
 
-#: ../../vdms_dialogs/showlogs.py:83 ../../vdms_dialogs/showlogs.py:117
+#: ../../vdms_dialogs/showlogs.py:82 ../../vdms_dialogs/showlogs.py:116
 msgid "Log messages"
 msgstr "Registro de mensajes"
 
-#: ../../vdms_dialogs/showlogs.py:106
+#: ../../vdms_dialogs/showlogs.py:105
 msgid "Refresh log messages"
 msgstr "Refrescar mensajes de registro"
 
-#: ../../vdms_dialogs/showlogs.py:108
+#: ../../vdms_dialogs/showlogs.py:107
 msgid "Clear log messages"
 msgstr "Limpiar mensajes de registro"
 
-#: ../../vdms_dialogs/showlogs.py:161
+#: ../../vdms_dialogs/showlogs.py:160
 msgid "Select a log file"
 msgstr "Seleccionar archivo de registro"
 
-#: ../../vdms_dialogs/showlogs.py:168
+#: ../../vdms_dialogs/showlogs.py:167
 msgid "Are you sure you want to clear the selected log file?"
 msgstr "¿Seguro desea limpiar el archivo de registro?"
 
-#: ../../vdms_dialogs/showlogs.py:169 ../../vdms_dialogs/wizard_dlg.py:251
+#: ../../vdms_dialogs/showlogs.py:168 ../../vdms_dialogs/wizard_dlg.py:251
 #: ../../vdms_io/checkup.py:68 ../../vdms_main/main_frame.py:205
-#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1669
+#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1685
 #: ../../vdms_panels/presets_manager.py:349
 #: ../../vdms_panels/presets_manager.py:550
 #: ../../vdms_panels/presets_manager.py:590
@@ -1776,8 +1776,8 @@ msgstr ""
 msgid "Videomass - Downloading..."
 msgstr "Videomass - Descargando..."
 
-#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1407
-#: ../../vdms_main/main_frame.py:1435
+#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1409
+#: ../../vdms_main/main_frame.py:1441
 msgid "Ready"
 msgstr "Listo"
 
@@ -1857,7 +1857,7 @@ msgid "File"
 msgstr "Archivo"
 
 #: ../../vdms_main/main_frame.py:486 ../../vdms_panels/filedrop.py:340
-#: ../../vdms_panels/filedrop.py:359
+#: ../../vdms_panels/filedrop.py:381
 msgid "Rename selected file\tCtrl+R"
 msgstr "Renombrar archivo seleccionado\tCtrl+R"
 
@@ -1866,7 +1866,7 @@ msgid "Rename the destination of the selected file"
 msgstr "Renombra destino de archivo seleccionado"
 
 #: ../../vdms_main/main_frame.py:490 ../../vdms_panels/filedrop.py:341
-#: ../../vdms_panels/filedrop.py:362
+#: ../../vdms_panels/filedrop.py:384
 #, fuzzy
 msgid "Batch rename files\tCtrl+B"
 msgstr "Renombrado en lote\tCtrl+B"
@@ -1876,7 +1876,7 @@ msgid "Numerically renames the destination of all items in the list"
 msgstr "Ennumerar el destino de todas las entradas de la lista"
 
 #: ../../vdms_main/main_frame.py:496 ../../vdms_panels/filedrop.py:343
-#: ../../vdms_panels/filedrop.py:366
+#: ../../vdms_panels/filedrop.py:388
 msgid "Remove selected entry\tDEL"
 msgstr "Quitar entrada seleccionada\tDEL"
 
@@ -1885,7 +1885,7 @@ msgid "Remove the selected file from the list"
 msgstr "Eliminar archivo seleccionado de la lista"
 
 #: ../../vdms_main/main_frame.py:500 ../../vdms_panels/filedrop.py:344
-#: ../../vdms_panels/filedrop.py:369
+#: ../../vdms_panels/filedrop.py:391
 msgid "Clear list\tShift+DEL"
 msgstr "Vaciar lista\tShift+DEL"
 
@@ -2260,44 +2260,43 @@ msgstr "Añadir a la Lista"
 msgid "Show queue"
 msgstr "Mostrar lista"
 
-#: ../../vdms_main/main_frame.py:1406 ../../vdms_panels/presets_manager.py:569
+#: ../../vdms_main/main_frame.py:1408 ../../vdms_panels/presets_manager.py:569
 msgid "Videomass"
 msgstr "Videomass"
 
-#: ../../vdms_main/main_frame.py:1436
+#: ../../vdms_main/main_frame.py:1442
 msgid "Videomass - File List"
 msgstr "Videomass - Lista de Archivos"
 
-#: ../../vdms_main/main_frame.py:1453
+#: ../../vdms_main/main_frame.py:1459
 msgid "Videomass - AV Conversions"
 msgstr "Videomass - Conversiones AV"
 
-#: ../../vdms_main/main_frame.py:1480
+#: ../../vdms_main/main_frame.py:1488
 msgid "Videomass - Presets Manager"
 msgstr "Videomass - Administrador de Presets"
 
-#: ../../vdms_main/main_frame.py:1508
+#: ../../vdms_main/main_frame.py:1518
 msgid "Videomass - Concatenate Demuxer"
 msgstr "Videomass - Encadenar Dezmezcladores"
 
-#: ../../vdms_main/main_frame.py:1535
+#: ../../vdms_main/main_frame.py:1547
 msgid "Videomass - From Movie to Pictures"
 msgstr "Videomass -De Película a Imágenes"
 
-#: ../../vdms_main/main_frame.py:1562
+#: ../../vdms_main/main_frame.py:1576
 msgid "Videomass - Still Image Maker"
 msgstr "Videomass -Productor de Imágenes Fijas"
 
-#: ../../vdms_main/main_frame.py:1644
-#: ../../vdms_panels/audio_encoders/acodecs.py:789
-#: ../../vdms_panels/av_conversions.py:577 ../../vdms_panels/filedrop.py:475
-#: ../../vdms_panels/filedrop.py:588 ../../vdms_panels/sequence_to_video.py:322
+#: ../../vdms_main/main_frame.py:1660 ../../vdms_panels/av_conversions.py:577
+#: ../../vdms_panels/filedrop.py:500 ../../vdms_panels/filedrop.py:616
+#: ../../vdms_panels/sequence_to_video.py:322
 #: ../../vdms_panels/video_to_sequence.py:369
 #: ../../vdms_panels/video_to_sequence.py:501
 msgid "Have to select an item in the file list first"
 msgstr "Primero elija un archivo en la lista"
 
-#: ../../vdms_main/main_frame.py:1666
+#: ../../vdms_main/main_frame.py:1682
 msgid ""
 "An item with the same destination file already exists.\n"
 "\n"
@@ -2307,29 +2306,29 @@ msgstr ""
 "\n"
 "¿Desea reemplazarlo añadiendo la entrada a la lista?"
 
-#: ../../vdms_main/main_frame.py:1687
+#: ../../vdms_main/main_frame.py:1703
 msgid "Videomass - FFmpeg Message Monitoring"
 msgstr "Videomass - Monitor de mensajes de FFmpeg"
 
-#: ../../vdms_main/main_frame.py:1814
+#: ../../vdms_main/main_frame.py:1828
 #, python-brace-format
 msgid "The system will turn off in {0} seconds"
 msgstr "El sistema se apagara en {0} segundos"
 
-#: ../../vdms_main/main_frame.py:1815
+#: ../../vdms_main/main_frame.py:1829
 msgid "Videomass - Shutdown!"
 msgstr "Videomass - ¡Apagando!"
 
-#: ../../vdms_main/main_frame.py:1822
+#: ../../vdms_main/main_frame.py:1836
 msgid "Error while shutting down. Please see file log for details."
 msgstr "Error al apagar. Vea el archivo de registro para detalles."
 
-#: ../../vdms_main/main_frame.py:1834
+#: ../../vdms_main/main_frame.py:1848
 #, python-brace-format
 msgid "Exiting the application in {0} seconds"
 msgstr "La aplicación se cerrara en {0} segundos"
 
-#: ../../vdms_main/main_frame.py:1835
+#: ../../vdms_main/main_frame.py:1849
 msgid "Videomass - Exiting!"
 msgstr "Videomass - ¡Saliendo!"
 
@@ -2770,7 +2769,7 @@ msgstr "Tipo de Medio"
 msgid "Size"
 msgstr "Tamaño"
 
-#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:383
+#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:405
 msgid "Drag one or more files below"
 msgstr "Arrastre uno o más archivos abajo"
 
@@ -2786,46 +2785,46 @@ msgstr "Carpeta destino para codificaciones"
 msgid "Encodings destination folder"
 msgstr "Carpeta destino para codificaciones"
 
-#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:372
+#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:394
 msgid "Play file"
 msgstr "Reproducir archivo"
 
-#: ../../vdms_panels/filedrop.py:386
+#: ../../vdms_panels/filedrop.py:408
 msgid "Drag two or more Audio/Video files below"
 msgstr "Arrastre dos o más archivos Audio/Video abajo"
 
-#: ../../vdms_panels/filedrop.py:390
+#: ../../vdms_panels/filedrop.py:412
 #, fuzzy
 msgid "Drag one or more Image files below"
 msgstr "Arrastre uno o más archivos abajo"
 
-#: ../../vdms_panels/filedrop.py:393
+#: ../../vdms_panels/filedrop.py:415
 msgid "Drag one or more Video files below"
 msgstr "Arrastre uno o más archivos Video abajo"
 
-#: ../../vdms_panels/filedrop.py:595
+#: ../../vdms_panels/filedrop.py:623
 msgid "Rename the file destination"
 msgstr "Renombra archivo destino"
 
-#: ../../vdms_panels/filedrop.py:596
+#: ../../vdms_panels/filedrop.py:624
 msgid "Rename the selected file to:"
 msgstr "Renombrar archivo seleccionado a:"
 
-#: ../../vdms_panels/filedrop.py:610 ../../vdms_panels/filedrop.py:620
-#: ../../vdms_panels/filedrop.py:651
+#: ../../vdms_panels/filedrop.py:638 ../../vdms_panels/filedrop.py:648
+#: ../../vdms_panels/filedrop.py:679
 msgid "Add Files"
 msgstr "Añadir Archivos"
 
-#: ../../vdms_panels/filedrop.py:627
+#: ../../vdms_panels/filedrop.py:655
 msgid "Rename in batch"
 msgstr "Renombrar por lote"
 
-#: ../../vdms_panels/filedrop.py:628
+#: ../../vdms_panels/filedrop.py:656
 #, python-brace-format
 msgid "Rename the {0} items to:"
 msgstr "Renombrar {0} objetos a:"
 
-#: ../../vdms_panels/filedrop.py:630
+#: ../../vdms_panels/filedrop.py:658
 msgid "New Name #"
 msgstr "Nombre Nuevo #"
 
@@ -3542,6 +3541,10 @@ msgid ""
 msgstr ""
 "Normalización de intensidad Alta calidad en dos pasos. Se Normaliza la intensidad percibida utilizando el filtro \"​loudnorm\", el cual\n"
 "implementa el algoritmo EBU R128. Ideal para postprocesado."
+
+#: ../../vdms_panels/audio_encoders/acodecs.py:789
+msgid "You need to import at least one file"
+msgstr ""
 
 #: ../../vdms_panels/miscellaneous/miscell.py:63
 msgid "Subtitle Mapping:"

--- a/videomass/data/locale/fr_FR/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/fr_FR/LC_MESSAGES/videomass.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Videomass 5.0.14\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-22 23:33+0200\n"
+"POT-Creation-Date: 2025-07-26 15:04+0200\n"
 "PO-Revision-Date: 2024-08-18 00:59+0200\n"
 "Last-Translator: Phil Aug <philiaug@live.fr>\n"
 "Language: fr_FR\n"
@@ -983,7 +983,7 @@ msgid "Change"
 msgstr "Changer"
 
 #: ../../vdms_dialogs/preferences.py:103
-#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:574
+#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:602
 #: ../../vdms_panels/presets_manager.py:1050
 msgid "Same destination paths as source files"
 msgstr "Même destination que les fichiers source"
@@ -1432,33 +1432,33 @@ msgstr "Profil complété avec succès !"
 msgid "Profile change successful!"
 msgstr "Changement de profil réussi!"
 
-#: ../../vdms_dialogs/showlogs.py:81
+#: ../../vdms_dialogs/showlogs.py:80
 msgid "Log file list"
 msgstr "Liste de fichier log"
 
-#: ../../vdms_dialogs/showlogs.py:83 ../../vdms_dialogs/showlogs.py:117
+#: ../../vdms_dialogs/showlogs.py:82 ../../vdms_dialogs/showlogs.py:116
 msgid "Log messages"
 msgstr "Messages Log"
 
-#: ../../vdms_dialogs/showlogs.py:106
+#: ../../vdms_dialogs/showlogs.py:105
 msgid "Refresh log messages"
 msgstr "Rafraîchir les messages de log"
 
-#: ../../vdms_dialogs/showlogs.py:108
+#: ../../vdms_dialogs/showlogs.py:107
 msgid "Clear log messages"
 msgstr "Effacer les messages de log"
 
-#: ../../vdms_dialogs/showlogs.py:161
+#: ../../vdms_dialogs/showlogs.py:160
 msgid "Select a log file"
 msgstr "Choisir un fichier log"
 
-#: ../../vdms_dialogs/showlogs.py:168
+#: ../../vdms_dialogs/showlogs.py:167
 msgid "Are you sure you want to clear the selected log file?"
 msgstr "Etes vous sûr de vouloir supprimer le fichier log ?"
 
-#: ../../vdms_dialogs/showlogs.py:169 ../../vdms_dialogs/wizard_dlg.py:251
+#: ../../vdms_dialogs/showlogs.py:168 ../../vdms_dialogs/wizard_dlg.py:251
 #: ../../vdms_io/checkup.py:68 ../../vdms_main/main_frame.py:205
-#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1669
+#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1685
 #: ../../vdms_panels/presets_manager.py:349
 #: ../../vdms_panels/presets_manager.py:550
 #: ../../vdms_panels/presets_manager.py:590
@@ -1779,8 +1779,8 @@ msgstr ""
 msgid "Videomass - Downloading..."
 msgstr "Videomass - Téléchargement en cours..."
 
-#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1407
-#: ../../vdms_main/main_frame.py:1435
+#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1409
+#: ../../vdms_main/main_frame.py:1441
 msgid "Ready"
 msgstr "Prêt"
 
@@ -1860,7 +1860,7 @@ msgid "File"
 msgstr "Fichier"
 
 #: ../../vdms_main/main_frame.py:486 ../../vdms_panels/filedrop.py:340
-#: ../../vdms_panels/filedrop.py:359
+#: ../../vdms_panels/filedrop.py:381
 msgid "Rename selected file\tCtrl+R"
 msgstr "Renommer les fichiers sélectionnés\tCtrl+R"
 
@@ -1869,7 +1869,7 @@ msgid "Rename the destination of the selected file"
 msgstr "Renommez la destination du fichier sélectionné"
 
 #: ../../vdms_main/main_frame.py:490 ../../vdms_panels/filedrop.py:341
-#: ../../vdms_panels/filedrop.py:362
+#: ../../vdms_panels/filedrop.py:384
 msgid "Batch rename files\tCtrl+B"
 msgstr "Renommer en lot \tCtrl+B"
 
@@ -1878,7 +1878,7 @@ msgid "Numerically renames the destination of all items in the list"
 msgstr "Renomme numériquement la destination de tous les éléments de la liste"
 
 #: ../../vdms_main/main_frame.py:496 ../../vdms_panels/filedrop.py:343
-#: ../../vdms_panels/filedrop.py:366
+#: ../../vdms_panels/filedrop.py:388
 msgid "Remove selected entry\tDEL"
 msgstr "Supprimer l'entrée selectionnée\tDEL"
 
@@ -1887,7 +1887,7 @@ msgid "Remove the selected file from the list"
 msgstr "Supprimer le fichier sélectionné de la liste"
 
 #: ../../vdms_main/main_frame.py:500 ../../vdms_panels/filedrop.py:344
-#: ../../vdms_panels/filedrop.py:369
+#: ../../vdms_panels/filedrop.py:391
 msgid "Clear list\tShift+DEL"
 msgstr "Effacer la liste\tShift+DEL"
 
@@ -2282,44 +2282,43 @@ msgstr "Ajouter à la file d'attente"
 msgid "Show queue"
 msgstr "Afficher la file d'attente"
 
-#: ../../vdms_main/main_frame.py:1406 ../../vdms_panels/presets_manager.py:569
+#: ../../vdms_main/main_frame.py:1408 ../../vdms_panels/presets_manager.py:569
 msgid "Videomass"
 msgstr "Videomass"
 
-#: ../../vdms_main/main_frame.py:1436
+#: ../../vdms_main/main_frame.py:1442
 msgid "Videomass - File List"
 msgstr "Videomass - liste fichier"
 
-#: ../../vdms_main/main_frame.py:1453
+#: ../../vdms_main/main_frame.py:1459
 msgid "Videomass - AV Conversions"
 msgstr "Videomass - Conversion Audio/Vidéo"
 
-#: ../../vdms_main/main_frame.py:1480
+#: ../../vdms_main/main_frame.py:1488
 msgid "Videomass - Presets Manager"
 msgstr "Videomass - Gestion des Jeux de Profils"
 
-#: ../../vdms_main/main_frame.py:1508
+#: ../../vdms_main/main_frame.py:1518
 msgid "Videomass - Concatenate Demuxer"
 msgstr "Videomass - Assemblage Fichiers Multimedia"
 
-#: ../../vdms_main/main_frame.py:1535
+#: ../../vdms_main/main_frame.py:1547
 msgid "Videomass - From Movie to Pictures"
 msgstr "Videomass -  Image(s) à partir d'un film"
 
-#: ../../vdms_main/main_frame.py:1562
+#: ../../vdms_main/main_frame.py:1576
 msgid "Videomass - Still Image Maker"
 msgstr "Videomass - Extraire image(s) à partir d'un film"
 
-#: ../../vdms_main/main_frame.py:1644
-#: ../../vdms_panels/audio_encoders/acodecs.py:789
-#: ../../vdms_panels/av_conversions.py:577 ../../vdms_panels/filedrop.py:475
-#: ../../vdms_panels/filedrop.py:588 ../../vdms_panels/sequence_to_video.py:322
+#: ../../vdms_main/main_frame.py:1660 ../../vdms_panels/av_conversions.py:577
+#: ../../vdms_panels/filedrop.py:500 ../../vdms_panels/filedrop.py:616
+#: ../../vdms_panels/sequence_to_video.py:322
 #: ../../vdms_panels/video_to_sequence.py:369
 #: ../../vdms_panels/video_to_sequence.py:501
 msgid "Have to select an item in the file list first"
 msgstr "Sélectionnerz d'abord un élément dans la liste des fichiers"
 
-#: ../../vdms_main/main_frame.py:1666
+#: ../../vdms_main/main_frame.py:1682
 msgid ""
 "An item with the same destination file already exists.\n"
 "\n"
@@ -2329,30 +2328,30 @@ msgstr ""
 "\n"
 "Voulez-vous le remplacer en ajoutant le nouvel élément à la file d'attente?"
 
-#: ../../vdms_main/main_frame.py:1687
+#: ../../vdms_main/main_frame.py:1703
 msgid "Videomass - FFmpeg Message Monitoring"
 msgstr "Videomass - Messages de sortie FFMPEG"
 
-#: ../../vdms_main/main_frame.py:1814
+#: ../../vdms_main/main_frame.py:1828
 #, python-brace-format
 msgid "The system will turn off in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1815
+#: ../../vdms_main/main_frame.py:1829
 msgid "Videomass - Shutdown!"
 msgstr "Videomass - Arrêt !"
 
-#: ../../vdms_main/main_frame.py:1822
+#: ../../vdms_main/main_frame.py:1836
 msgid "Error while shutting down. Please see file log for details."
 msgstr "Erreur à la fermeture. Consulter le fichier log pour plus de détails."
 
 # | msgid "Exit the application"
-#: ../../vdms_main/main_frame.py:1834
+#: ../../vdms_main/main_frame.py:1848
 #, fuzzy, python-brace-format
 msgid "Exiting the application in {0} seconds"
 msgstr "Quitter l'application"
 
-#: ../../vdms_main/main_frame.py:1835
+#: ../../vdms_main/main_frame.py:1849
 msgid "Videomass - Exiting!"
 msgstr "Videomass -  en cours d'arrêt !"
 
@@ -2789,7 +2788,7 @@ msgstr "Type de média"
 msgid "Size"
 msgstr "Taille"
 
-#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:383
+#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:405
 msgid "Drag one or more files below"
 msgstr "Faites glisser un ou plusieurs fichiers ci-dessous"
 
@@ -2805,45 +2804,45 @@ msgstr "Définir un nouveau dossier pour l'encodage"
 msgid "Encodings destination folder"
 msgstr "Dossier de destination de l'encodage"
 
-#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:372
+#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:394
 msgid "Play file"
 msgstr "Jouer le fichier"
 
-#: ../../vdms_panels/filedrop.py:386
+#: ../../vdms_panels/filedrop.py:408
 msgid "Drag two or more Audio/Video files below"
 msgstr "Faites glisser deux ou plusieurs fichiersAudio/Vidéo ci-dessous"
 
-#: ../../vdms_panels/filedrop.py:390
+#: ../../vdms_panels/filedrop.py:412
 msgid "Drag one or more Image files below"
 msgstr "Faites glisser un ou plusieurs fichiers d'images ci-dessous"
 
-#: ../../vdms_panels/filedrop.py:393
+#: ../../vdms_panels/filedrop.py:415
 msgid "Drag one or more Video files below"
 msgstr "Faites glisser un ou plusieurs fichiers Vidéo ci-dessous"
 
-#: ../../vdms_panels/filedrop.py:595
+#: ../../vdms_panels/filedrop.py:623
 msgid "Rename the file destination"
 msgstr "Renommer le fichier de destination"
 
-#: ../../vdms_panels/filedrop.py:596
+#: ../../vdms_panels/filedrop.py:624
 msgid "Rename the selected file to:"
 msgstr "Renommer le fichier selectionné:"
 
-#: ../../vdms_panels/filedrop.py:610 ../../vdms_panels/filedrop.py:620
-#: ../../vdms_panels/filedrop.py:651
+#: ../../vdms_panels/filedrop.py:638 ../../vdms_panels/filedrop.py:648
+#: ../../vdms_panels/filedrop.py:679
 msgid "Add Files"
 msgstr "Ajouter des Fichiers"
 
-#: ../../vdms_panels/filedrop.py:627
+#: ../../vdms_panels/filedrop.py:655
 msgid "Rename in batch"
 msgstr "Renommer par lot"
 
-#: ../../vdms_panels/filedrop.py:628
+#: ../../vdms_panels/filedrop.py:656
 #, python-brace-format
 msgid "Rename the {0} items to:"
 msgstr "Renommer les {0} éléments en:"
 
-#: ../../vdms_panels/filedrop.py:630
+#: ../../vdms_panels/filedrop.py:658
 msgid "New Name #"
 msgstr "Nouveau Nom #"
 
@@ -3552,6 +3551,10 @@ msgid ""
 msgstr ""
 "Normalisation Loudnorm à deux passes de haute qualité. Normalise le volume perçu à l'aide du filtre \"loudnorm\", qui implémente\n"
 "l'algorithme EBU R128. Idéal pour le post-traitement."
+
+#: ../../vdms_panels/audio_encoders/acodecs.py:789
+msgid "You need to import at least one file"
+msgstr ""
 
 #: ../../vdms_panels/miscellaneous/miscell.py:63
 msgid "Subtitle Mapping:"

--- a/videomass/data/locale/hu_HU/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/hu_HU/LC_MESSAGES/videomass.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-22 23:33+0200\n"
+"POT-Creation-Date: 2025-07-26 15:04+0200\n"
 "PO-Revision-Date: 2024-07-17 16:31+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: hu_HU\n"
@@ -936,7 +936,7 @@ msgid "Change"
 msgstr ""
 
 #: ../../vdms_dialogs/preferences.py:103
-#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:574
+#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:602
 #: ../../vdms_panels/presets_manager.py:1050
 msgid "Same destination paths as source files"
 msgstr ""
@@ -1359,33 +1359,33 @@ msgstr ""
 msgid "Profile change successful!"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:81
+#: ../../vdms_dialogs/showlogs.py:80
 msgid "Log file list"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:83 ../../vdms_dialogs/showlogs.py:117
+#: ../../vdms_dialogs/showlogs.py:82 ../../vdms_dialogs/showlogs.py:116
 msgid "Log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:106
+#: ../../vdms_dialogs/showlogs.py:105
 msgid "Refresh log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:108
+#: ../../vdms_dialogs/showlogs.py:107
 msgid "Clear log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:161
+#: ../../vdms_dialogs/showlogs.py:160
 msgid "Select a log file"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:168
+#: ../../vdms_dialogs/showlogs.py:167
 msgid "Are you sure you want to clear the selected log file?"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:169 ../../vdms_dialogs/wizard_dlg.py:251
+#: ../../vdms_dialogs/showlogs.py:168 ../../vdms_dialogs/wizard_dlg.py:251
 #: ../../vdms_io/checkup.py:68 ../../vdms_main/main_frame.py:205
-#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1669
+#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1685
 #: ../../vdms_panels/presets_manager.py:349
 #: ../../vdms_panels/presets_manager.py:550
 #: ../../vdms_panels/presets_manager.py:590
@@ -1662,8 +1662,8 @@ msgstr ""
 msgid "Videomass - Downloading..."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1407
-#: ../../vdms_main/main_frame.py:1435
+#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1409
+#: ../../vdms_main/main_frame.py:1441
 msgid "Ready"
 msgstr ""
 
@@ -1740,7 +1740,7 @@ msgid "File"
 msgstr ""
 
 #: ../../vdms_main/main_frame.py:486 ../../vdms_panels/filedrop.py:340
-#: ../../vdms_panels/filedrop.py:359
+#: ../../vdms_panels/filedrop.py:381
 msgid "Rename selected file\tCtrl+R"
 msgstr ""
 
@@ -1749,7 +1749,7 @@ msgid "Rename the destination of the selected file"
 msgstr ""
 
 #: ../../vdms_main/main_frame.py:490 ../../vdms_panels/filedrop.py:341
-#: ../../vdms_panels/filedrop.py:362
+#: ../../vdms_panels/filedrop.py:384
 msgid "Batch rename files\tCtrl+B"
 msgstr ""
 
@@ -1758,7 +1758,7 @@ msgid "Numerically renames the destination of all items in the list"
 msgstr ""
 
 #: ../../vdms_main/main_frame.py:496 ../../vdms_panels/filedrop.py:343
-#: ../../vdms_panels/filedrop.py:366
+#: ../../vdms_panels/filedrop.py:388
 msgid "Remove selected entry\tDEL"
 msgstr ""
 
@@ -1767,7 +1767,7 @@ msgid "Remove the selected file from the list"
 msgstr ""
 
 #: ../../vdms_main/main_frame.py:500 ../../vdms_panels/filedrop.py:344
-#: ../../vdms_panels/filedrop.py:369
+#: ../../vdms_panels/filedrop.py:391
 msgid "Clear list\tShift+DEL"
 msgstr ""
 
@@ -2133,73 +2133,72 @@ msgstr ""
 msgid "Show queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1406 ../../vdms_panels/presets_manager.py:569
+#: ../../vdms_main/main_frame.py:1408 ../../vdms_panels/presets_manager.py:569
 msgid "Videomass"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1436
+#: ../../vdms_main/main_frame.py:1442
 msgid "Videomass - File List"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1453
+#: ../../vdms_main/main_frame.py:1459
 msgid "Videomass - AV Conversions"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1480
+#: ../../vdms_main/main_frame.py:1488
 msgid "Videomass - Presets Manager"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1508
+#: ../../vdms_main/main_frame.py:1518
 msgid "Videomass - Concatenate Demuxer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1535
+#: ../../vdms_main/main_frame.py:1547
 msgid "Videomass - From Movie to Pictures"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1562
+#: ../../vdms_main/main_frame.py:1576
 msgid "Videomass - Still Image Maker"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1644
-#: ../../vdms_panels/audio_encoders/acodecs.py:789
-#: ../../vdms_panels/av_conversions.py:577 ../../vdms_panels/filedrop.py:475
-#: ../../vdms_panels/filedrop.py:588 ../../vdms_panels/sequence_to_video.py:322
+#: ../../vdms_main/main_frame.py:1660 ../../vdms_panels/av_conversions.py:577
+#: ../../vdms_panels/filedrop.py:500 ../../vdms_panels/filedrop.py:616
+#: ../../vdms_panels/sequence_to_video.py:322
 #: ../../vdms_panels/video_to_sequence.py:369
 #: ../../vdms_panels/video_to_sequence.py:501
 msgid "Have to select an item in the file list first"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1666
+#: ../../vdms_main/main_frame.py:1682
 msgid ""
 "An item with the same destination file already exists.\n"
 "\n"
 "Do you want to replace it by adding the new item to the queue?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1687
+#: ../../vdms_main/main_frame.py:1703
 msgid "Videomass - FFmpeg Message Monitoring"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1814
+#: ../../vdms_main/main_frame.py:1828
 #, python-brace-format
 msgid "The system will turn off in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1815
+#: ../../vdms_main/main_frame.py:1829
 msgid "Videomass - Shutdown!"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1822
+#: ../../vdms_main/main_frame.py:1836
 msgid "Error while shutting down. Please see file log for details."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1834
+#: ../../vdms_main/main_frame.py:1848
 #, python-brace-format
 msgid "Exiting the application in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1835
+#: ../../vdms_main/main_frame.py:1849
 msgid "Videomass - Exiting!"
 msgstr ""
 
@@ -2589,7 +2588,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:383
+#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:405
 msgid "Drag one or more files below"
 msgstr ""
 
@@ -2605,45 +2604,45 @@ msgstr ""
 msgid "Encodings destination folder"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:372
+#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:394
 msgid "Play file"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:386
+#: ../../vdms_panels/filedrop.py:408
 msgid "Drag two or more Audio/Video files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:390
+#: ../../vdms_panels/filedrop.py:412
 msgid "Drag one or more Image files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:393
+#: ../../vdms_panels/filedrop.py:415
 msgid "Drag one or more Video files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:595
+#: ../../vdms_panels/filedrop.py:623
 msgid "Rename the file destination"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:596
+#: ../../vdms_panels/filedrop.py:624
 msgid "Rename the selected file to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:610 ../../vdms_panels/filedrop.py:620
-#: ../../vdms_panels/filedrop.py:651
+#: ../../vdms_panels/filedrop.py:638 ../../vdms_panels/filedrop.py:648
+#: ../../vdms_panels/filedrop.py:679
 msgid "Add Files"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:627
+#: ../../vdms_panels/filedrop.py:655
 msgid "Rename in batch"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:628
+#: ../../vdms_panels/filedrop.py:656
 #, python-brace-format
 msgid "Rename the {0} items to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:630
+#: ../../vdms_panels/filedrop.py:658
 msgid "New Name #"
 msgstr ""
 
@@ -3240,6 +3239,10 @@ msgstr ""
 msgid ""
 "High-quality two-pass Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements\n"
 "the EBU R128 algorithm. Ideal for postprocessing."
+msgstr ""
+
+#: ../../vdms_panels/audio_encoders/acodecs.py:789
+msgid "You need to import at least one file"
 msgstr ""
 
 #: ../../vdms_panels/miscellaneous/miscell.py:63

--- a/videomass/data/locale/it_IT/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/it_IT/LC_MESSAGES/videomass.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Videomass - IT - 12.07.2025\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-22 23:33+0200\n"
-"PO-Revision-Date: 2025-07-22 23:39+0200\n"
+"POT-Creation-Date: 2025-07-26 15:04+0200\n"
+"PO-Revision-Date: 2025-07-26 15:07+0200\n"
 "Last-Translator: bovirus <bovirus@gmail.comn>\n"
 "Language-Team: bovirus (bovirus@gmail.com)\n"
 "Language: it_IT\n"
@@ -987,7 +987,7 @@ msgid "Change"
 msgstr "Modifica"
 
 #: ../../vdms_dialogs/preferences.py:103
-#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:574
+#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:602
 #: ../../vdms_panels/presets_manager.py:1050
 msgid "Same destination paths as source files"
 msgstr "Stessi percorsi per file destinazione e sorgente"
@@ -1435,33 +1435,33 @@ msgstr "Memorizzazione profilo completata!"
 msgid "Profile change successful!"
 msgstr "Modifica profilo completata!"
 
-#: ../../vdms_dialogs/showlogs.py:81
+#: ../../vdms_dialogs/showlogs.py:80
 msgid "Log file list"
 msgstr "Elenco file registro"
 
-#: ../../vdms_dialogs/showlogs.py:83 ../../vdms_dialogs/showlogs.py:117
+#: ../../vdms_dialogs/showlogs.py:82 ../../vdms_dialogs/showlogs.py:116
 msgid "Log messages"
 msgstr "Messaggi di registro"
 
-#: ../../vdms_dialogs/showlogs.py:106
+#: ../../vdms_dialogs/showlogs.py:105
 msgid "Refresh log messages"
 msgstr "Aggiorna i messaggi di registro"
 
-#: ../../vdms_dialogs/showlogs.py:108
+#: ../../vdms_dialogs/showlogs.py:107
 msgid "Clear log messages"
 msgstr "Cancella messaggi di registro"
 
-#: ../../vdms_dialogs/showlogs.py:161
+#: ../../vdms_dialogs/showlogs.py:160
 msgid "Select a log file"
 msgstr "Seleziona un file registro"
 
-#: ../../vdms_dialogs/showlogs.py:168
+#: ../../vdms_dialogs/showlogs.py:167
 msgid "Are you sure you want to clear the selected log file?"
 msgstr "Sei sicuro di voler eliminare il file registro selezionato?"
 
-#: ../../vdms_dialogs/showlogs.py:169 ../../vdms_dialogs/wizard_dlg.py:251
+#: ../../vdms_dialogs/showlogs.py:168 ../../vdms_dialogs/wizard_dlg.py:251
 #: ../../vdms_io/checkup.py:68 ../../vdms_main/main_frame.py:205
-#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1669
+#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1685
 #: ../../vdms_panels/presets_manager.py:349
 #: ../../vdms_panels/presets_manager.py:550
 #: ../../vdms_panels/presets_manager.py:590
@@ -1786,8 +1786,8 @@ msgstr ""
 msgid "Videomass - Downloading..."
 msgstr "Download in corso..."
 
-#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1407
-#: ../../vdms_main/main_frame.py:1435
+#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1409
+#: ../../vdms_main/main_frame.py:1441
 msgid "Ready"
 msgstr "Pronto"
 
@@ -1867,7 +1867,7 @@ msgid "File"
 msgstr "File"
 
 #: ../../vdms_main/main_frame.py:486 ../../vdms_panels/filedrop.py:340
-#: ../../vdms_panels/filedrop.py:359
+#: ../../vdms_panels/filedrop.py:381
 msgid "Rename selected file\tCtrl+R"
 msgstr "Rinomina il file selezionato\tCtrl+R"
 
@@ -1876,7 +1876,7 @@ msgid "Rename the destination of the selected file"
 msgstr "Rinomina la destinazione del file selezionato"
 
 #: ../../vdms_main/main_frame.py:490 ../../vdms_panels/filedrop.py:341
-#: ../../vdms_panels/filedrop.py:362
+#: ../../vdms_panels/filedrop.py:384
 msgid "Batch rename files\tCtrl+B"
 msgstr "Rinomina i file in batch\tCtrl+B"
 
@@ -1887,7 +1887,7 @@ msgstr "Rinomina numericamente la destinazione di tutti gli elementi nell'elenco
 # Warning: DEL refers to the "Del" or "Canc" button on the keyboard. This may
 # depends on your country. This button is an accelerator used as a shortcut.
 #: ../../vdms_main/main_frame.py:496 ../../vdms_panels/filedrop.py:343
-#: ../../vdms_panels/filedrop.py:366
+#: ../../vdms_panels/filedrop.py:388
 msgid "Remove selected entry\tDEL"
 msgstr "Rimuovi voce selezionata\tDEL"
 
@@ -1896,7 +1896,7 @@ msgid "Remove the selected file from the list"
 msgstr "Rimuovi dall'elenco il file selezionato"
 
 #: ../../vdms_main/main_frame.py:500 ../../vdms_panels/filedrop.py:344
-#: ../../vdms_panels/filedrop.py:369
+#: ../../vdms_panels/filedrop.py:391
 msgid "Clear list\tShift+DEL"
 msgstr "Azzera elenco\tShift+DEL"
 
@@ -2275,44 +2275,43 @@ msgstr "Aggiungi a coda"
 msgid "Show queue"
 msgstr "Visualizza coda"
 
-#: ../../vdms_main/main_frame.py:1406 ../../vdms_panels/presets_manager.py:569
+#: ../../vdms_main/main_frame.py:1408 ../../vdms_panels/presets_manager.py:569
 msgid "Videomass"
 msgstr "Videomass"
 
-#: ../../vdms_main/main_frame.py:1436
+#: ../../vdms_main/main_frame.py:1442
 msgid "Videomass - File List"
 msgstr "Videomass - Lista dei File"
 
-#: ../../vdms_main/main_frame.py:1453
+#: ../../vdms_main/main_frame.py:1459
 msgid "Videomass - AV Conversions"
 msgstr "Videomass - Conversioni AV"
 
-#: ../../vdms_main/main_frame.py:1480
+#: ../../vdms_main/main_frame.py:1488
 msgid "Videomass - Presets Manager"
 msgstr "Videomass - Gestione profili"
 
-#: ../../vdms_main/main_frame.py:1508
+#: ../../vdms_main/main_frame.py:1518
 msgid "Videomass - Concatenate Demuxer"
 msgstr "Videomass - Unione con demuxer"
 
-#: ../../vdms_main/main_frame.py:1535
+#: ../../vdms_main/main_frame.py:1547
 msgid "Videomass - From Movie to Pictures"
 msgstr "Videomass - Converti filmato in immagini"
 
-#: ../../vdms_main/main_frame.py:1562
+#: ../../vdms_main/main_frame.py:1576
 msgid "Videomass - Still Image Maker"
 msgstr "Videomass - Crea presentazioni"
 
-#: ../../vdms_main/main_frame.py:1644
-#: ../../vdms_panels/audio_encoders/acodecs.py:789
-#: ../../vdms_panels/av_conversions.py:577 ../../vdms_panels/filedrop.py:475
-#: ../../vdms_panels/filedrop.py:588 ../../vdms_panels/sequence_to_video.py:322
+#: ../../vdms_main/main_frame.py:1660 ../../vdms_panels/av_conversions.py:577
+#: ../../vdms_panels/filedrop.py:500 ../../vdms_panels/filedrop.py:616
+#: ../../vdms_panels/sequence_to_video.py:322
 #: ../../vdms_panels/video_to_sequence.py:369
 #: ../../vdms_panels/video_to_sequence.py:501
 msgid "Have to select an item in the file list first"
 msgstr "Prima dovresti selezionare un elemento nella lista dei file"
 
-#: ../../vdms_main/main_frame.py:1666
+#: ../../vdms_main/main_frame.py:1682
 msgid ""
 "An item with the same destination file already exists.\n"
 "\n"
@@ -2322,31 +2321,31 @@ msgstr ""
 "\n"
 "Vuoi sostituirlo aggiungendo il nuovo elemento alla coda?"
 
-#: ../../vdms_main/main_frame.py:1687
+#: ../../vdms_main/main_frame.py:1703
 msgid "Videomass - FFmpeg Message Monitoring"
 msgstr "Videomass - Monitoraggio dei messaggi FFmpeg"
 
-#: ../../vdms_main/main_frame.py:1814
+#: ../../vdms_main/main_frame.py:1828
 #, python-brace-format
 msgid "The system will turn off in {0} seconds"
 msgstr "Il sistema si spegnerà tra {0} secondi"
 
-#: ../../vdms_main/main_frame.py:1815
+#: ../../vdms_main/main_frame.py:1829
 msgid "Videomass - Shutdown!"
 msgstr "Videomass - Spegnimento!"
 
-#: ../../vdms_main/main_frame.py:1822
+#: ../../vdms_main/main_frame.py:1836
 msgid "Error while shutting down. Please see file log for details."
 msgstr ""
 "Errore durante lo spegnimento. \n"
 "Per i dettagli consultare il file registro."
 
-#: ../../vdms_main/main_frame.py:1834
+#: ../../vdms_main/main_frame.py:1848
 #, python-brace-format
 msgid "Exiting the application in {0} seconds"
 msgstr "Chiusura dell'applicazione tra {0} secondi"
 
-#: ../../vdms_main/main_frame.py:1835
+#: ../../vdms_main/main_frame.py:1849
 msgid "Videomass - Exiting!"
 msgstr "Videomass - Uscita dall'applicazione!"
 
@@ -2792,7 +2791,7 @@ msgstr "Tipo di media"
 msgid "Size"
 msgstr "Dimensione"
 
-#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:383
+#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:405
 msgid "Drag one or more files below"
 msgstr "Trascina uno o più file qui sotto"
 
@@ -2808,45 +2807,45 @@ msgstr "Imposta nuova cartella di destinazione codifiche"
 msgid "Encodings destination folder"
 msgstr "Cartella di destinazione delle codifiche"
 
-#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:372
+#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:394
 msgid "Play file"
 msgstr "Riproduci file"
 
-#: ../../vdms_panels/filedrop.py:386
+#: ../../vdms_panels/filedrop.py:408
 msgid "Drag two or more Audio/Video files below"
 msgstr "Trascina due o più file audio/video qui sotto"
 
-#: ../../vdms_panels/filedrop.py:390
+#: ../../vdms_panels/filedrop.py:412
 msgid "Drag one or more Image files below"
 msgstr "Trascina uno o più file immagine qui sotto"
 
-#: ../../vdms_panels/filedrop.py:393
+#: ../../vdms_panels/filedrop.py:415
 msgid "Drag one or more Video files below"
 msgstr "Trascina uno o più file video qui sotto"
 
-#: ../../vdms_panels/filedrop.py:595
+#: ../../vdms_panels/filedrop.py:623
 msgid "Rename the file destination"
 msgstr "Rinomina destinazione del file"
 
-#: ../../vdms_panels/filedrop.py:596
+#: ../../vdms_panels/filedrop.py:624
 msgid "Rename the selected file to:"
 msgstr "Rinomina il file selezionato in:"
 
-#: ../../vdms_panels/filedrop.py:610 ../../vdms_panels/filedrop.py:620
-#: ../../vdms_panels/filedrop.py:651
+#: ../../vdms_panels/filedrop.py:638 ../../vdms_panels/filedrop.py:648
+#: ../../vdms_panels/filedrop.py:679
 msgid "Add Files"
 msgstr "Aggiungi file"
 
-#: ../../vdms_panels/filedrop.py:627
+#: ../../vdms_panels/filedrop.py:655
 msgid "Rename in batch"
 msgstr "Rinomina in batch"
 
-#: ../../vdms_panels/filedrop.py:628
+#: ../../vdms_panels/filedrop.py:656
 #, python-brace-format
 msgid "Rename the {0} items to:"
 msgstr "Rinominare i {0} elementi in:"
 
-#: ../../vdms_panels/filedrop.py:630
+#: ../../vdms_panels/filedrop.py:658
 msgid "New Name #"
 msgstr "Nuovo Nome #"
 
@@ -3560,6 +3559,10 @@ msgid ""
 msgstr ""
 "Normalizzazione Loudnorm a due passaggi di alta qualità. Normalizza il volume percepito usando il filtro \"loudnorm\", il quale\n"
 "implementa l'algoritmo EBU R128. Ideale per la post-elaborazione."
+
+#: ../../vdms_panels/audio_encoders/acodecs.py:789
+msgid "You need to import at least one file"
+msgstr "Importa almeno un file"
 
 #: ../../vdms_panels/miscellaneous/miscell.py:63
 msgid "Subtitle Mapping:"

--- a/videomass/data/locale/nl_NL/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/nl_NL/LC_MESSAGES/videomass.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Videomass 5.0.18\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-22 23:33+0200\n"
+"POT-Creation-Date: 2025-07-26 15:04+0200\n"
 "PO-Revision-Date: 2024-07-03 18:48+0200\n"
 "Last-Translator: johannesdedoper <https://github.com/johannesdedoper>\n"
 "Language: nl_NL\n"
@@ -1005,7 +1005,7 @@ msgid "Change"
 msgstr ""
 
 #: ../../vdms_dialogs/preferences.py:103
-#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:574
+#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:602
 #: ../../vdms_panels/presets_manager.py:1050
 #, fuzzy
 msgid "Same destination paths as source files"
@@ -1473,33 +1473,33 @@ msgstr "Wizard met succes afgerond!\n"
 msgid "Profile change successful!"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:81
+#: ../../vdms_dialogs/showlogs.py:80
 msgid "Log file list"
 msgstr "Log bestanden lijst"
 
-#: ../../vdms_dialogs/showlogs.py:83 ../../vdms_dialogs/showlogs.py:117
+#: ../../vdms_dialogs/showlogs.py:82 ../../vdms_dialogs/showlogs.py:116
 msgid "Log messages"
 msgstr "Log-berichten"
 
-#: ../../vdms_dialogs/showlogs.py:106
+#: ../../vdms_dialogs/showlogs.py:105
 msgid "Refresh log messages"
 msgstr "Ververs log-berichten"
 
-#: ../../vdms_dialogs/showlogs.py:108
+#: ../../vdms_dialogs/showlogs.py:107
 msgid "Clear log messages"
 msgstr "Wis log-berichten"
 
-#: ../../vdms_dialogs/showlogs.py:161
+#: ../../vdms_dialogs/showlogs.py:160
 msgid "Select a log file"
 msgstr "Selecteer een log bestand"
 
-#: ../../vdms_dialogs/showlogs.py:168
+#: ../../vdms_dialogs/showlogs.py:167
 msgid "Are you sure you want to clear the selected log file?"
 msgstr "Wilt u echt dit log-bestand legen ?"
 
-#: ../../vdms_dialogs/showlogs.py:169 ../../vdms_dialogs/wizard_dlg.py:251
+#: ../../vdms_dialogs/showlogs.py:168 ../../vdms_dialogs/wizard_dlg.py:251
 #: ../../vdms_io/checkup.py:68 ../../vdms_main/main_frame.py:205
-#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1669
+#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1685
 #: ../../vdms_panels/presets_manager.py:349
 #: ../../vdms_panels/presets_manager.py:550
 #: ../../vdms_panels/presets_manager.py:590
@@ -1831,8 +1831,8 @@ msgstr ""
 msgid "Videomass - Downloading..."
 msgstr "Videomass - Bezig met downloaden..."
 
-#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1407
-#: ../../vdms_main/main_frame.py:1435
+#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1409
+#: ../../vdms_main/main_frame.py:1441
 msgid "Ready"
 msgstr "Gereed"
 
@@ -1917,7 +1917,7 @@ msgid "File"
 msgstr "Bestand"
 
 #: ../../vdms_main/main_frame.py:486 ../../vdms_panels/filedrop.py:340
-#: ../../vdms_panels/filedrop.py:359
+#: ../../vdms_panels/filedrop.py:381
 #, fuzzy
 msgid "Rename selected file\tCtrl+R"
 msgstr "Verwijder het geselecteerde profiel"
@@ -1928,7 +1928,7 @@ msgid "Rename the destination of the selected file"
 msgstr "Een doel-bestand moet geselecteerd zijn in de wachtrij-bestanden"
 
 #: ../../vdms_main/main_frame.py:490 ../../vdms_panels/filedrop.py:341
-#: ../../vdms_panels/filedrop.py:362
+#: ../../vdms_panels/filedrop.py:384
 #, fuzzy
 msgid "Batch rename files\tCtrl+B"
 msgstr "Toon Log-berichten\tCtrl+L"
@@ -1938,7 +1938,7 @@ msgid "Numerically renames the destination of all items in the list"
 msgstr ""
 
 #: ../../vdms_main/main_frame.py:496 ../../vdms_panels/filedrop.py:343
-#: ../../vdms_panels/filedrop.py:366
+#: ../../vdms_panels/filedrop.py:388
 #, fuzzy
 msgid "Remove selected entry\tDEL"
 msgstr "Verwijder het geselecteerde profiel"
@@ -1949,7 +1949,7 @@ msgid "Remove the selected file from the list"
 msgstr "Verwijder het geselecteerde bestand uit de lijst"
 
 #: ../../vdms_main/main_frame.py:500 ../../vdms_panels/filedrop.py:344
-#: ../../vdms_panels/filedrop.py:369
+#: ../../vdms_panels/filedrop.py:391
 msgid "Clear list\tShift+DEL"
 msgstr ""
 
@@ -2350,79 +2350,78 @@ msgstr ""
 msgid "Show queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1406 ../../vdms_panels/presets_manager.py:569
+#: ../../vdms_main/main_frame.py:1408 ../../vdms_panels/presets_manager.py:569
 msgid "Videomass"
 msgstr "Videomass"
 
-#: ../../vdms_main/main_frame.py:1436
+#: ../../vdms_main/main_frame.py:1442
 #, fuzzy
 msgid "Videomass - File List"
 msgstr "Videomass - Wachtrij Bestanden"
 
-#: ../../vdms_main/main_frame.py:1453
+#: ../../vdms_main/main_frame.py:1459
 msgid "Videomass - AV Conversions"
 msgstr "Videomass - AV Conversies"
 
-#: ../../vdms_main/main_frame.py:1480
+#: ../../vdms_main/main_frame.py:1488
 msgid "Videomass - Presets Manager"
 msgstr "Videomass - Presets Manager"
 
-#: ../../vdms_main/main_frame.py:1508
+#: ../../vdms_main/main_frame.py:1518
 msgid "Videomass - Concatenate Demuxer"
 msgstr "Videomass - Samenvoeg Demuxer"
 
-#: ../../vdms_main/main_frame.py:1535
+#: ../../vdms_main/main_frame.py:1547
 #, fuzzy
 msgid "Videomass - From Movie to Pictures"
 msgstr "Van afbeelingen serie naar een video file"
 
-#: ../../vdms_main/main_frame.py:1562
+#: ../../vdms_main/main_frame.py:1576
 #, fuzzy
 msgid "Videomass - Still Image Maker"
 msgstr "Videomass - Presets Manager"
 
-#: ../../vdms_main/main_frame.py:1644
-#: ../../vdms_panels/audio_encoders/acodecs.py:789
-#: ../../vdms_panels/av_conversions.py:577 ../../vdms_panels/filedrop.py:475
-#: ../../vdms_panels/filedrop.py:588 ../../vdms_panels/sequence_to_video.py:322
+#: ../../vdms_main/main_frame.py:1660 ../../vdms_panels/av_conversions.py:577
+#: ../../vdms_panels/filedrop.py:500 ../../vdms_panels/filedrop.py:616
+#: ../../vdms_panels/sequence_to_video.py:322
 #: ../../vdms_panels/video_to_sequence.py:369
 #: ../../vdms_panels/video_to_sequence.py:501
 #, fuzzy
 msgid "Have to select an item in the file list first"
 msgstr "Selecteer eerst een profiel in de lijst"
 
-#: ../../vdms_main/main_frame.py:1666
+#: ../../vdms_main/main_frame.py:1682
 msgid ""
 "An item with the same destination file already exists.\n"
 "\n"
 "Do you want to replace it by adding the new item to the queue?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1687
+#: ../../vdms_main/main_frame.py:1703
 #, fuzzy
 msgid "Videomass - FFmpeg Message Monitoring"
 msgstr "Videomass - Output Monitor"
 
-#: ../../vdms_main/main_frame.py:1814
+#: ../../vdms_main/main_frame.py:1828
 #, python-brace-format
 msgid "The system will turn off in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1815
+#: ../../vdms_main/main_frame.py:1829
 #, fuzzy
 msgid "Videomass - Shutdown!"
 msgstr "Videomass - Laden..."
 
-#: ../../vdms_main/main_frame.py:1822
+#: ../../vdms_main/main_frame.py:1836
 msgid "Error while shutting down. Please see file log for details."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1834
+#: ../../vdms_main/main_frame.py:1848
 #, python-brace-format
 msgid "Exiting the application in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1835
+#: ../../vdms_main/main_frame.py:1849
 #, fuzzy
 msgid "Videomass - Exiting!"
 msgstr "Videomass - Laden..."
@@ -2871,7 +2870,7 @@ msgstr "Media type"
 msgid "Size"
 msgstr "Grootte"
 
-#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:383
+#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:405
 msgid "Drag one or more files below"
 msgstr "Sleep een of meer bestanden hieronder"
 
@@ -2890,51 +2889,51 @@ msgstr "Maak een nieuwe preset"
 msgid "Encodings destination folder"
 msgstr "Configuratie folder"
 
-#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:372
+#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:394
 #, fuzzy
 msgid "Play file"
 msgstr "Profiel"
 
-#: ../../vdms_panels/filedrop.py:386
+#: ../../vdms_panels/filedrop.py:408
 #, fuzzy
 msgid "Drag two or more Audio/Video files below"
 msgstr "Sleep een of meer bestanden hieronder"
 
-#: ../../vdms_panels/filedrop.py:390
+#: ../../vdms_panels/filedrop.py:412
 #, fuzzy
 msgid "Drag one or more Image files below"
 msgstr "Sleep een of meer bestanden hieronder"
 
-#: ../../vdms_panels/filedrop.py:393
+#: ../../vdms_panels/filedrop.py:415
 #, fuzzy
 msgid "Drag one or more Video files below"
 msgstr "Sleep een of meer bestanden hieronder"
 
-#: ../../vdms_panels/filedrop.py:595
+#: ../../vdms_panels/filedrop.py:623
 #, fuzzy
 msgid "Rename the file destination"
 msgstr "Herstel de standaard bestemming-folders"
 
-#: ../../vdms_panels/filedrop.py:596
+#: ../../vdms_panels/filedrop.py:624
 #, fuzzy
 msgid "Rename the selected file to:"
 msgstr "Verwijder het geselecteerde profiel"
 
-#: ../../vdms_panels/filedrop.py:610 ../../vdms_panels/filedrop.py:620
-#: ../../vdms_panels/filedrop.py:651
+#: ../../vdms_panels/filedrop.py:638 ../../vdms_panels/filedrop.py:648
+#: ../../vdms_panels/filedrop.py:679
 msgid "Add Files"
 msgstr "Voeg bestanden toe"
 
-#: ../../vdms_panels/filedrop.py:627
+#: ../../vdms_panels/filedrop.py:655
 msgid "Rename in batch"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:628
+#: ../../vdms_panels/filedrop.py:656
 #, python-brace-format
 msgid "Rename the {0} items to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:630
+#: ../../vdms_panels/filedrop.py:658
 #, fuzzy
 msgid "New Name #"
 msgstr "Bestandsnaam"
@@ -3600,6 +3599,10 @@ msgid ""
 "High-quality two-pass Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements\n"
 "the EBU R128 algorithm. Ideal for postprocessing."
 msgstr "Activeer twee-pass normalisatie. Het normaliseert de ervaarde loudness door gebruikmaking van het \"​loudnorm\" filter, wat het EBU R128 algoritme toepast."
+
+#: ../../vdms_panels/audio_encoders/acodecs.py:789
+msgid "You need to import at least one file"
+msgstr ""
 
 #: ../../vdms_panels/miscellaneous/miscell.py:63
 msgid "Subtitle Mapping:"

--- a/videomass/data/locale/pt_BR/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/pt_BR/LC_MESSAGES/videomass.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Videomass 5.0.18\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-22 23:33+0200\n"
+"POT-Creation-Date: 2025-07-26 15:04+0200\n"
 "PO-Revision-Date: 2024-07-03 18:48+0200\n"
 "Last-Translator: Samuel / http://littlesvr.ca/ostd/\n"
 "Language: pt_BR\n"
@@ -1000,7 +1000,7 @@ msgid "Change"
 msgstr ""
 
 #: ../../vdms_dialogs/preferences.py:103
-#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:574
+#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:602
 #: ../../vdms_panels/presets_manager.py:1050
 #, fuzzy
 msgid "Same destination paths as source files"
@@ -1469,34 +1469,34 @@ msgstr "Assistente concluído com sucesso!\n"
 msgid "Profile change successful!"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:81
+#: ../../vdms_dialogs/showlogs.py:80
 #, fuzzy
 msgid "Log file list"
 msgstr "Nenhum arquivo selecionado"
 
-#: ../../vdms_dialogs/showlogs.py:83 ../../vdms_dialogs/showlogs.py:117
+#: ../../vdms_dialogs/showlogs.py:82 ../../vdms_dialogs/showlogs.py:116
 msgid "Log messages"
 msgstr "Mensagens de log"
 
-#: ../../vdms_dialogs/showlogs.py:106
+#: ../../vdms_dialogs/showlogs.py:105
 msgid "Refresh log messages"
 msgstr "Atualizar mensagens de log"
 
-#: ../../vdms_dialogs/showlogs.py:108
+#: ../../vdms_dialogs/showlogs.py:107
 msgid "Clear log messages"
 msgstr "Limpar mensagens de log"
 
-#: ../../vdms_dialogs/showlogs.py:161
+#: ../../vdms_dialogs/showlogs.py:160
 msgid "Select a log file"
 msgstr "Selecione um arquivo de log"
 
-#: ../../vdms_dialogs/showlogs.py:168
+#: ../../vdms_dialogs/showlogs.py:167
 msgid "Are you sure you want to clear the selected log file?"
 msgstr "Tem certeza de que deseja limpar o arquivo de log selecionado?"
 
-#: ../../vdms_dialogs/showlogs.py:169 ../../vdms_dialogs/wizard_dlg.py:251
+#: ../../vdms_dialogs/showlogs.py:168 ../../vdms_dialogs/wizard_dlg.py:251
 #: ../../vdms_io/checkup.py:68 ../../vdms_main/main_frame.py:205
-#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1669
+#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1685
 #: ../../vdms_panels/presets_manager.py:349
 #: ../../vdms_panels/presets_manager.py:550
 #: ../../vdms_panels/presets_manager.py:590
@@ -1811,8 +1811,8 @@ msgstr ""
 msgid "Videomass - Downloading..."
 msgstr "Videomass - Baixando ..."
 
-#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1407
-#: ../../vdms_main/main_frame.py:1435
+#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1409
+#: ../../vdms_main/main_frame.py:1441
 msgid "Ready"
 msgstr "Pronto"
 
@@ -1897,7 +1897,7 @@ msgid "File"
 msgstr "Arquivo"
 
 #: ../../vdms_main/main_frame.py:486 ../../vdms_panels/filedrop.py:340
-#: ../../vdms_panels/filedrop.py:359
+#: ../../vdms_panels/filedrop.py:381
 #, fuzzy
 msgid "Rename selected file\tCtrl+R"
 msgstr "Exclua o perfil selecionado"
@@ -1908,7 +1908,7 @@ msgid "Rename the destination of the selected file"
 msgstr "Um arquivo de destino deve ser selecionado nos arquivos em fila"
 
 #: ../../vdms_main/main_frame.py:490 ../../vdms_panels/filedrop.py:341
-#: ../../vdms_panels/filedrop.py:362
+#: ../../vdms_panels/filedrop.py:384
 #, fuzzy
 msgid "Batch rename files\tCtrl+B"
 msgstr "Exibir Logs\tCtrl+L"
@@ -1918,7 +1918,7 @@ msgid "Numerically renames the destination of all items in the list"
 msgstr ""
 
 #: ../../vdms_main/main_frame.py:496 ../../vdms_panels/filedrop.py:343
-#: ../../vdms_panels/filedrop.py:366
+#: ../../vdms_panels/filedrop.py:388
 #, fuzzy
 msgid "Remove selected entry\tDEL"
 msgstr "Exclua o perfil selecionado"
@@ -1929,7 +1929,7 @@ msgid "Remove the selected file from the list"
 msgstr "Remova o arquivo selecionado da lista"
 
 #: ../../vdms_main/main_frame.py:500 ../../vdms_panels/filedrop.py:344
-#: ../../vdms_panels/filedrop.py:369
+#: ../../vdms_panels/filedrop.py:391
 msgid "Clear list\tShift+DEL"
 msgstr ""
 
@@ -2334,79 +2334,78 @@ msgstr ""
 msgid "Show queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1406 ../../vdms_panels/presets_manager.py:569
+#: ../../vdms_main/main_frame.py:1408 ../../vdms_panels/presets_manager.py:569
 msgid "Videomass"
 msgstr "Videomass"
 
-#: ../../vdms_main/main_frame.py:1436
+#: ../../vdms_main/main_frame.py:1442
 #, fuzzy
 msgid "Videomass - File List"
 msgstr "Videomass - arquivos enfileirados"
 
-#: ../../vdms_main/main_frame.py:1453
+#: ../../vdms_main/main_frame.py:1459
 msgid "Videomass - AV Conversions"
 msgstr "Videomass - Conversões AV"
 
-#: ../../vdms_main/main_frame.py:1480
+#: ../../vdms_main/main_frame.py:1488
 msgid "Videomass - Presets Manager"
 msgstr "Videomass - Gerenciador de predefinições"
 
-#: ../../vdms_main/main_frame.py:1508
+#: ../../vdms_main/main_frame.py:1518
 msgid "Videomass - Concatenate Demuxer"
 msgstr "Videomass - Concatenate Demuxer"
 
-#: ../../vdms_main/main_frame.py:1535
+#: ../../vdms_main/main_frame.py:1547
 #, fuzzy
 msgid "Videomass - From Movie to Pictures"
 msgstr "Videomass - Monitor de Saída"
 
-#: ../../vdms_main/main_frame.py:1562
+#: ../../vdms_main/main_frame.py:1576
 #, fuzzy
 msgid "Videomass - Still Image Maker"
 msgstr "Videomass - Gerenciador de predefinições"
 
-#: ../../vdms_main/main_frame.py:1644
-#: ../../vdms_panels/audio_encoders/acodecs.py:789
-#: ../../vdms_panels/av_conversions.py:577 ../../vdms_panels/filedrop.py:475
-#: ../../vdms_panels/filedrop.py:588 ../../vdms_panels/sequence_to_video.py:322
+#: ../../vdms_main/main_frame.py:1660 ../../vdms_panels/av_conversions.py:577
+#: ../../vdms_panels/filedrop.py:500 ../../vdms_panels/filedrop.py:616
+#: ../../vdms_panels/sequence_to_video.py:322
 #: ../../vdms_panels/video_to_sequence.py:369
 #: ../../vdms_panels/video_to_sequence.py:501
 #, fuzzy
 msgid "Have to select an item in the file list first"
 msgstr "Primeiro selecione um perfil na lista"
 
-#: ../../vdms_main/main_frame.py:1666
+#: ../../vdms_main/main_frame.py:1682
 msgid ""
 "An item with the same destination file already exists.\n"
 "\n"
 "Do you want to replace it by adding the new item to the queue?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1687
+#: ../../vdms_main/main_frame.py:1703
 #, fuzzy
 msgid "Videomass - FFmpeg Message Monitoring"
 msgstr "Videomass - Monitor de Saída"
 
-#: ../../vdms_main/main_frame.py:1814
+#: ../../vdms_main/main_frame.py:1828
 #, python-brace-format
 msgid "The system will turn off in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1815
+#: ../../vdms_main/main_frame.py:1829
 #, fuzzy
 msgid "Videomass - Shutdown!"
 msgstr "Videomass - Carregando ..."
 
-#: ../../vdms_main/main_frame.py:1822
+#: ../../vdms_main/main_frame.py:1836
 msgid "Error while shutting down. Please see file log for details."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1834
+#: ../../vdms_main/main_frame.py:1848
 #, python-brace-format
 msgid "Exiting the application in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1835
+#: ../../vdms_main/main_frame.py:1849
 #, fuzzy
 msgid "Videomass - Exiting!"
 msgstr "Videomass - Carregando ..."
@@ -2857,7 +2856,7 @@ msgstr "Tipo de mídia"
 msgid "Size"
 msgstr "Tamanho"
 
-#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:383
+#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:405
 msgid "Drag one or more files below"
 msgstr "Arraste um ou mais arquivos abaixo"
 
@@ -2876,51 +2875,51 @@ msgstr "Crie uma nova predefinição"
 msgid "Encodings destination folder"
 msgstr "Pasta de configuração"
 
-#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:372
+#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:394
 #, fuzzy
 msgid "Play file"
 msgstr "Perfil"
 
-#: ../../vdms_panels/filedrop.py:386
+#: ../../vdms_panels/filedrop.py:408
 #, fuzzy
 msgid "Drag two or more Audio/Video files below"
 msgstr "Arraste um ou mais arquivos abaixo"
 
-#: ../../vdms_panels/filedrop.py:390
+#: ../../vdms_panels/filedrop.py:412
 #, fuzzy
 msgid "Drag one or more Image files below"
 msgstr "Arraste um ou mais arquivos abaixo"
 
-#: ../../vdms_panels/filedrop.py:393
+#: ../../vdms_panels/filedrop.py:415
 #, fuzzy
 msgid "Drag one or more Video files below"
 msgstr "Arraste um ou mais arquivos abaixo"
 
-#: ../../vdms_panels/filedrop.py:595
+#: ../../vdms_panels/filedrop.py:623
 #, fuzzy
 msgid "Rename the file destination"
 msgstr "Restaurar as pastas de destino padrão"
 
-#: ../../vdms_panels/filedrop.py:596
+#: ../../vdms_panels/filedrop.py:624
 #, fuzzy
 msgid "Rename the selected file to:"
 msgstr "Exclua o perfil selecionado"
 
-#: ../../vdms_panels/filedrop.py:610 ../../vdms_panels/filedrop.py:620
-#: ../../vdms_panels/filedrop.py:651
+#: ../../vdms_panels/filedrop.py:638 ../../vdms_panels/filedrop.py:648
+#: ../../vdms_panels/filedrop.py:679
 msgid "Add Files"
 msgstr "Adicionar arquivos"
 
-#: ../../vdms_panels/filedrop.py:627
+#: ../../vdms_panels/filedrop.py:655
 msgid "Rename in batch"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:628
+#: ../../vdms_panels/filedrop.py:656
 #, python-brace-format
 msgid "Rename the {0} items to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:630
+#: ../../vdms_panels/filedrop.py:658
 #, fuzzy
 msgid "New Name #"
 msgstr "Nome do arquivo"
@@ -3599,6 +3598,10 @@ msgid ""
 "High-quality two-pass Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements\n"
 "the EBU R128 algorithm. Ideal for postprocessing."
 msgstr "Ative a normalização de duas passagens. Ele normaliza o volume percebido usando o filtro \"loudnorm\", que implementa o algoritmo EBU R128."
+
+#: ../../vdms_panels/audio_encoders/acodecs.py:789
+msgid "You need to import at least one file"
+msgstr ""
 
 #: ../../vdms_panels/miscellaneous/miscell.py:63
 msgid "Subtitle Mapping:"

--- a/videomass/data/locale/ru_RU/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/ru_RU/LC_MESSAGES/videomass.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Videomass 5.0.20\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-22 23:33+0200\n"
+"POT-Creation-Date: 2025-07-26 15:04+0200\n"
 "PO-Revision-Date: 2025-06-09 19:36+0300\n"
 "Last-Translator: ChourS <ChourS2008@yandex.ru>\n"
 "Language: ru_RU\n"
@@ -986,7 +986,7 @@ msgid "Change"
 msgstr "Изменить"
 
 #: ../../vdms_dialogs/preferences.py:103
-#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:574
+#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:602
 #: ../../vdms_panels/presets_manager.py:1050
 msgid "Same destination paths as source files"
 msgstr "Те же пути назначения, что и у исходных файлов"
@@ -1443,33 +1443,33 @@ msgstr "Profile stored successfully!"
 msgid "Profile change successful!"
 msgstr "Смена профиля прошла успешно!"
 
-#: ../../vdms_dialogs/showlogs.py:81
+#: ../../vdms_dialogs/showlogs.py:80
 msgid "Log file list"
 msgstr "Список log-файлов"
 
-#: ../../vdms_dialogs/showlogs.py:83 ../../vdms_dialogs/showlogs.py:117
+#: ../../vdms_dialogs/showlogs.py:82 ../../vdms_dialogs/showlogs.py:116
 msgid "Log messages"
 msgstr "Log-журнал"
 
-#: ../../vdms_dialogs/showlogs.py:106
+#: ../../vdms_dialogs/showlogs.py:105
 msgid "Refresh log messages"
 msgstr "Обновить log-журналы"
 
-#: ../../vdms_dialogs/showlogs.py:108
+#: ../../vdms_dialogs/showlogs.py:107
 msgid "Clear log messages"
 msgstr "Очистить log-журналы"
 
-#: ../../vdms_dialogs/showlogs.py:161
+#: ../../vdms_dialogs/showlogs.py:160
 msgid "Select a log file"
 msgstr "Выберите файл журнала"
 
-#: ../../vdms_dialogs/showlogs.py:168
+#: ../../vdms_dialogs/showlogs.py:167
 msgid "Are you sure you want to clear the selected log file?"
 msgstr "Вы действительно хотите удалить выбранный файл log-журнала?"
 
-#: ../../vdms_dialogs/showlogs.py:169 ../../vdms_dialogs/wizard_dlg.py:251
+#: ../../vdms_dialogs/showlogs.py:168 ../../vdms_dialogs/wizard_dlg.py:251
 #: ../../vdms_io/checkup.py:68 ../../vdms_main/main_frame.py:205
-#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1669
+#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1685
 #: ../../vdms_panels/presets_manager.py:349
 #: ../../vdms_panels/presets_manager.py:550
 #: ../../vdms_panels/presets_manager.py:590
@@ -1793,8 +1793,8 @@ msgstr ""
 msgid "Videomass - Downloading..."
 msgstr "Videomass - Скачивание..."
 
-#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1407
-#: ../../vdms_main/main_frame.py:1435
+#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1409
+#: ../../vdms_main/main_frame.py:1441
 msgid "Ready"
 msgstr "Готово"
 
@@ -1874,7 +1874,7 @@ msgid "File"
 msgstr "Файл"
 
 #: ../../vdms_main/main_frame.py:486 ../../vdms_panels/filedrop.py:340
-#: ../../vdms_panels/filedrop.py:359
+#: ../../vdms_panels/filedrop.py:381
 msgid "Rename selected file\tCtrl+R"
 msgstr "Переименовать выбранный файл\tCtrl+R"
 
@@ -1883,7 +1883,7 @@ msgid "Rename the destination of the selected file"
 msgstr "Переименуйте место назначения выбранного файла"
 
 #: ../../vdms_main/main_frame.py:490 ../../vdms_panels/filedrop.py:341
-#: ../../vdms_panels/filedrop.py:362
+#: ../../vdms_panels/filedrop.py:384
 msgid "Batch rename files\tCtrl+B"
 msgstr "Пакетное переименование файлов\tCtrl+B"
 
@@ -1892,7 +1892,7 @@ msgid "Numerically renames the destination of all items in the list"
 msgstr "Численно переименовывает пункт назначения всех элементов в списке."
 
 #: ../../vdms_main/main_frame.py:496 ../../vdms_panels/filedrop.py:343
-#: ../../vdms_panels/filedrop.py:366
+#: ../../vdms_panels/filedrop.py:388
 msgid "Remove selected entry\tDEL"
 msgstr "Удалить выбранный файл\tDEL"
 
@@ -1901,7 +1901,7 @@ msgid "Remove the selected file from the list"
 msgstr "Удалить выбранный файл из списка"
 
 #: ../../vdms_main/main_frame.py:500 ../../vdms_panels/filedrop.py:344
-#: ../../vdms_panels/filedrop.py:369
+#: ../../vdms_panels/filedrop.py:391
 msgid "Clear list\tShift+DEL"
 msgstr "Очистить список\tShift+DEL"
 
@@ -2282,44 +2282,43 @@ msgstr "Добавить в очередь"
 msgid "Show queue"
 msgstr "Показать очередь"
 
-#: ../../vdms_main/main_frame.py:1406 ../../vdms_panels/presets_manager.py:569
+#: ../../vdms_main/main_frame.py:1408 ../../vdms_panels/presets_manager.py:569
 msgid "Videomass"
 msgstr "Videomass"
 
-#: ../../vdms_main/main_frame.py:1436
+#: ../../vdms_main/main_frame.py:1442
 msgid "Videomass - File List"
 msgstr "Videomass - Список файлов"
 
-#: ../../vdms_main/main_frame.py:1453
+#: ../../vdms_main/main_frame.py:1459
 msgid "Videomass - AV Conversions"
 msgstr "Videomass - AV-конвертация"
 
-#: ../../vdms_main/main_frame.py:1480
+#: ../../vdms_main/main_frame.py:1488
 msgid "Videomass - Presets Manager"
 msgstr "Videomass - Менеджер Пресетов"
 
-#: ../../vdms_main/main_frame.py:1508
+#: ../../vdms_main/main_frame.py:1518
 msgid "Videomass - Concatenate Demuxer"
 msgstr "Videomass - Concatenate Demuxer"
 
-#: ../../vdms_main/main_frame.py:1535
+#: ../../vdms_main/main_frame.py:1547
 msgid "Videomass - From Movie to Pictures"
 msgstr "Videomass - Картинки из фильма"
 
-#: ../../vdms_main/main_frame.py:1562
+#: ../../vdms_main/main_frame.py:1576
 msgid "Videomass - Still Image Maker"
 msgstr "Videomass - Still Image Maker"
 
-#: ../../vdms_main/main_frame.py:1644
-#: ../../vdms_panels/audio_encoders/acodecs.py:789
-#: ../../vdms_panels/av_conversions.py:577 ../../vdms_panels/filedrop.py:475
-#: ../../vdms_panels/filedrop.py:588 ../../vdms_panels/sequence_to_video.py:322
+#: ../../vdms_main/main_frame.py:1660 ../../vdms_panels/av_conversions.py:577
+#: ../../vdms_panels/filedrop.py:500 ../../vdms_panels/filedrop.py:616
+#: ../../vdms_panels/sequence_to_video.py:322
 #: ../../vdms_panels/video_to_sequence.py:369
 #: ../../vdms_panels/video_to_sequence.py:501
 msgid "Have to select an item in the file list first"
 msgstr "Сначала необходимо выбрать элемент в списке файлов"
 
-#: ../../vdms_main/main_frame.py:1666
+#: ../../vdms_main/main_frame.py:1682
 msgid ""
 "An item with the same destination file already exists.\n"
 "\n"
@@ -2329,31 +2328,31 @@ msgstr ""
 "\n"
 "Хотите заменить его, добавив новый элемент в очередь?"
 
-#: ../../vdms_main/main_frame.py:1687
+#: ../../vdms_main/main_frame.py:1703
 msgid "Videomass - FFmpeg Message Monitoring"
 msgstr "Videomass - Мониторинг сообщений FFmpeg"
 
 # русское сокращение последнего слова
-#: ../../vdms_main/main_frame.py:1814
+#: ../../vdms_main/main_frame.py:1828
 #, python-brace-format
 msgid "The system will turn off in {0} seconds"
 msgstr "Система выключится через {0} сек."
 
-#: ../../vdms_main/main_frame.py:1815
+#: ../../vdms_main/main_frame.py:1829
 msgid "Videomass - Shutdown!"
 msgstr "Videomass - Выключение!"
 
-#: ../../vdms_main/main_frame.py:1822
+#: ../../vdms_main/main_frame.py:1836
 msgid "Error while shutting down. Please see file log for details."
 msgstr "Ошибка при выключении. Подробности смотрите в журнале файлов."
 
 # русское сокращение последнего слова
-#: ../../vdms_main/main_frame.py:1834
+#: ../../vdms_main/main_frame.py:1848
 #, python-brace-format
 msgid "Exiting the application in {0} seconds"
 msgstr "Выход из приложения через {0} сек."
 
-#: ../../vdms_main/main_frame.py:1835
+#: ../../vdms_main/main_frame.py:1849
 msgid "Videomass - Exiting!"
 msgstr "Videomass - Выход!"
 
@@ -2798,7 +2797,7 @@ msgstr "Тип медиа"
 msgid "Size"
 msgstr "Размер"
 
-#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:383
+#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:405
 msgid "Drag one or more files below"
 msgstr "Перетащите один или несколько файлов ниже"
 
@@ -2814,46 +2813,46 @@ msgstr "Установите новую папку назначения для �
 msgid "Encodings destination folder"
 msgstr "Папка назначения кодировок"
 
-#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:372
+#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:394
 msgid "Play file"
 msgstr "Воспроизвести файл"
 
-#: ../../vdms_panels/filedrop.py:386
+#: ../../vdms_panels/filedrop.py:408
 msgid "Drag two or more Audio/Video files below"
 msgstr "Перетащите два (или более) аудио/видео файла в поле ниже"
 
-#: ../../vdms_panels/filedrop.py:390
+#: ../../vdms_panels/filedrop.py:412
 msgid "Drag one or more Image files below"
 msgstr "Перетащите один или несколько файлов изображений ниже"
 
-#: ../../vdms_panels/filedrop.py:393
+#: ../../vdms_panels/filedrop.py:415
 msgid "Drag one or more Video files below"
 msgstr "Перетащите один или несколько видеофайлов ниже"
 
-#: ../../vdms_panels/filedrop.py:595
+#: ../../vdms_panels/filedrop.py:623
 msgid "Rename the file destination"
 msgstr "Переименуйте место назначения файла"
 
-#: ../../vdms_panels/filedrop.py:596
+#: ../../vdms_panels/filedrop.py:624
 msgid "Rename the selected file to:"
 msgstr "Переименуйте выбранный файл в:"
 
-#: ../../vdms_panels/filedrop.py:610 ../../vdms_panels/filedrop.py:620
-#: ../../vdms_panels/filedrop.py:651
+#: ../../vdms_panels/filedrop.py:638 ../../vdms_panels/filedrop.py:648
+#: ../../vdms_panels/filedrop.py:679
 msgid "Add Files"
 msgstr "Добавить файлы"
 
-#: ../../vdms_panels/filedrop.py:627
+#: ../../vdms_panels/filedrop.py:655
 msgid "Rename in batch"
 msgstr "Переименование в пакетном режиме"
 
 # Здесь изменил фразу исходника для правильного использования в русском языке
-#: ../../vdms_panels/filedrop.py:628
+#: ../../vdms_panels/filedrop.py:656
 #, python-brace-format
 msgid "Rename the {0} items to:"
 msgstr "Файлов для переименования: {0}"
 
-#: ../../vdms_panels/filedrop.py:630
+#: ../../vdms_panels/filedrop.py:658
 msgid "New Name #"
 msgstr "Новое имя #"
 
@@ -3577,6 +3576,10 @@ msgstr ""
 "Качественная двухпроходная нормализация Loudnorm. Нормализует воспринимаемую\n"
 "громкость с помощью фильтра «loudnorm», реализующего алгоритм EBU R128.\n"
 "Идеально подходит для постобработки."
+
+#: ../../vdms_panels/audio_encoders/acodecs.py:789
+msgid "You need to import at least one file"
+msgstr ""
 
 #: ../../vdms_panels/miscellaneous/miscell.py:63
 msgid "Subtitle Mapping:"

--- a/videomass/data/locale/videomass.pot
+++ b/videomass/data/locale/videomass.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-22 23:33+0200\n"
+"POT-Creation-Date: 2025-07-26 15:04+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -935,7 +935,7 @@ msgid "Change"
 msgstr ""
 
 #: ../../vdms_dialogs/preferences.py:103
-#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:574
+#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:602
 #: ../../vdms_panels/presets_manager.py:1050
 msgid "Same destination paths as source files"
 msgstr ""
@@ -1358,33 +1358,33 @@ msgstr ""
 msgid "Profile change successful!"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:81
+#: ../../vdms_dialogs/showlogs.py:80
 msgid "Log file list"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:83 ../../vdms_dialogs/showlogs.py:117
+#: ../../vdms_dialogs/showlogs.py:82 ../../vdms_dialogs/showlogs.py:116
 msgid "Log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:106
+#: ../../vdms_dialogs/showlogs.py:105
 msgid "Refresh log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:108
+#: ../../vdms_dialogs/showlogs.py:107
 msgid "Clear log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:161
+#: ../../vdms_dialogs/showlogs.py:160
 msgid "Select a log file"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:168
+#: ../../vdms_dialogs/showlogs.py:167
 msgid "Are you sure you want to clear the selected log file?"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:169 ../../vdms_dialogs/wizard_dlg.py:251
+#: ../../vdms_dialogs/showlogs.py:168 ../../vdms_dialogs/wizard_dlg.py:251
 #: ../../vdms_io/checkup.py:68 ../../vdms_main/main_frame.py:205
-#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1669
+#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1685
 #: ../../vdms_panels/presets_manager.py:349
 #: ../../vdms_panels/presets_manager.py:550
 #: ../../vdms_panels/presets_manager.py:590
@@ -1661,8 +1661,8 @@ msgstr ""
 msgid "Videomass - Downloading..."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1407
-#: ../../vdms_main/main_frame.py:1435
+#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1409
+#: ../../vdms_main/main_frame.py:1441
 msgid "Ready"
 msgstr ""
 
@@ -1739,7 +1739,7 @@ msgid "File"
 msgstr ""
 
 #: ../../vdms_main/main_frame.py:486 ../../vdms_panels/filedrop.py:340
-#: ../../vdms_panels/filedrop.py:359
+#: ../../vdms_panels/filedrop.py:381
 msgid "Rename selected file\tCtrl+R"
 msgstr ""
 
@@ -1748,7 +1748,7 @@ msgid "Rename the destination of the selected file"
 msgstr ""
 
 #: ../../vdms_main/main_frame.py:490 ../../vdms_panels/filedrop.py:341
-#: ../../vdms_panels/filedrop.py:362
+#: ../../vdms_panels/filedrop.py:384
 msgid "Batch rename files\tCtrl+B"
 msgstr ""
 
@@ -1757,7 +1757,7 @@ msgid "Numerically renames the destination of all items in the list"
 msgstr ""
 
 #: ../../vdms_main/main_frame.py:496 ../../vdms_panels/filedrop.py:343
-#: ../../vdms_panels/filedrop.py:366
+#: ../../vdms_panels/filedrop.py:388
 msgid "Remove selected entry\tDEL"
 msgstr ""
 
@@ -1766,7 +1766,7 @@ msgid "Remove the selected file from the list"
 msgstr ""
 
 #: ../../vdms_main/main_frame.py:500 ../../vdms_panels/filedrop.py:344
-#: ../../vdms_panels/filedrop.py:369
+#: ../../vdms_panels/filedrop.py:391
 msgid "Clear list\tShift+DEL"
 msgstr ""
 
@@ -2132,73 +2132,72 @@ msgstr ""
 msgid "Show queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1406 ../../vdms_panels/presets_manager.py:569
+#: ../../vdms_main/main_frame.py:1408 ../../vdms_panels/presets_manager.py:569
 msgid "Videomass"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1436
+#: ../../vdms_main/main_frame.py:1442
 msgid "Videomass - File List"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1453
+#: ../../vdms_main/main_frame.py:1459
 msgid "Videomass - AV Conversions"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1480
+#: ../../vdms_main/main_frame.py:1488
 msgid "Videomass - Presets Manager"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1508
+#: ../../vdms_main/main_frame.py:1518
 msgid "Videomass - Concatenate Demuxer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1535
+#: ../../vdms_main/main_frame.py:1547
 msgid "Videomass - From Movie to Pictures"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1562
+#: ../../vdms_main/main_frame.py:1576
 msgid "Videomass - Still Image Maker"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1644
-#: ../../vdms_panels/audio_encoders/acodecs.py:789
-#: ../../vdms_panels/av_conversions.py:577 ../../vdms_panels/filedrop.py:475
-#: ../../vdms_panels/filedrop.py:588 ../../vdms_panels/sequence_to_video.py:322
+#: ../../vdms_main/main_frame.py:1660 ../../vdms_panels/av_conversions.py:577
+#: ../../vdms_panels/filedrop.py:500 ../../vdms_panels/filedrop.py:616
+#: ../../vdms_panels/sequence_to_video.py:322
 #: ../../vdms_panels/video_to_sequence.py:369
 #: ../../vdms_panels/video_to_sequence.py:501
 msgid "Have to select an item in the file list first"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1666
+#: ../../vdms_main/main_frame.py:1682
 msgid ""
 "An item with the same destination file already exists.\n"
 "\n"
 "Do you want to replace it by adding the new item to the queue?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1687
+#: ../../vdms_main/main_frame.py:1703
 msgid "Videomass - FFmpeg Message Monitoring"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1814
+#: ../../vdms_main/main_frame.py:1828
 #, python-brace-format
 msgid "The system will turn off in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1815
+#: ../../vdms_main/main_frame.py:1829
 msgid "Videomass - Shutdown!"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1822
+#: ../../vdms_main/main_frame.py:1836
 msgid "Error while shutting down. Please see file log for details."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1834
+#: ../../vdms_main/main_frame.py:1848
 #, python-brace-format
 msgid "Exiting the application in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1835
+#: ../../vdms_main/main_frame.py:1849
 msgid "Videomass - Exiting!"
 msgstr ""
 
@@ -2588,7 +2587,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:383
+#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:405
 msgid "Drag one or more files below"
 msgstr ""
 
@@ -2604,45 +2603,45 @@ msgstr ""
 msgid "Encodings destination folder"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:372
+#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:394
 msgid "Play file"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:386
+#: ../../vdms_panels/filedrop.py:408
 msgid "Drag two or more Audio/Video files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:390
+#: ../../vdms_panels/filedrop.py:412
 msgid "Drag one or more Image files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:393
+#: ../../vdms_panels/filedrop.py:415
 msgid "Drag one or more Video files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:595
+#: ../../vdms_panels/filedrop.py:623
 msgid "Rename the file destination"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:596
+#: ../../vdms_panels/filedrop.py:624
 msgid "Rename the selected file to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:610 ../../vdms_panels/filedrop.py:620
-#: ../../vdms_panels/filedrop.py:651
+#: ../../vdms_panels/filedrop.py:638 ../../vdms_panels/filedrop.py:648
+#: ../../vdms_panels/filedrop.py:679
 msgid "Add Files"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:627
+#: ../../vdms_panels/filedrop.py:655
 msgid "Rename in batch"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:628
+#: ../../vdms_panels/filedrop.py:656
 #, python-brace-format
 msgid "Rename the {0} items to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:630
+#: ../../vdms_panels/filedrop.py:658
 msgid "New Name #"
 msgstr ""
 
@@ -3239,6 +3238,10 @@ msgstr ""
 msgid ""
 "High-quality two-pass Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements\n"
 "the EBU R128 algorithm. Ideal for postprocessing."
+msgstr ""
+
+#: ../../vdms_panels/audio_encoders/acodecs.py:789
+msgid "You need to import at least one file"
 msgstr ""
 
 #: ../../vdms_panels/miscellaneous/miscell.py:63

--- a/videomass/data/locale/zh_CN/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/zh_CN/LC_MESSAGES/videomass.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Videomass 5.0.26\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-22 23:33+0200\n"
+"POT-Creation-Date: 2025-07-26 15:04+0200\n"
 "PO-Revision-Date: 2025-04-19 11:19+0800\n"
 "Last-Translator: Gao Zimu <gaozimu_0502@163.com>\n"
 "Language: zh_CN\n"
@@ -1030,7 +1030,7 @@ msgid "Change"
 msgstr "更改"
 
 #: ../../vdms_dialogs/preferences.py:103
-#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:574
+#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:602
 #: ../../vdms_panels/presets_manager.py:1050
 msgid "Same destination paths as source files"
 msgstr "使用与源文件相同的输出路径"
@@ -1480,33 +1480,33 @@ msgstr "配置文件保存完成！"
 msgid "Profile change successful!"
 msgstr "配置文件更改完成！"
 
-#: ../../vdms_dialogs/showlogs.py:81
+#: ../../vdms_dialogs/showlogs.py:80
 msgid "Log file list"
 msgstr "日志文件列表"
 
-#: ../../vdms_dialogs/showlogs.py:83 ../../vdms_dialogs/showlogs.py:117
+#: ../../vdms_dialogs/showlogs.py:82 ../../vdms_dialogs/showlogs.py:116
 msgid "Log messages"
 msgstr "日志信息"
 
-#: ../../vdms_dialogs/showlogs.py:106
+#: ../../vdms_dialogs/showlogs.py:105
 msgid "Refresh log messages"
 msgstr "刷新日志消息"
 
-#: ../../vdms_dialogs/showlogs.py:108
+#: ../../vdms_dialogs/showlogs.py:107
 msgid "Clear log messages"
 msgstr "清空日志消息"
 
-#: ../../vdms_dialogs/showlogs.py:161
+#: ../../vdms_dialogs/showlogs.py:160
 msgid "Select a log file"
 msgstr "选择一个日志文件"
 
-#: ../../vdms_dialogs/showlogs.py:168
+#: ../../vdms_dialogs/showlogs.py:167
 msgid "Are you sure you want to clear the selected log file?"
 msgstr "你确定要清除选定的日志文件吗？"
 
-#: ../../vdms_dialogs/showlogs.py:169 ../../vdms_dialogs/wizard_dlg.py:251
+#: ../../vdms_dialogs/showlogs.py:168 ../../vdms_dialogs/wizard_dlg.py:251
 #: ../../vdms_io/checkup.py:68 ../../vdms_main/main_frame.py:205
-#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1669
+#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1685
 #: ../../vdms_panels/presets_manager.py:349
 #: ../../vdms_panels/presets_manager.py:550
 #: ../../vdms_panels/presets_manager.py:590
@@ -1845,8 +1845,8 @@ msgstr ""
 msgid "Videomass - Downloading..."
 msgstr "Videomass - 下载中..."
 
-#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1407
-#: ../../vdms_main/main_frame.py:1435
+#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1409
+#: ../../vdms_main/main_frame.py:1441
 msgid "Ready"
 msgstr "准备就绪"
 
@@ -1923,7 +1923,7 @@ msgid "File"
 msgstr "文件"
 
 #: ../../vdms_main/main_frame.py:486 ../../vdms_panels/filedrop.py:340
-#: ../../vdms_panels/filedrop.py:359
+#: ../../vdms_panels/filedrop.py:381
 msgid "Rename selected file\tCtrl+R"
 msgstr "重命名选中的文件\tCtrl+R"
 
@@ -1932,7 +1932,7 @@ msgid "Rename the destination of the selected file"
 msgstr "重命名选中的文件的输出"
 
 #: ../../vdms_main/main_frame.py:490 ../../vdms_panels/filedrop.py:341
-#: ../../vdms_panels/filedrop.py:362
+#: ../../vdms_panels/filedrop.py:384
 msgid "Batch rename files\tCtrl+B"
 msgstr "批量重命名\tCtrl+B"
 
@@ -1941,7 +1941,7 @@ msgid "Numerically renames the destination of all items in the list"
 msgstr "对列表中的所有项目目标按数字顺序重命名"
 
 #: ../../vdms_main/main_frame.py:496 ../../vdms_panels/filedrop.py:343
-#: ../../vdms_panels/filedrop.py:366
+#: ../../vdms_panels/filedrop.py:388
 msgid "Remove selected entry\tDEL"
 msgstr "移除选中项\tDEL"
 
@@ -1950,7 +1950,7 @@ msgid "Remove the selected file from the list"
 msgstr "从列表中移除选定的文件"
 
 #: ../../vdms_main/main_frame.py:500 ../../vdms_panels/filedrop.py:344
-#: ../../vdms_panels/filedrop.py:369
+#: ../../vdms_panels/filedrop.py:391
 msgid "Clear list\tShift+DEL"
 msgstr "清空列表\tShift+DEL"
 
@@ -2330,75 +2330,74 @@ msgstr "添加至队列"
 msgid "Show queue"
 msgstr "显示队列"
 
-#: ../../vdms_main/main_frame.py:1406 ../../vdms_panels/presets_manager.py:569
+#: ../../vdms_main/main_frame.py:1408 ../../vdms_panels/presets_manager.py:569
 msgid "Videomass"
 msgstr "Videomass"
 
-#: ../../vdms_main/main_frame.py:1436
+#: ../../vdms_main/main_frame.py:1442
 msgid "Videomass - File List"
 msgstr "Videomass - 文件列表"
 
-#: ../../vdms_main/main_frame.py:1453
+#: ../../vdms_main/main_frame.py:1459
 msgid "Videomass - AV Conversions"
 msgstr "Videomass - 视频、音频转换"
 
-#: ../../vdms_main/main_frame.py:1480
+#: ../../vdms_main/main_frame.py:1488
 msgid "Videomass - Presets Manager"
 msgstr "Videomass - 预设管理器"
 
-#: ../../vdms_main/main_frame.py:1508
+#: ../../vdms_main/main_frame.py:1518
 #, fuzzy
 msgid "Videomass - Concatenate Demuxer"
 msgstr "Videomass - Concatenate Demuxer"
 
-#: ../../vdms_main/main_frame.py:1535
+#: ../../vdms_main/main_frame.py:1547
 msgid "Videomass - From Movie to Pictures"
 msgstr "Videomass - 转换视频为图片序列"
 
-#: ../../vdms_main/main_frame.py:1562
+#: ../../vdms_main/main_frame.py:1576
 #, fuzzy
 msgid "Videomass - Still Image Maker"
 msgstr "Videomass - 静态图像制作"
 
-#: ../../vdms_main/main_frame.py:1644
-#: ../../vdms_panels/audio_encoders/acodecs.py:789
-#: ../../vdms_panels/av_conversions.py:577 ../../vdms_panels/filedrop.py:475
-#: ../../vdms_panels/filedrop.py:588 ../../vdms_panels/sequence_to_video.py:322
+#: ../../vdms_main/main_frame.py:1660 ../../vdms_panels/av_conversions.py:577
+#: ../../vdms_panels/filedrop.py:500 ../../vdms_panels/filedrop.py:616
+#: ../../vdms_panels/sequence_to_video.py:322
 #: ../../vdms_panels/video_to_sequence.py:369
 #: ../../vdms_panels/video_to_sequence.py:501
 msgid "Have to select an item in the file list first"
 msgstr "需要在列表中选择一个项"
 
-#: ../../vdms_main/main_frame.py:1666
+#: ../../vdms_main/main_frame.py:1682
 msgid ""
 "An item with the same destination file already exists.\n"
 "\n"
 "Do you want to replace it by adding the new item to the queue?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1687
+#: ../../vdms_main/main_frame.py:1703
 msgid "Videomass - FFmpeg Message Monitoring"
 msgstr "Videomass - FFmpeg 消息监控"
 
-#: ../../vdms_main/main_frame.py:1814
+#: ../../vdms_main/main_frame.py:1828
 #, python-brace-format
 msgid "The system will turn off in {0} seconds"
 msgstr "系统将在 {0} 秒后关机"
 
-#: ../../vdms_main/main_frame.py:1815
+#: ../../vdms_main/main_frame.py:1829
 msgid "Videomass - Shutdown!"
 msgstr "Videomass - 关机！"
 
-#: ../../vdms_main/main_frame.py:1822
+#: ../../vdms_main/main_frame.py:1836
 msgid "Error while shutting down. Please see file log for details."
 msgstr "关机时出现错误。请查看日志以获取详情。"
 
-#: ../../vdms_main/main_frame.py:1834
+#: ../../vdms_main/main_frame.py:1848
 #, python-brace-format
 msgid "Exiting the application in {0} seconds"
 msgstr "此程序将在 {0} 秒后退出"
 
-#: ../../vdms_main/main_frame.py:1835
+#: ../../vdms_main/main_frame.py:1849
 msgid "Videomass - Exiting!"
 msgstr "Videomass - 退出中！"
 
@@ -2851,7 +2850,7 @@ msgstr "媒体类型"
 msgid "Size"
 msgstr "大小"
 
-#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:383
+#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:405
 msgid "Drag one or more files below"
 msgstr "拖动下面的一个或多个文件"
 
@@ -2869,50 +2868,50 @@ msgstr "创建一个新的预设"
 msgid "Encodings destination folder"
 msgstr "配置文件夹"
 
-#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:372
+#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:394
 #, fuzzy
 msgid "Play file"
 msgstr "配置文件"
 
-#: ../../vdms_panels/filedrop.py:386
+#: ../../vdms_panels/filedrop.py:408
 #, fuzzy
 msgid "Drag two or more Audio/Video files below"
 msgstr "拖动下面的一个或多个文件"
 
-#: ../../vdms_panels/filedrop.py:390
+#: ../../vdms_panels/filedrop.py:412
 #, fuzzy
 msgid "Drag one or more Image files below"
 msgstr "拖动下面的一个或多个文件"
 
-#: ../../vdms_panels/filedrop.py:393
+#: ../../vdms_panels/filedrop.py:415
 #, fuzzy
 msgid "Drag one or more Video files below"
 msgstr "拖动下面的一个或多个文件"
 
-#: ../../vdms_panels/filedrop.py:595
+#: ../../vdms_panels/filedrop.py:623
 #, fuzzy
 msgid "Rename the file destination"
 msgstr "恢复默认的目标文件夹"
 
-#: ../../vdms_panels/filedrop.py:596
+#: ../../vdms_panels/filedrop.py:624
 msgid "Rename the selected file to:"
 msgstr "重命名选中的文件至："
 
-#: ../../vdms_panels/filedrop.py:610 ../../vdms_panels/filedrop.py:620
-#: ../../vdms_panels/filedrop.py:651
+#: ../../vdms_panels/filedrop.py:638 ../../vdms_panels/filedrop.py:648
+#: ../../vdms_panels/filedrop.py:679
 msgid "Add Files"
 msgstr "添加文件"
 
-#: ../../vdms_panels/filedrop.py:627
+#: ../../vdms_panels/filedrop.py:655
 msgid "Rename in batch"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:628
+#: ../../vdms_panels/filedrop.py:656
 #, python-brace-format
 msgid "Rename the {0} items to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:630
+#: ../../vdms_panels/filedrop.py:658
 msgid "New Name #"
 msgstr "新名称 #"
 
@@ -3651,6 +3650,10 @@ msgid ""
 "High-quality two-pass Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements\n"
 "the EBU R128 algorithm. Ideal for postprocessing."
 msgstr "激活两个通道的正常化。它使用 \"loudnorm \"滤波器对感知的响度进行归一化，该滤波器实现了EBU R128算法。"
+
+#: ../../vdms_panels/audio_encoders/acodecs.py:789
+msgid "You need to import at least one file"
+msgstr ""
 
 #: ../../vdms_panels/miscellaneous/miscell.py:63
 msgid "Subtitle Mapping:"

--- a/videomass/vdms_dialogs/showlogs.py
+++ b/videomass/vdms_dialogs/showlogs.py
@@ -6,7 +6,7 @@ Compatibility: Python3, wxPython Phoenix
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
 Copyleft - 2025 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
-Rev: July.17.2023
+Rev: July.25.2025
 Code checker: flake8, pylint
 
 This file is part of Videomass.
@@ -43,7 +43,6 @@ class ShowLogs(wx.Dialog):
                 'From Movie to Pictures.log',
                 'Still Image Maker.log',
                 'generic_task.log',
-                'YouTube Downloader.log',
                 'Queue Processing.log',
                 'Shutdown.log',
                 )

--- a/videomass/vdms_main/main_frame.py
+++ b/videomass/vdms_main/main_frame.py
@@ -6,7 +6,7 @@ Compatibility: Python3, wxPython Phoenix
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
 Copyleft - 2025 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
-Rev: July.17.2025
+Rev: July.26.2025
 Code checker: flake8, pylint
 
 This file is part of Videomass.

--- a/videomass/vdms_main/main_frame.py
+++ b/videomass/vdms_main/main_frame.py
@@ -1403,6 +1403,8 @@ class MainFrame(wx.Frame):
         self.menu_go_items((0, 1, 1, 1, 1, 1, 1))  # Go menu items
         self.delfile.Enable(False)
         self.clearall.Enable(False)
+        self.rename.Enable(False)
+        self.rename_batch.Enable(False)
         self.SetTitle(_('Videomass'))
         self.statusbar_msg(_('Ready'), None)
         self.Layout()
@@ -1423,8 +1425,12 @@ class MainFrame(wx.Frame):
         self.fileDnDTarget.Show()
         pub.sendMessage("SET_DRAG_AND_DROP_TOPIC", topic=self.topicname)
         self.menu_go_items((1, 1, 1, 1, 1, 1, 1))  # Go menu items
-        self.delfile.Enable(True)
-        self.clearall.Enable(True)
+        if self.filedropselected:
+            self.delfile.Enable(True)
+            self.rename.Enable(True)
+        if self.outputnames:
+            self.clearall.Enable(True)
+            self.rename_batch.Enable(True)
         self.openmedia.Enable(True)
         [self.toolbar.EnableTool(x, True) for x in (3, 4, 5, 6, 35)]
         [self.toolbar.EnableTool(x, False) for x in (7, 8, 36)]
@@ -1454,6 +1460,8 @@ class MainFrame(wx.Frame):
         self.menu_go_items((1, 1, 0, 1, 1, 1, 1))  # Go menu items
         self.delfile.Enable(False)
         self.clearall.Enable(False)
+        self.rename.Enable(False)
+        self.rename_batch.Enable(False)
         self.openmedia.Enable(True)
         self.loadqueue.Enable(True)
         [self.toolbar.EnableTool(x, True) for x in (3, 4, 5, 6, 7, 35, 36)]
@@ -1481,6 +1489,8 @@ class MainFrame(wx.Frame):
         self.menu_go_items((1, 0, 1, 1, 1, 1, 1))  # Go menu items
         self.delfile.Enable(False)
         self.clearall.Enable(False)
+        self.rename.Enable(False)
+        self.rename_batch.Enable(False)
         self.openmedia.Enable(True)
         self.loadqueue.Enable(True)
         [self.toolbar.EnableTool(x, True) for x in (3, 4, 5, 6, 7, 35, 36)]
@@ -1509,6 +1519,8 @@ class MainFrame(wx.Frame):
         self.menu_go_items((1, 1, 1, 0, 1, 1, 1))  # Go menu items
         self.delfile.Enable(False)
         self.clearall.Enable(False)
+        self.rename.Enable(False)
+        self.rename_batch.Enable(False)
         self.openmedia.Enable(True)
         self.loadqueue.Enable(True)
         [self.toolbar.EnableTool(x, True) for x in (3, 4, 5, 6, 7, 35)]
@@ -1536,6 +1548,8 @@ class MainFrame(wx.Frame):
         self.menu_go_items((1, 1, 1, 1, 1, 0, 1))  # Go menu items
         self.delfile.Enable(False)
         self.clearall.Enable(False)
+        self.rename.Enable(False)
+        self.rename_batch.Enable(False)
         self.openmedia.Enable(True)
         self.loadqueue.Enable(True)
         [self.toolbar.EnableTool(x, True) for x in (3, 4, 5, 6, 7, 35)]
@@ -1563,6 +1577,8 @@ class MainFrame(wx.Frame):
         self.menu_go_items((1, 1, 1, 1, 0, 1, 1))  # Go menu items
         self.delfile.Enable(False)
         self.clearall.Enable(False)
+        self.rename.Enable(False)
+        self.rename_batch.Enable(False)
         self.openmedia.Enable(True)
         self.loadqueue.Enable(True)
         [self.toolbar.EnableTool(x, True) for x in (3, 4, 5, 6, 7, 35)]
@@ -1693,17 +1709,15 @@ class MainFrame(wx.Frame):
         self.toPictures.Hide()
         self.toSlideshow.Hide()
         self.ProcessPanel.Show()
+        self.delfile.Enable(False)
+        self.clearall.Enable(False)
+        self.rename.Enable(False)
+        self.rename_batch.Enable(False)
         if not args[0] == 'View':
-            self.delfile.Enable(False)
-            self.clearall.Enable(False)
             self.menu_go_items((0, 0, 0, 0, 0, 0, 0))  # Go menu items
             self.openmedia.Enable(False)
             self.loadqueue.Enable(False)
             self.setupItem.Enable(False)
-            if self.rename.IsEnabled():
-                self.rename.Enable(False)
-            if self.rename_batch.IsEnabled():
-                self.rename_batch.Enable(False)
             [self.toolbar.EnableTool(x, True) for x in (6, 8)]
             [self.toolbar.EnableTool(x, False) for x in (3, 4, 5, 36, 37, 7)]
         else:

--- a/videomass/vdms_panels/audio_encoders/acodecs.py
+++ b/videomass/vdms_panels/audio_encoders/acodecs.py
@@ -785,8 +785,8 @@ class AudioEncoders(scrolled.ScrolledPanel):
         <https://superuser.com/questions/323119/how-can-i-normalize-audio-
         using-ffmpeg?utm_medium=organic>
         """
-        if not self.maindata.filedropselected:
-            wx.MessageBox(_("Have to select an item in the file list first"),
+        if not self.maindata.data_files:
+            wx.MessageBox(_("You need to import at least one file"),
                           'Videomass', wx.ICON_INFORMATION, self)
             return
 

--- a/videomass/vdms_panels/audio_encoders/acodecs.py
+++ b/videomass/vdms_panels/audio_encoders/acodecs.py
@@ -6,7 +6,7 @@ Compatibility: Python3, wxPython4 Phoenix
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
 Copyleft - 2025 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
-Rev: Jan.18.2025
+Rev: July.26.2025
 Code checker: flake8, pylint
 
 This file is part of Videomass.

--- a/videomass/vdms_panels/filedrop.py
+++ b/videomass/vdms_panels/filedrop.py
@@ -6,7 +6,7 @@ Compatibility: Python3, wxPython Phoenix
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
 Copyleft - 2025 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
-Rev: Feb.18.2024
+Rev: July.26.2025
 Code checker: flake8, pylint
 
 This file is part of Videomass.

--- a/videomass/vdms_panels/filedrop.py
+++ b/videomass/vdms_panels/filedrop.py
@@ -335,13 +335,35 @@ class FileDnD(wx.Panel):
             self.Bind(wx.EVT_MENU, self.onPopup, id=popupID4)
         # build the menu
         menu = wx.Menu()
-        menu.Append(popupID5, _("Play file"))
+        playfile = menu.Append(popupID5, _("Play file"))
         menu.AppendSeparator()
-        menu.Append(popupID2, _("Rename selected file\tCtrl+R"))
-        menu.Append(popupID1, _("Batch rename files\tCtrl+B"))
+        rename = menu.Append(popupID2, _("Rename selected file\tCtrl+R"))
+        rename_batch = menu.Append(popupID1, _("Batch rename files\tCtrl+B"))
         menu.AppendSeparator()
-        menu.Append(popupID3, _("Remove selected entry\tDEL"))
-        menu.Append(popupID4, _("Clear list\tShift+DEL"))
+        delfile = menu.Append(popupID3, _("Remove selected entry\tDEL"))
+        clearall = menu.Append(popupID4, _("Clear list\tShift+DEL"))
+        # Enabling the correct items
+        if self.outputnames:
+            clearall.Enable(True)
+            if len(self.outputnames) > 1:
+                rename_batch.Enable(True)
+            else:
+                rename_batch.Enable(False)
+            if self.parent.filedropselected:
+                playfile.Enable(True)
+                rename.Enable(True)
+                delfile.Enable(True)
+            else:
+                playfile.Enable(False)
+                rename.Enable(False)
+                delfile.Enable(False)
+        else:
+            playfile.Enable(False)
+            rename.Enable(False)
+            rename_batch.Enable(False)
+            delfile.Enable(False)
+            clearall.Enable(False)
+
         # show the popup menu
         self.PopupMenu(menu)
         menu.Destroy()
@@ -367,7 +389,7 @@ class FileDnD(wx.Panel):
             self.on_delete_selected(None)
 
         elif menuItem.GetItemLabel() == _("Clear list\tShift+DEL"):
-            self.delete_all(None)
+            self.delete_all(event)  # need pass event here
 
         elif menuItem.GetItemLabel() == _("Play file"):
             self.on_play_select(None)
@@ -431,7 +453,7 @@ class FileDnD(wx.Panel):
             elif event.GetColumn() == 5:
                 curritems.sort(key=lambda item: item[4])
 
-            self.delete_all(None, setstate=False)  # does not setstate here
+            self.delete_all(None, setstate=False)  # no event, no setstate here
 
             if self.sortingstate == 'descending':
                 self.sortingstate = 'ascending'
@@ -459,12 +481,15 @@ class FileDnD(wx.Panel):
             self.parent.rename_batch.Enable(True)
         else:
             self.parent.rename_batch.Enable(False)
+        self.parent.clearall.Enable(True)
 
         if setfocus:
             sel = self.flCtrl.GetFocusedItem()  # Get the current row
             selitem = sel if sel != -1 else 0
             self.flCtrl.Focus(selitem)  # make the line the current line
             self.flCtrl.Select(selitem, on=1)  # default event selection
+
+        pub.sendMessage("RESET_ON_CHANGED_LIST", msg=None)
     # ----------------------------------------------------------------------
 
     def on_play_select(self, event):
@@ -538,8 +563,9 @@ class FileDnD(wx.Panel):
             self.changes_in_progress(setfocus=False)
             self.parent.rename.Enable(False)
             self.parent.rename_batch.Enable(False)
+            self.parent.delfile.Enable(False)
+            self.parent.clearall.Enable(False)
             self.parent.filedropselected = None
-            pub.sendMessage("RESET_ON_CHANGED_LIST", msg=None)
         if setstate:
             self.sortingstate = None
             self.parent.toolbar.EnableTool(9, False)
@@ -553,6 +579,7 @@ class FileDnD(wx.Panel):
         item = self.flCtrl.GetItemText(index, 1)
         self.parent.filedropselected = item
         self.parent.rename.Enable(True)
+        self.parent.delfile.Enable(True)
         pub.sendMessage("RESET_ON_CHANGED_LIST", msg=index)
     # ----------------------------------------------------------------------
 
@@ -563,6 +590,7 @@ class FileDnD(wx.Panel):
         """
         self.parent.filedropselected = None
         self.parent.rename.Enable(False)
+        self.parent.delfile.Enable(False)
         pub.sendMessage("RESET_ON_CHANGED_LIST", msg=None)
     # ----------------------------------------------------------------------
 

--- a/videomass/vdms_threads/volumedetect.py
+++ b/videomass/vdms_threads/volumedetect.py
@@ -153,7 +153,8 @@ class VolumeDetectThread(Thread):
         write ffmpeg command log
         """
         with open(self.logf, "a", encoding='utf-8') as log:
-            log.write(f"{cmd}\n")
+            line = '=' * 80
+            log.write(f"\n{line}\n{cmd}\n")
     # ----------------------------------------------------------------#
 
     def logerror(self, output):

--- a/videomass/vdms_threads/volumedetect.py
+++ b/videomass/vdms_threads/volumedetect.py
@@ -6,7 +6,7 @@ Compatibility: Python3, wxPython Phoenix
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
 Copyleft - 2025 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
-Rev: Apr.23.2024
+Rev: July.26.2025
 Code checker: flake8, pylint
 
 This file is part of Videomass.


### PR DESCRIPTION
improves #398 

This PR fixes `IndexError: list index out of range` stack-traces raised if audio volumedetected list is not `None` while the user import new files and Run transcoding process. To prevent this error is been needed to reset some data structure whenever removing or importing new files.

The "Volume detect" feature will now require at least one file to activate, rather than a selection.

In addition, the "Edit" menu and the pop-up menu for the File List panel have been corrected to reflect user actions. This will enable or disable some menu items.



