### PR TITLE
POT/PO file - no obsolete/source ref. - long line no forced CR/LF

### DIFF
--- a/develop/gettext_utils/create_POT_file.sh
+++ b/develop/gettext_utils/create_POT_file.sh
@@ -32,7 +32,7 @@ DATA=$(<"${CATALOG}")  # read catalog data
 
 cd "${TARGET}"
 #xgettext --width=400 --default-domain videomass ${DATA}
-pygettext3 -v -o videomass.pot $DATA
+pygettext3 --no-location --width=400 -v -o videomass.pot $DATA
 
 
 if [[ $? -ne 0 ]]; then

--- a/develop/gettext_utils/update_PO_files.sh
+++ b/develop/gettext_utils/update_PO_files.sh
@@ -35,7 +35,7 @@ do
         exit $?
     fi
     # remove obsolete strings
-    msgattrib --no-obsolete $PO > temp.po
+    msgattrib --no-obsolete --width=400 --no-wrap --no-location $PO > temp.po
     \cp -rf temp.po $PO
     \rm test.po
     echo "Update '${langdirs}LC_MESSAGES/videomass.po' ...OK"


### PR DESCRIPTION
@jeanslack 

Add options to create a pot file without source refences.

Add options to have always long lines without forced CR/LF without obsolete strings and without source references.

It help to monitor real changing in the strings files and not change in source code referencers line refrred to translation.

Ex,. I monitored last two po file changes in italian language but are not strings changes but only source code line refences changes.

' https://www.commandlinux.com/man-page/man1/pygettext3.1.html
pygettext3 --no-location --width=400 -v -o videomass.pot $DATA
' --no-location - Do not write filename/lineno location comments.
' --width=400 - Set width of output to 400 chars for line.

The first option remove internal source code references.
It useful to get not right info monitoring translation changes when there is a source changes and not string changes

The second option don't add forced break after 77/80' chars.
