### PR TITLE
Improve contextual help for video filters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,7 +7,7 @@ License: GPL3
 Change Log:
 
 +------------------------------------+
-Tue, 29 July 2025 v6.1.13
+Wed, 30 July 2025 v6.1.13
 
   * Fixed "Go" menu item that was incorrectly left enabled on "Output Monitor"
     during transcoding processes, leaving the user able to click on it, leading
@@ -36,6 +36,8 @@ Tue, 29 July 2025 v6.1.13
     added by @bovirus in #401 .
   * Fixed typo on shownormalist.py incorrectly aliased to _(
   * Fixed typo on sequence_to_video.py incorrectly aliased to _(
+  * Added contextual help for all video filters. Clicking the contextual help
+    buttons will direct the user to the corresponding web page.
 
 +------------------------------------+
 Tue, 15 July 2025 v6.1.12

--- a/videomass/data/locale/ar_SA/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/ar_SA/LC_MESSAGES/videomass.po
@@ -1,13 +1,13 @@
-# Arabic (Saudi Arabia) translations for PROJECT.
-# Copyright (C) 2024 ORGANIZATION
-# This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+# Arabic (Saudi Arabia) translations for Videomass.
+# Copyright (C) 2025 ORGANIZATION
+# This file is distributed under the same license as the Videomass project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-26 15:04+0200\n"
+"POT-Creation-Date: 2025-07-30 11:02+0200\n"
 "PO-Revision-Date: 2024-07-17 16:34+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ar_SA\n"
@@ -18,7 +18,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
-#: ../../gui_app.py:196
 #, python-brace-format
 msgid ""
 "Unexpected error while deleting file contents:\n"
@@ -26,162 +25,111 @@ msgid ""
 "{0}"
 msgstr ""
 
-#: ../../vdms_dialogs/about_dialog.py:52
 msgid "Cross-platform graphical user interface for FFmpeg\n"
 msgstr ""
 
-#: ../../vdms_dialogs/audioproperties.py:224
 msgid "Videomass supports mono and stereo audio channels. If you are not sure set to \"Auto\" and source values will be copied."
 msgstr ""
 
-#: ../../vdms_dialogs/audioproperties.py:228
 msgid "The audio Rate (or sample-rate) is the sound sampling frequency and is measured in Hertz. The higher the frequency, the more true it will be to the sound source and the more the file will increase in size. For audio CD playback, set a sampling frequency of 44100 kHz. If you are not sure, set to \"Auto\" and source values will be copied."
 msgstr ""
 
-#: ../../vdms_dialogs/audioproperties.py:237
 msgid "The audio bitrate affects the file compression and thus the quality of listening. The higher the value, the higher the quality."
 msgstr ""
 
-#: ../../vdms_dialogs/audioproperties.py:241
 msgid "Bit depth is the number of bits of information in each sample, and it directly corresponds to the resolution of each sample. Bit depth is only meaningful in reference to a PCM digital signal. Non-PCM formats, such as lossy compression formats, do not have associated bit depths."
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:74 ../../vdms_dialogs/queuedlg.py:120
 msgid "When finished, once the operations have been completed successfully:"
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:80 ../../vdms_dialogs/queuedlg.py:126
 msgid "Trash the source files"
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:84 ../../vdms_dialogs/queuedlg.py:130
 msgid "Clear the File List"
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:91 ../../vdms_dialogs/queuedlg.py:142
-#: ../../vdms_main/main_frame.py:1322
 msgid "Run"
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:97
 msgid "Videomass - Batch Mode"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:47
 msgid "FFmpeg encoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:48
 msgid "supported encoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:50
 msgid "FFmpeg decoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:51
 msgid "supported decoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:77
-#: ../../vdms_panels/av_conversions.py:293
 msgid "Video"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:87
-#: ../../vdms_panels/av_conversions.py:305
 msgid "Audio"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:97
 msgid "Subtitle"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:114
-#: ../../vdms_dialogs/ffmpeg_codecs.py:123
-#: ../../vdms_dialogs/ffmpeg_codecs.py:132
-#: ../../vdms_dialogs/ffmpeg_formats.py:112
-#: ../../vdms_dialogs/ffmpeg_formats.py:115
-#: ../../vdms_dialogs/ffmpeg_formats.py:118
 msgid "description"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:72
 msgid "Informations"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:83
 msgid "Flags settings"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:93
 msgid "Flags enabled"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:103
 msgid "Flags disabled"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:116
 msgid "FFmpeg configuration"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:124
 msgid "flags"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:125 ../../vdms_dialogs/ffmpeg_conf.py:129
-#: ../../vdms_dialogs/ffmpeg_conf.py:133
 msgid "options"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:128 ../../vdms_dialogs/ffmpeg_conf.py:132
 msgid "status"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:167
 msgid "FFprobe   ...not found !"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:175
 msgid "FFplay   ...not found !"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:205
-#: ../../vdms_panels/sequence_to_video.py:706
-#: ../../vdms_panels/video_to_sequence.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:216
-#: ../../vdms_panels/sequence_to_video.py:706
-#: ../../vdms_panels/video_to_sequence.py:610
 msgid "Disabled"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:71
 msgid "Demuxing only"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:82
 msgid "Muxing only"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:93
 msgid "Demuxing/Muxing support"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:104
 msgid "FFmpeg file formats"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:111
-#: ../../vdms_dialogs/ffmpeg_formats.py:114
-#: ../../vdms_dialogs/ffmpeg_formats.py:117
 msgid "supported formats"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:46
 msgid ""
 "Contextual help based on the argument entered in the additional text field.\n"
 "Each argument consists of the type and a type-specific name.\n"
@@ -196,117 +144,84 @@ msgid ""
 "Some examples:"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:68 ../../vdms_dialogs/ffmpeg_help.py:301
-#: ../../vdms_dialogs/ffmpeg_help.py:315
 msgid "Help topic"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:69
 msgid "List basic options"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:70
 msgid "List more options"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:71
 msgid "List all options (very long)"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:72
 msgid "Show available devices"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:73
 msgid "Show available bit stream filters"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:74
 msgid "Show available protocols"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:75
 msgid "Show available filters"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:76
 msgid "Show available pixel formats"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:77
 msgid "Show available audio sample formats"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:78
 msgid "Show available color names"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:79
 msgid "List sources of the input device"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:80
 msgid "List sinks of the output device"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:81
 msgid "Show available HW acceleration methods"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:82
 msgid "Show license"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:117 ../../vdms_dialogs/filter_scale.py:76
-#: ../../vdms_dialogs/shownormlist.py:98 ../../vdms_dialogs/shownormlist.py:107
-#: ../../vdms_dialogs/shownormlist.py:116 ../../vdms_miniframes/timeline.py:263
-#: ../../vdms_miniframes/timeline.py:283 ../../vdms_panels/concatenate.py:117
-#: ../../vdms_panels/sequence_to_video.py:117
-#: ../../vdms_panels/video_to_sequence.py:81
 msgid "Read me"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:123 ../../vdms_main/main_frame.py:534
 msgid "Show configuration"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:127 ../../vdms_main/main_frame.py:542
 msgid "Encoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:131 ../../vdms_main/main_frame.py:545
 msgid "Decoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:135 ../../vdms_main/main_frame.py:538
 msgid "Muxers and Demuxers"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:165
 msgid "help topic list"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:184
 msgid "Type the argument here and confirm with the enter key on your keyboard"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:192
 msgid "The search function allows you to find entries in the current topic"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:195
 msgid "Ignore case"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:196
 msgid "Ignore case distinctions: characters with different case will match."
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:206
 msgid "FFmpeg help topics"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:254
 msgid ""
 "This is a multifunctional search tool useful for local help searches\n"
 "on multiple FFmpeg topics and options. The search control, to\n"
@@ -319,942 +234,647 @@ msgid ""
 "with those features."
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:320 ../../vdms_dialogs/ffmpeg_help.py:345
-#: ../../vdms_dialogs/ffmpeg_help.py:371
 msgid ""
 "\n"
 "  ..Nothing available"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:391
 msgid ""
 "\n"
 "  ..Not found"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:91
 msgid "Before"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:97
 msgid "After"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:103
-#: ../../vdms_dialogs/filter_crop.py:239
 msgid "Search for a specific frame"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:117
-#: ../../vdms_dialogs/filter_crop.py:253
 msgid "Load"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:120
 msgid "Color EQ"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:126
 msgid "Contrast:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:134
-#: ../../vdms_dialogs/filter_colorcorrection.py:148
 msgid "-100 to +100, default value 0"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:139
 msgid "Brightness:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:158
 msgid "Saturation:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:166
 msgid "0 to 300, default value 100"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:170
 msgid "Gamma:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:179
 msgid "0 to 100, default value 10"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:187
-#: ../../vdms_dialogs/filter_crop.py:306
-#: ../../vdms_dialogs/filter_deinterlace.py:209
-#: ../../vdms_dialogs/filter_denoisers.py:110
-#: ../../vdms_dialogs/filter_scale.py:210 ../../vdms_dialogs/filter_stab.py:316
-#: ../../vdms_dialogs/filter_transpose.py:105
-#: ../../vdms_miniframes/timeline.py:262 ../../vdms_miniframes/timeline.py:281
 msgid "Reset"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:207
 msgid "Color Correction EQ Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:343
-#: ../../vdms_dialogs/filter_colorcorrection.py:383
-#: ../../vdms_dialogs/filter_colorcorrection.py:390
-#: ../../vdms_dialogs/filter_crop.py:417 ../../vdms_dialogs/filter_scale.py:287
-#: ../../vdms_dialogs/filter_scale.py:394 ../../vdms_dialogs/filter_stab.py:473
-#: ../../vdms_dialogs/filter_stab.py:483 ../../vdms_dialogs/filter_stab.py:494
-#: ../../vdms_dialogs/filter_transpose.py:182
-#: ../../vdms_dialogs/mediainfo.py:245 ../../vdms_dialogs/mediainfo.py:265
-#: ../../vdms_dialogs/mediainfo.py:285 ../../vdms_dialogs/mediainfo.py:305
-#: ../../vdms_dialogs/setting_profiles.py:281
-#: ../../vdms_dialogs/setting_profiles.py:289 ../../vdms_io/checkup.py:45
-#: ../../vdms_io/checkup.py:93 ../../vdms_io/io_tools.py:144
-#: ../../vdms_main/main_frame.py:904 ../../vdms_main/main_frame.py:939
-#: ../../vdms_main/main_frame.py:961 ../../vdms_main/main_frame.py:979
-#: ../../vdms_main/main_frame.py:999
-#: ../../vdms_panels/audio_encoders/acodecs.py:510
-#: ../../vdms_panels/audio_encoders/acodecs.py:800
-#: ../../vdms_panels/concatenate.py:186
-#: ../../vdms_panels/long_processing_task.py:60
-#: ../../vdms_panels/presets_manager.py:426
-#: ../../vdms_panels/presets_manager.py:490
-#: ../../vdms_panels/presets_manager.py:560
-#: ../../vdms_panels/presets_manager.py:599
-#: ../../vdms_panels/presets_manager.py:619
-#: ../../vdms_panels/presets_manager.py:657
-#: ../../vdms_panels/presets_manager.py:701
-#: ../../vdms_panels/presets_manager.py:714
-#: ../../vdms_panels/presets_manager.py:721
-#: ../../vdms_panels/presets_manager.py:756
-#: ../../vdms_panels/presets_manager.py:785
-#: ../../vdms_panels/presets_manager.py:791
-#: ../../vdms_panels/sequence_to_video.py:467
-#: ../../vdms_panels/sequence_to_video.py:473
-#: ../../vdms_panels/sequence_to_video.py:561
-#: ../../vdms_panels/sequence_to_video.py:571
-#: ../../vdms_panels/sequence_to_video.py:588
-#: ../../vdms_panels/sequence_to_video.py:596
-#: ../../vdms_panels/sequence_to_video.py:602
-#: ../../vdms_panels/sequence_to_video.py:643
-#: ../../vdms_panels/sequence_to_video.py:689
-#: ../../vdms_panels/video_to_sequence.py:512
-#: ../../vdms_panels/video_to_sequence.py:583
-#: ../../vdms_threads/ffplay_file.py:43
-#: ../../vdms_utils/presets_manager_utils.py:86
-#: ../../vdms_utils/presets_manager_utils.py:95
-#: ../../vdms_utils/queue_utils.py:68 ../../vdms_utils/queue_utils.py:82
-#: ../../vdms_utils/queue_utils.py:95
 msgid "Videomass - Error!"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:228 ../../vdms_dialogs/filter_scale.py:109
 #, python-brace-format
 msgid "Source size: {0} x {1} pixels"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:236
 msgid "Crop color"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:256
 msgid "Cropping area selection "
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:261 ../../vdms_dialogs/filter_scale.py:121
 msgid "Height"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:281
 msgid "Center"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:292 ../../vdms_dialogs/filter_scale.py:121
 msgid "Width"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:334
 msgid "Crop Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:335
 msgid "Choose the color to draw the cropping area"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:337
 msgid "Crop to width"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:338
 msgid "Move vertically (set to -1 to center the vertical axis)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:340
 msgid "Move horizontally (set to -1 to center the horizontal axis)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:342
 msgid "Crop to height"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:56
 msgid "Advanced Options"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:57
-#: ../../vdms_panels/av_conversions.py:351
 msgid "Deinterlace"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:59
 msgid "Interlace"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:63
 msgid "Deinterlaces with w3fdif filter"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:77
 msgid "Deinterlaces with yadif filter"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:101
 msgid "Interlaces with interlace filter"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:118
 msgid "Deinterlacing and Interlacing"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:144
 msgid "Deinterlace the input video with `w3fdif` filter"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:146
 msgid "Set the interlacing filter coefficients."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:148
-#: ../../vdms_dialogs/filter_deinterlace.py:158
 msgid "Specify which frames to deinterlace."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:150
 msgid "Deinterlace the input video with `yadif` filter. Using FFmpeg, this is the best and fastest choice"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:153
 msgid ""
 "mode\n"
 "The interlacing mode to adopt."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:155
 msgid ""
 "parity\n"
 "The picture field parity assumed for the input interlaced video."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:160
 msgid "Simple interlacing filter from progressive contents."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:162
 msgid ""
 "scan:\n"
 "determines whether the interlaced frame is taken from the even (tff - default) or odd (bff) lines of the progressive frame."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:166
 msgid ""
 "lowpass:\n"
 "Enable (default) or disable the vertical lowpass filter to avoid twitter interlacing and reduce moire patterns.\n"
 "Default is no setting."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:56
 msgid "Denoiser Filters"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:60
 msgid "Enable nlmeans denoiser"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:73
 msgid "nlmeans options"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:82
 msgid "Enable hqdn3d denoiser"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:91
 msgid "hqdn3d options"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:116
 msgid "Denoiser Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:117
 msgid ""
 "nlmeans:\n"
 "Denoise frames using Non-Local Means algorithm is capable of restoring video sequences, even with strong noise. It is ideal for enhancing the quality of old VHS tapes."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:122
 msgid ""
 "hqdn3d:\n"
 "This is a high precision/quality 3d denoise filter. It aims to reduce image noise, producing smooth images and making still images really still. It should enhance compressibility."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:81
 msgid "View result"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:85
 msgid "New size in pixels"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:89
 msgid "Width:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:99
 msgid "Height:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:115
 msgid "Constrain proportions (keep aspect ratio)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:120
 msgid "Which dimension to adjust?"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:129
 msgid "Aspect Ratio"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:132
 msgid "Setdar filter (display aspect ratio) example 16/9, 4/3 "
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:137
-#: ../../vdms_dialogs/filter_scale.py:171
 msgid "Numerator"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:162
-#: ../../vdms_dialogs/filter_scale.py:196
 msgid "Denominator"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:166
 msgid "Setsar filter (sample aspect ratio) example 1/1"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:217
 msgid "Resize Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:218
 msgid "Scale filter, set to 0 to disable"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:221
 msgid "Display Aspect Ratio. Set to 0 to disable"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:224
 msgid ""
 "Sample (aka Pixel) Aspect Ratio.\n"
 "Set to 0 to disable"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:366
 msgid ""
 "If you want to keep the aspect ratio, select \"Constrain proportions\" below and\n"
 "specify only one dimension, either width or height, and set the other dimension\n"
 "to -1 or -2 (some codecs require -2, so you should do some testing first)."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:81
 msgid "Enable stabilizer"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:83
 msgid "Create a side-by-side comparison video"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:88
 msgid "Create a snapshot"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:106
-#: ../../vdms_panels/audio_encoders/acodecs.py:167
 msgid "Preview"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:109
 msgid "Duration seconds:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:118
 msgid "Video Detect"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:176
 msgid "[TRIPOD] Enable tripod mode if checked"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:183
 msgid "Video transform"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:202
 msgid "[OPTALGO] optimization algorithm"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:224
 msgid "[CROP] Specify how to deal with borders at movement compensation"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:231
 msgid "[INVERT] Invert transforms if checked"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:234
 msgid "[RELATIVE] Consider transforms as relative to previous frame if checked, absolute if unchecked"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:279
 msgid "Specify type of interpolation"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:287
 msgid "[TRIPOD2] virtual tripod mode, equivalent to relative=unchecked:smoothing=0"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:294
 msgid "Unsharp filter:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:323
 msgid "Seek to a position on the video."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:325
 msgid "Make a snapshot of the video with the settings made."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:327
 msgid "Set the snapshot duration from 3 to 15 seconds from the seek position, default is 5 seconds."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:331
 msgid "Set how shaky the video is and how quick the camera is. A value of 1 means little shakiness, a value of 10 means strong shakiness. Default value is 5."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:335
 msgid "Set the accuracy of the detection process. A value of 1 means low accuracy, a value of 15 means high accuracy. Default value is 15."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:339
 msgid "Set stepsize of the search process. The region around minimum is scanned with 1 pixel resolution. Default value is 6."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:343
 msgid "Set minimum contrast. Below this value a local measurement field is discarded. The range is 0-1. Default value is 0.25."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:346
 msgid "Set reference frame number for tripod mode. If enabled, the motion of the frames is compared to a reference frame in the filtered stream, identified by the specified number. The idea is to compensate all movements in a more-or-less static scene and keep the camera view absolutely still. The frames are counted starting from 1."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:355
-msgid "Set the number of frames (value*2 + 1) used for lowpass filtering the camera movements. Default value is 15. For example a number of 10 means that 21 frames are used (10 in the past and 10 in the future) to smoothen the motion in the video. A larger value leads to a smoother video, but limits the acceleration of the camera (pan/tilt movements). 0 is a special case where a static camera is simulated."
+msgid ""
+"Set the number of frames (value*2 + 1) used for lowpass filtering the camera movements. Default value is 15. For example a number of 10 means that 21 frames are used (10 in the past and 10 in the future) to smoothen the motion in the video. A larger value leads to a smoother video, but limits the acceleration of the camera (pan/tilt movements). 0 is a special case where a static camera is "
+"simulated."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:363
 msgid "Set the camera path optimization algorithm. Values are: `gauss`: gaussian kernel low-pass filter on camera motion (default), and `avg`: averaging on transformations"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:367
 msgid "Set maximal angle in radians (degree*PI/180) to rotate frames. Default value is -1, meaning no limit."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:370
 msgid "Specify how to deal with borders that may be visible due to movement compensation. Values are: `keep` keep image information from previous frame (default), `black` fill the border black"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:375
 msgid "Invert transforms if checked. Default is unchecked."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:377
 msgid "Consider transforms as relative to previous frame if checked, absolute if unchecked. Default is checked."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:380
 msgid "Set percentage to zoom. A positive value will result in a zoom-in effect, a negative value in a zoom-out effect. Default value is 0 (no zoom)."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:384
 msgid "Set optimal zooming to avoid borders. Accepted values are: `0` disabled, `1` optimal static zoom value is determined (only very strong movements will lead to visible borders) (default), `2` optimal adaptive zoom value is determined (no borders will be visible), see zoomspeed. Note that the value given at zoom is added to the one calculated here."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:391
 msgid "Set percent to zoom maximally each frame (enabled when optzoom is set to 2). Range is from 0 to 5, default value is 0.25."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:395
 msgid "Specify type of interpolation. Available values are: `no` no interpolation, `linear` linear only horizontal, `bilinear` linear in both directions (default), `bicubic` cubic in both directions (slow)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:400
 msgid "Enable virtual tripod mode if checked, which is equivalent to relative=0:smoothing=0. Default is unchecked. Use also tripod option of vidstabdetect."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:405
 msgid "Sharpen or blur the input video. Note the use of the unsharp filter which is always recommended."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:409
 msgid "Video Stabilizer Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:541 ../../vdms_io/io_tools.py:73
 msgid "Videomass - Loading..."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:542
 msgid ""
 "Please wait,\n"
 "This process will take a few seconds."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:80
-#: ../../vdms_dialogs/filter_transpose.py:293
 msgid "Default position"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:86
 msgid "Rotation setting"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:94
 msgid "90° (left)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:96
 msgid "90° (right)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:100
 msgid "180°"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:115
 msgid "Transpose Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:229
 msgid "Rotate 90 degrees right"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:251
 msgid "Rotate 180 degrees"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:272
 msgid "Rotate 90 degrees left"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:82
 msgid "Format"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:96
 msgid "Video Stream"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:109
 msgid "Audio Streams"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:122
 msgid "Subtitle Streams"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:126
 msgid "Copy to clipboard"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:137
 msgid "FILE SELECTION"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:139 ../../vdms_dialogs/mediainfo.py:142
-#: ../../vdms_dialogs/mediainfo.py:145 ../../vdms_dialogs/mediainfo.py:148
-#: ../../vdms_main/main_frame.py:1318
 msgid "Properties"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:140 ../../vdms_dialogs/mediainfo.py:143
-#: ../../vdms_dialogs/mediainfo.py:146 ../../vdms_dialogs/mediainfo.py:149
 msgid "Values"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:152
 msgid "Streams Properties"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:244
 msgid "Unable to open the clipboard on Format tab"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:263
 msgid "Unable to open the clipboard on Video Streams tab"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:283
 msgid "Unable to open the clipboard on Audio Streams tab"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:303
 msgid "Unable to open the clipboard on Subtitle Streams tab"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:90
 msgid "Where do you prefer to save your transcodes?"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:101 ../../vdms_dialogs/preferences.py:128
-#: ../../vdms_dialogs/preferences.py:149 ../../vdms_dialogs/preferences.py:161
-#: ../../vdms_dialogs/preferences.py:173 ../../vdms_panels/filedrop.py:284
 msgid "Change"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:103
-#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:602
-#: ../../vdms_panels/presets_manager.py:1050
 msgid "Same destination paths as source files"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:108
 msgid "Assign optional suffix to destination file names:"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:114
 msgid "File removal preferences"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:118
 msgid "Trash the source files after successful encoding"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:131
 msgid "File Preferences"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:138
 msgid "Location of executables"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:140
 msgid ""
 "FFmpeg can be built by enabling/disabling its options and this depends on your needs.\n"
 "For some use cases it is possible to provide a custom build of FFmpeg where you can specify\n"
 "it in this preferences tab."
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:147
 msgid "Enable a custom location to run FFmpeg"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:159
 msgid "Enable a custom location to run FFprobe"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:171
 msgid "Enable a custom location to run FFplay"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:183
 msgid "FFmpeg"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:189
 msgid "Look and Feel (requires application restart)"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:194
 msgid "Icon themes"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:208
 msgid "At the top of window (default)"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:209
 msgid "At the bottom of window"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:210
 msgid "At the right of window"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:211
 msgid "At the left of window"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:213
 msgid "Place the toolbar"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:222
 msgid "Toolbar's icons size:"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:236
 msgid "Application Language (requires application restart)"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:248
 msgid "Look and Language"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:254
 msgid "Upon exiting the application"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:259
 msgid "Always ask me to confirm"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:261
 msgid "Clean the log files"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:264
 msgid "Remove cached files"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:268
 msgid "On operations completion"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:271
 msgid "These settings will remain active until the application is closed, If necessary, remember to reactivate them."
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:276
 msgid "Exit the application"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:279
 msgid "Shutdown the system"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:283
 msgid "SUDO password:"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:292
 msgid "Exit and Shutdown"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:298
 msgid "Specify the character encoding format"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:301
 msgid ""
 "Although UTF-8 is the default and most widely used standard encoding format, it is not the only encoding format available.\n"
 "Some file metadata may still contain non-UTF-8 character encodings resulting in the error \"'utf-8' codec can't decode bytes...\".\n"
 "If you know the encoding format the file was written in, you can try specifying it here, e.g. ISO 8859-1, ISO 8859-16, etc."
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:311
 msgid "Character encoding:"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:320
 msgid "Default application directories"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:324
 msgid "Configuration directory"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:337
 msgid "Cache directory"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:349
 msgid "Log directory"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:363
 msgid "Advanced"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:369
 msgid ""
 "The following settings affect output messages and the log messages during transcoding processes.\n"
 "Be careful, by changing these settings some functions of the application may not work correctly,\n"
 "change only if you know what you are doing.\n"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:376
 msgid "Set logging level flags used by FFmpeg"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:383
 msgid "Set logging level flags used by FFplay"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:391
 msgid "FFmpeg logging levels"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:437
 msgid "By assigning an additional suffix you could avoid overwriting files"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:440
 msgid "Type sudo password here, only for Unix-like operating systems, not for MS Windows"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:443
 msgid "Preferences"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:596 ../../vdms_dialogs/preferences.py:676
-#: ../../vdms_main/main_frame.py:879 ../../vdms_main/main_frame.py:1060
 msgid "Choose Destination"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:627
 msgid "Enter only alphanumeric characters. You can also use the hyphen (\"-\") and the underscore (\"_\"). Spaces are not allowed."
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:642
-#: ../../vdms_dialogs/setting_profiles.py:257
-#: ../../vdms_dialogs/setting_profiles.py:264
-#: ../../vdms_dialogs/setting_profiles.py:286
-#: ../../vdms_dialogs/setting_profiles.py:309 ../../vdms_main/main_frame.py:399
-#: ../../vdms_main/main_frame.py:421 ../../vdms_panels/av_conversions.py:605
-#: ../../vdms_panels/av_conversions.py:612
-#: ../../vdms_panels/sequence_to_video.py:352
-#: ../../vdms_panels/video_to_sequence.py:399
 msgid "Videomass - Warning!"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:731 ../../vdms_dialogs/preferences.py:771
-#: ../../vdms_dialogs/preferences.py:811 ../../vdms_dialogs/wizard_dlg.py:365
-#: ../../vdms_dialogs/wizard_dlg.py:384 ../../vdms_dialogs/wizard_dlg.py:403
 #, python-brace-format
 msgid "{} location"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:36
-#: ../../vdms_dialogs/setting_profiles.py:38
 msgid "One-Pass, Do not start with `ffmpeg -i filename`; do not end with `output-filename`"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:40
-#: ../../vdms_dialogs/setting_profiles.py:42
 msgid "Two-Pass (optional), Do not start with `ffmpeg -i filename`; do not end with `output-filename`"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:59
 msgid "Videomass - Edit the selected item in the queue"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:71
-#: ../../vdms_dialogs/setting_profiles.py:92
 msgid "Pre-input arguments for One-Pass (optional)"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:82
-#: ../../vdms_dialogs/setting_profiles.py:151
-#: ../../vdms_panels/presets_manager.py:255
 msgid "FFmpeg arguments for one-pass encoding"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:88
-#: ../../vdms_dialogs/setting_profiles.py:158
-#: ../../vdms_panels/presets_manager.py:259
 msgid "Any optional arguments to add before input file on the one-pass encoding, e.g required names of some hardware accelerations like -hwaccel to use with CUDA."
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:102
-#: ../../vdms_dialogs/setting_profiles.py:98
 msgid "Pre-input arguments for Two-Pass (optional)"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:113
-#: ../../vdms_dialogs/setting_profiles.py:152
-#: ../../vdms_panels/presets_manager.py:257
 msgid "FFmpeg arguments for two-pass encoding"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:120
-#: ../../vdms_dialogs/setting_profiles.py:162
-#: ../../vdms_panels/presets_manager.py:263
 msgid "Any optional arguments to add before input file on the two-pass encoding, e.g required names of some hardware accelerations like -hwaccel to use with CUDA."
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:65 ../../vdms_main/main_frame.py:508
-#: ../../vdms_panels/presets_manager.py:189
-#: ../../vdms_panels/video_to_sequence.py:171
 msgid "Edit"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:68
 msgid "Remove"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:71
 msgid "Remove all"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:74
 msgid ""
 "Export\n"
 "queue file"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:77
 msgid ""
 "Import\n"
 "queue file"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:85 ../../vdms_panels/filedrop.py:273
 msgid "Destination file name"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:137
 msgid "Remove all items in the queue"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:151
 msgid "Videomass - Queue"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:228
 msgid "Export queue file"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:296 ../../vdms_panels/av_conversions.py:1192
-#: ../../vdms_panels/presets_manager.py:1044
-#: ../../vdms_panels/video_to_sequence.py:600
 msgid "Same as source"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:301
 msgid ""
 "Source\n"
 "File destination\n"
@@ -1265,186 +885,129 @@ msgid ""
 "Clip duration"
 msgstr ""
 
-#: ../../vdms_dialogs/renamer.py:76
 msgid "# will be replaced by ascending numbers starting with:"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:87
 msgid "Font Size"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:111
 msgid "Font Color"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:121
 msgid "Shadow Color"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:132
 msgid "Show text box"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:136
 msgid "Box Color"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:156
 msgid "The timestamp size does not auto-adjust to the video size, you have to set the size here"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:160 ../../vdms_main/main_frame.py:559
 msgid "Timestamp settings"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:46
 msgid "Supported Formats list (optional). Do not include the `.`"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:47
 msgid "Output Format. Empty to copy format and codec. Do not include the `.`"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:70
 msgid "Profile Name"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:74
-#: ../../vdms_panels/presets_manager.py:404
 msgid "Description"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:149
 msgid "A short profile name"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:150
 msgid "A long description of the profile"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:153
 msgid "One or more comma-separated format names compatible with this profile"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:155
 msgid "Output format extension. Leave empty to copy codec and format"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:256
 msgid "Incomplete profile assignments"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:263
 msgid "Formats must be comma-separated"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:279
-#: ../../vdms_utils/queue_utils.py:80
 #, python-brace-format
 msgid ""
 "ERROR: Keys mismatched for requested data.\n"
 "Invalid file: «{0}»"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:285
-#: ../../vdms_dialogs/setting_profiles.py:308
 msgid "Profile already stored with same name"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:293
 msgid "Profile stored successfully!"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:311
 msgid "Profile change successful!"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:80
 msgid "Log file list"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:82 ../../vdms_dialogs/showlogs.py:116
 msgid "Log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:105
 msgid "Refresh log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:107
 msgid "Clear log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:160
 msgid "Select a log file"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:167
 msgid "Are you sure you want to clear the selected log file?"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:168 ../../vdms_dialogs/wizard_dlg.py:251
-#: ../../vdms_io/checkup.py:68 ../../vdms_main/main_frame.py:205
-#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1685
-#: ../../vdms_panels/presets_manager.py:349
-#: ../../vdms_panels/presets_manager.py:550
-#: ../../vdms_panels/presets_manager.py:590
-#: ../../vdms_panels/presets_manager.py:649
-#: ../../vdms_panels/presets_manager.py:684
-#: ../../vdms_panels/presets_manager.py:749
-#: ../../vdms_panels/presets_manager.py:775
-#: ../../vdms_panels/presets_manager.py:874
-#: ../../vdms_panels/presets_manager.py:904
 msgid "Please confirm"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:83
 msgid "File name"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:84
 msgid "Max volume dBFS"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:85
 msgid "Mean volume dBFS"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:86
 msgid "Offset dBFS"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:87
 msgid "Result dBFS"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:92
 msgid "Post-normalization references:"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:102
 msgid "=  Clipped peaks"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:111
 msgid "=  No changes"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:121
 msgid "=  Below max peak"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:166
-#: ../../vdms_panels/audio_encoders/acodecs.py:841
 msgid "RMS-based volume statistics"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:191
-#: ../../vdms_panels/audio_encoders/acodecs.py:839
 msgid "PEAK-based volume statistics"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:216
 msgid ""
 "...It means the resulting audio will be clipped,\n"
 "because its volume is higher than the maximum 0 db\n"
@@ -1452,34 +1015,28 @@ msgid ""
 "sound distorted."
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:242
 msgid ""
 "...It means the resulting audio will not change,\n"
 "because it's equal to the source."
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:266
 msgid ""
 "...It means an audio signal will be produced with\n"
 "a lower volume than the source."
 msgstr ""
 
-#: ../../vdms_dialogs/videomass_check_version.py:63
 msgid "Get Latest Version"
 msgstr ""
 
-#: ../../vdms_dialogs/videomass_check_version.py:67
 msgid "Checking for newer version"
 msgstr ""
 
-#: ../../vdms_dialogs/videomass_check_version.py:95
 msgid ""
 "\n"
 "\n"
 "New releases fix bugs and offer new features."
 msgstr ""
 
-#: ../../vdms_dialogs/videomass_check_version.py:96
 #, python-brace-format
 msgid ""
 "\n"
@@ -1488,7 +1045,6 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../../vdms_dialogs/while_playing.py:37
 msgid ""
 "q, ESC\n"
 "f\n"
@@ -1511,115 +1067,89 @@ msgid ""
 "left mouse double-click"
 msgstr ""
 
-#: ../../vdms_dialogs/while_playing.py:92
 msgid "Shortcut keys while playing with FFplay"
 msgstr ""
 
-#: ../../vdms_dialogs/widget_utils.py:120 ../../vdms_main/main_frame.py:1326
 msgid "Stop"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:63
 msgid "Please take a moment to set up the application"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:64
 msgid "Click the \"Next\" button to get started"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:79
 msgid "Welcome to the Videomass Wizard!"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:123
 msgid "Videomass is an application based on FFmpeg\n"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:125
 msgid "If FFmpeg is not on your computer, this application will be unusable"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:128
 msgid ""
 "If you have already installed FFmpeg on your operating system,\n"
 "click the \"Auto-detection\" button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:131
 msgid ""
 "If you want to use a version of FFmpeg located on your filesystem\n"
 "but not installed on your operating system,\n"
 "click the \"Locate\" button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:162
 msgid "Auto-detection"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:164
 msgid "Locate"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:214
 msgid "Click the \"Next\" button"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:235
 #, python-brace-format
 msgid "'{}' is not installed on your computer. Install it or indicate another location by clicking the 'Locate' button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:249
 msgid ""
 "Videomass already seems to include FFmpeg.\n"
 "\n"
 "Do you want to use that?"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:275
 msgid "Locating FFmpeg executables\n"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:277
 msgid ""
 "\"ffmpeg\", \"ffprobe\" and \"ffplay\" are required. Complete all\n"
 "the text boxes below by clicking on the respective buttons."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:437
 msgid "Wizard completed successfully!\n"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:438
 msgid "Remember that you can always change these settings later, through the Preferences dialog."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:440
 msgid "Thank You!"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:441
 msgid "To exit click the \"Finish\" button"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:527
 msgid "< Previous"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:530 ../../vdms_dialogs/wizard_dlg.py:613
 msgid "Next >"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:535
 msgid "Videomass Wizard"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:563 ../../vdms_dialogs/wizard_dlg.py:586
-#: ../../vdms_dialogs/wizard_dlg.py:591
 msgid "Finish"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:44 ../../vdms_io/checkup.py:92
 #, python-brace-format
 msgid ""
 "Output folder does not exist:\n"
@@ -1627,432 +1157,326 @@ msgid ""
 "\"{}\"\n"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:65
 msgid "Files already exist, do you want to overwrite them?"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:67
 msgid "Already exist"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:81
 msgid "Not found"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:82 ../../vdms_panels/filedrop.py:196
 msgid "Error list"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:83
 msgid "File(s) not found"
 msgstr ""
 
-#: ../../vdms_io/io_tools.py:56
 #, python-format
 msgid "File does not exist or is invalid:  %s"
 msgstr ""
 
-#: ../../vdms_io/io_tools.py:74
 msgid ""
 "Wait....\n"
 "Audio peak analysis."
 msgstr ""
 
-#: ../../vdms_io/io_tools.py:179
 msgid "Videomass - Downloading..."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1409
-#: ../../vdms_main/main_frame.py:1441
 msgid "Ready"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:203
 msgid ""
 "Not all items in the queue were completed.\n"
 "\n"
 "Would you like to keep them in the queue?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:224
 #, python-brace-format
 msgid "Queue ({0})"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:229 ../../vdms_main/main_frame.py:1334
 msgid "Queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:396 ../../vdms_main/main_frame.py:418
 msgid "There are still active windows with running processes, make sure you finish your work before exit."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:403
 msgid "Are you sure you want to exit the application?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:405
 msgid "Exit"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:463
 msgid "Import files\tCtrl+O"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:466
 msgid "Open destination folder of encodings\tCtrl+D"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:469
 msgid "Load queue file"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:470
 msgid "Load a previously exported queue file"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:473
 msgid "Open trash"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:474
 msgid "Open the Videomass trash folder"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:476
 msgid "Empty trash"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:477
 msgid "Delete all files in the Videomass trash folder"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:480
 msgid "Exit\tCtrl+Q"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:481
 msgid "Completely exit the application"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:482
 msgid "File"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:486 ../../vdms_panels/filedrop.py:340
-#: ../../vdms_panels/filedrop.py:381
 msgid "Rename selected file\tCtrl+R"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:487
 msgid "Rename the destination of the selected file"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:490 ../../vdms_panels/filedrop.py:341
-#: ../../vdms_panels/filedrop.py:384
 msgid "Batch rename files\tCtrl+B"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:491
 msgid "Numerically renames the destination of all items in the list"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:496 ../../vdms_panels/filedrop.py:343
-#: ../../vdms_panels/filedrop.py:388
 msgid "Remove selected entry\tDEL"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:497
 msgid "Remove the selected file from the list"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:500 ../../vdms_panels/filedrop.py:344
-#: ../../vdms_panels/filedrop.py:391
 msgid "Clear list\tShift+DEL"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:501
 msgid "Clear the file list"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:506
 msgid "Preferences\tCtrl+P"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:507
 msgid "Application preferences"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:512
 msgid "Find FFmpeg topics"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:513
 msgid "A useful tool to search for FFmpeg help topics and options"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:518
 msgid "Check for preset updates"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:519
 #, python-brace-format
 msgid "Check for new presets updates from {0}"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:521
 msgid "Get latest presets"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:522
 #, python-brace-format
 msgid "Get the latest presets from {0}"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:525
 msgid "Work notes\tCtrl+N"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:526
 msgid "Read and write useful notes and reminders."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:528
 msgid "Tools"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:535
 msgid "Show FFmpeg's built-in configuration capabilities"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:539
 msgid "Muxers and demuxers available on your version of FFmpeg"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:543
 msgid "Encoders available on your version of FFmpeg"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:546
 msgid "Decoders available on your version of FFmpeg"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:550
 msgid "Enable timestamps on playback"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:551
 msgid "Displays timestamp when playing media with FFplay"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:554
 msgid "Auto-exit after playback"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:555
 msgid "If checked, the FFplay window will auto-close when playback is complete"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:559
 msgid "Customize the timestamp style"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:562
 msgid "While playing..."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:563
 msgid "Show useful shortcut keys when playing or previewing using FFplay"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:567
 msgid "Show timeline editor\tCtrl+T"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:568
 msgid "Set duration or trim slices of time to remove unwanted parts from your files"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:572
 msgid "View"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:579
 msgid "Home panel\tCtrl+Shift+H"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:580
 msgid "Go to the «Home» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:583
 msgid "Presets Manager\tCtrl+Shift+P"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:584
 msgid "Go to the «Presets Manager» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:586
 msgid "A/V Conversions\tCtrl+Shift+V"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:587
 msgid "Go to the «A/V Conversions» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:589
 msgid "Concatenate Demuxer\tCtrl+Shift+D"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:590
 msgid "Go to the «Concatenate Demuxer» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:593
 msgid "Still Image Maker\tCtrl+Shift+I"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:594
 msgid "Go to the «Still Image Maker» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:596
 msgid "From Movie to Pictures\tCtrl+Shift+S"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:597
 msgid "Go to the «From Movie to Pictures» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:600
 msgid "Output monitor\tCtrl+Shift+O"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:601
 msgid "Keeps track of the output for debugging errors"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:603
 msgid "Go"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:607
 msgid "User guide"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:611
 msgid "System version"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:612
 msgid "Get version about your operating system, version of Python and wxPython."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:616
 msgid "Show log files\tCtrl+L"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:617
 msgid "Viewing log messages"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:620
 msgid "Issue tracker"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:624
 msgid "Contribute to the project"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:627
 msgid "Sponsor this project"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:628
 msgid "Become a developer supporter"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:629
 msgid "Donate"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:630
 msgid "Donate to the app developer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:634
 msgid "Other projects by the developer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:650
 msgid "About Videomass"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:651
 msgid "Check for newer version"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:652
 msgid "Check for the latest Videomass version"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:654
 msgid "Help"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:729
 msgid "Import files"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:752
 msgid "No default folder has been set for the destination of the encodings. The current setting is \"Same destination paths as source files\"."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:784 ../../vdms_main/main_frame.py:809
 #, python-brace-format
 msgid ""
 "'{}':\n"
 "No such file or directory"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:797
 msgid "Are you sure to empty trash folder?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:805
 #, python-brace-format
 msgid ""
 "'{}':\n"
 "There are no files to delete."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:862
 #, python-brace-format
 msgid "Installed release v{0}. A new presets release is available {1}"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:866
 #, python-brace-format
 msgid "Installed release v{0}. No new updates found."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:896
 msgid ""
 "Wait....\n"
 "The archive is being downloaded"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:908
 #, python-brace-format
 msgid "Successfully downloaded to \"{0}\""
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1120
 msgid "Some changes require restarting the application."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1126
 #, python-brace-format
 msgid ""
 "{0}\n"
@@ -2060,214 +1484,159 @@ msgid ""
 "Do you want to restart the application now?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1128
 msgid "Restart Videomass?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1207
 #, python-brace-format
 msgid "A new release is available - v.{0}\n"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1210
 msgid "You are using a development version that has not yet been released!\n"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1213
 msgid "Congratulation! You are already using the latest version.\n"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1301
 msgid "Previous panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1302
 msgid "Back"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1305
 msgid "Next panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1306
 msgid "Next"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1309
 msgid "Home panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1310
 msgid "Home"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1313
 msgid "Play the selected imput file"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1314
 msgid "Play"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1317
 msgid "Get informative data about imported media streams"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1321
 msgid "Start batch processing"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1325
 msgid "Stops current process"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1329
 msgid "Add an item to Queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1330
 msgid "Add to Queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1333
 msgid "Show queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1408 ../../vdms_panels/presets_manager.py:569
 msgid "Videomass"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1442
 msgid "Videomass - File List"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1459
 msgid "Videomass - AV Conversions"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1488
 msgid "Videomass - Presets Manager"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1518
 msgid "Videomass - Concatenate Demuxer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1547
 msgid "Videomass - From Movie to Pictures"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1576
 msgid "Videomass - Still Image Maker"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1660 ../../vdms_panels/av_conversions.py:577
-#: ../../vdms_panels/filedrop.py:500 ../../vdms_panels/filedrop.py:616
-#: ../../vdms_panels/sequence_to_video.py:322
-#: ../../vdms_panels/video_to_sequence.py:369
-#: ../../vdms_panels/video_to_sequence.py:501
 msgid "Have to select an item in the file list first"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1682
 msgid ""
 "An item with the same destination file already exists.\n"
 "\n"
 "Do you want to replace it by adding the new item to the queue?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1703
 msgid "Videomass - FFmpeg Message Monitoring"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1828
 #, python-brace-format
 msgid "The system will turn off in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1829
 msgid "Videomass - Shutdown!"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1836
 msgid "Error while shutting down. Please see file log for details."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1848
 #, python-brace-format
 msgid "Exiting the application in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1849
 msgid "Videomass - Exiting!"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:46
 msgid "Start point adjustment"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:48
 msgid "End point adjustment"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:105
 msgid "Hours"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:106
 msgid "Minutes"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:107
 msgid "Seconds"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:108
 msgid "Milliseconds"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:189 ../../vdms_miniframes/timeline.py:312
 msgid "No source duration:"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:208 ../../vdms_miniframes/timeline.py:298
-#: ../../vdms_miniframes/timeline.py:333 ../../vdms_miniframes/timeline.py:338
-#: ../../vdms_miniframes/timeline.py:441
 #, python-brace-format
 msgid "{0} {1}  |  Segment Duration: {2}"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:260 ../../vdms_miniframes/timeline.py:277
 msgid "End adjustment"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:261 ../../vdms_miniframes/timeline.py:279
 msgid "Start adjustment"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:320
 msgid "Source duration:"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:387
 msgid "WARNING: Invalid selection, out of range."
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:461
 msgid ""
 "Start by dragging the bottom left handle,\n"
 "or right-click for options."
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:497
 msgid "Start"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:498
 msgid "End"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:548
 msgid ""
 "The timeline editor is a tool that allows you to trim slices of time on selected imported media (see File List panel).\n"
 "\n"
@@ -2280,39 +1649,30 @@ msgid ""
 "The \"Start\"/\"End\" duration values always refer to the initial position of the timeline: 00:00:00.000. For other informations as the segment duration and warnings, please refer to the status bar messages."
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:565
 msgid "Timeline Editor Usage"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:153
 msgid "Media:"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:169
 msgid "Container:"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:180
 msgid "Save profile"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:183
 msgid "Target"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:316
 msgid "Miscellaneous"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:323
 msgid "Save as a new profile of the Presets Manager."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:325
 msgid "Available video encoders. \"Copy\" means that the video stream will not be re-encoded and will allow you (depending on the encoder) to change the container, audio codec and a few other parameters."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:330
 msgid ""
 "Container format. It is usually represented by the file extension (output format).\n"
 "\n"
@@ -2321,73 +1681,53 @@ msgid ""
 "If the media target is set to \"Audio\", you can extract only the audio streams from videos, or simply convert audio source files."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:338
 msgid ""
 "Set output files target: \"Video\" to save output files as video files; \"Audio\" to save files using an audio encoder and format.\n"
 "\n"
 "Note that by using \"Audio\" as the target, you will still be able to work on the video source files but you will only be able to extract the audio streams, convert them and apply audio filters such as normalization."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:346
 msgid "Preview video filters"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:347
 msgid "Disable active filters"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:348
-#: ../../vdms_panels/sequence_to_video.py:156
-#: ../../vdms_panels/video_to_sequence.py:113
 msgid "Resize"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:349
 msgid "Crop"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:350
 msgid "Transpose"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:352
 msgid "Denoise"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:353
 msgid "Stabilize"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:354
 msgid "Equalize"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:517
 msgid "Unable to preview Video Stabilizer filter"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:602
 msgid ""
 "Unsupported file:\n"
 "Missing decoder or library? Check FFmpeg configuration."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:611
-#: ../../vdms_panels/sequence_to_video.py:351
-#: ../../vdms_panels/video_to_sequence.py:398
 msgid "The file is not a frame or a video file"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:434
-#: ../../vdms_panels/av_conversions.py:861
 msgid "Undetected volume values! Click the \"Volume detect\" button to analyze audio volume data."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1186
 msgid "Off"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1203
 msgid ""
 "Batch processing items\n"
 "Destination\n"
@@ -2402,109 +1742,81 @@ msgid ""
 "Clip duration"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1246
-#: ../../vdms_panels/presets_manager.py:814
 #, python-brace-format
 msgid "Write profile on «{0}»"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1266
-#: ../../vdms_panels/presets_manager.py:513
 msgid "Enter name for new preset"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1276
-#: ../../vdms_panels/presets_manager.py:524
 msgid "Invalid file name, make sure to provide a valid name including the «.json» extension"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1284
 #, python-brace-format
 msgid "Cannot save current data in file «{}»."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1289
 msgid "Open Videomass preset"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1307
 msgid "Videomass - Save new profile"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1308
 msgid "Where do you want to save this profile?"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1309
 msgid "Save the profile to a new preset"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1310
 msgid "Save the profile to an existing preset"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:69
 msgid "Welcome to Videomass"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:71
 #, python-brace-format
 msgid "Version {}"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:82
 msgid "Presets Manager"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:85
 msgid "AV-Conversions"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:88
 msgid "Concatenate media files"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:91
 msgid "Still Image Maker"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:94
 msgid "From Movie to Pictures"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:123
 msgid "Create, edit and use quickly your favorite FFmpeg presets and profiles with full formats support and codecs."
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:127
 msgid "A set of useful tools for audio and video conversions. Save your profiles and reuse them with Presets Manager."
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:131
 msgid "Concatenate multiple media files based on import order without re-encoding"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:134
 msgid "Create video from a sequence of images, based on import order, with the ability to add an audio file."
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:137
 msgid "Extract images (frames) from your movies in JPG, PNG, BMP, GIF formats."
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:47
 msgid "At least two files are required to perform concatenation."
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:63
 msgid "Invalid data found"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:68
 msgid "The files do not have the same \"codec_types\", same \"sample_rate\" or same \"width\" or \"height\". Unable to proceed."
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:84
 msgid ""
 "\n"
 "- The concatenation function is performed only with Audio files or only with Video files.\n"
@@ -2520,17 +1832,12 @@ msgid ""
 "- Audio files must have exactly the same formats, same codecs with equal sample rate."
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:125
 msgid "Videomass Documentation:"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:136
-#: ../../vdms_panels/sequence_to_video.py:212
-#: ../../vdms_panels/video_to_sequence.py:181
 msgid "Official FFmpeg documentation:"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:253
 msgid ""
 "Items to concatenate\n"
 "File destination\n"
@@ -2539,250 +1846,188 @@ msgid ""
 "Duration"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:45
 msgid "File has illegal characters like:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:46
 msgid "Invalid character found in path name: (\")"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:47
 msgid "Directories are not allowed, just add files, please."
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:48
 msgid "File without format extension: please give an appropriate extension to the file name, example '.mkv', '.avi', '.mp3', etc."
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:84
 #, python-brace-format
 msgid "Name has illegal characters like: {0}"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:85
 msgid "Name already in use:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:185
 msgid "Duplicate file, it has already been added to the list."
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:197
 msgid "Rejected files"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:269
 msgid "Source file"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:270
 msgid "Duration"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:271
 msgid "Media type"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:272
 msgid "Size"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:405
 msgid "Drag one or more files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:282
 msgid "Save to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:306
 msgid "Set a new destination folder for encodings"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:308
 msgid "Encodings destination folder"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:394
 msgid "Play file"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:408
 msgid "Drag two or more Audio/Video files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:412
 msgid "Drag one or more Image files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:415
 msgid "Drag one or more Video files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:623
 msgid "Rename the file destination"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:624
 msgid "Rename the selected file to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:638 ../../vdms_panels/filedrop.py:648
-#: ../../vdms_panels/filedrop.py:679
 msgid "Add Files"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:655
 msgid "Rename in batch"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:656
 #, python-brace-format
 msgid "Rename the {0} items to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:658
 msgid "New Name #"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:114
 msgid "Sorry, all task failed !"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:115
 msgid "The process was stopped due to a fatal error."
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:116
 msgid "Interrupted Process !"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:117
 msgid "Successfully completed !"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:118
 msgid "Not everything was successful."
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:148
 msgid "Encoding Status"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:152
 msgid "Current Log"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:354
 msgid "Fatal Error !"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:363
 msgid "Get your files at the destination you specified"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:377
 msgid "For more details please read the Current Log."
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:380
 msgid "...Finished"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:399
 msgid "Please wait... interruption in progress"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:402
 msgid "...Interrupted"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:166
 msgid "Presets"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:180
 msgid "Write"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:184
 msgid "Delete"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:194
 msgid "Duplicate"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:199
 msgid "Profiles"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:206
 msgid "One-Pass Encoding"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:218
 msgid "Two-Pass Encoding"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:232
 msgid "Choose a preset and view its profiles"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:233
 msgid "Write a new profile and save it in the selected preset"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:235
 msgid "Delete the selected profile"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:236
 msgid "Edit the selected profile"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:237
 msgid "Duplicate the selected profile"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:238
 msgid "Create new preset"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:240
 msgid "Remove selected preset"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:242
 msgid "Backup selected preset"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:244
 msgid "Backup the presets folder"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:246
 msgid "Restore a preset"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:248
 msgid "Restore a presets folder"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:250
 msgid "Resets the selected preset to default values"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:252
 msgid "Reset all presets to default values"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:254
 msgid "Refresh the presets list"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:338
 #, python-brace-format
 msgid ""
 "Outdated presets version found: v{1}\n"
@@ -2796,28 +2041,22 @@ msgid ""
 "Do you want to perform this update now?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:403
 msgid "Name"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:405
 msgid "Output Format"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:406
 msgid "Supported Format List"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:531
 #, python-brace-format
 msgid "Cannot save current data in file '{}'."
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:535
 msgid "You just successfully created a new preset!"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:547
 #, python-brace-format
 msgid ""
 "Are you sure you want to remove \"{}\" preset?\n"
@@ -2825,7 +2064,6 @@ msgid ""
 " It will be moved to the \"Removals\" subfolder inside the presets folder."
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:558
 #, python-brace-format
 msgid ""
 "{}\n"
@@ -2833,72 +2071,55 @@ msgid ""
 "Sorry, removal failed, cannot continue.."
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:568
 #, python-brace-format
 msgid "The preset \"{0}\" was successfully removed"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:583
-#: ../../vdms_panels/presets_manager.py:612
 msgid "Open a destination folder"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:588
 msgid "A file with this name already exists, do you want to overwrite it?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:602
-#: ../../vdms_panels/presets_manager.py:622
 msgid "Backup completed successfully"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:631
 msgid "Open the preset you want to restore"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:645
 msgid ""
 "This preset already exists and is about to be updated. Don't worry, it will keep all your saved profiles.\n"
 "\n"
 "Do you want to continue?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:663
 msgid "Restore successful"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:681
 msgid ""
 "This will update the presets database. Don't worry, it will keep all your saved profiles.\n"
 "\n"
 "Do you want to continue?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:689
 msgid "Open the presets folder to restore"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:725
 msgid "The presets database has been successfully updated"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:740
 msgid "The selected preset is not part of Videomass's default presets."
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:745
 msgid ""
 "Be careful! The selected preset will be overwritten with the default one. Your profiles may be deleted!\n"
 "\n"
 "Do you want to continue?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:760
-#: ../../vdms_panels/presets_manager.py:794
 msgid "Successful recovery"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:769
 msgid ""
 "Be careful! This action will restore all presets to default ones. Your profiles may be deleted!\n"
 "\n"
@@ -2907,30 +2128,24 @@ msgid ""
 "Do you want to continue?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:833
 #, python-brace-format
 msgid "Edit profile on «{0}»"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:872
 msgid "Are you sure you want to delete the selected profile? It will no longer be possible to recover it."
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:891
 msgid "First select a profile in the list"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:899
 msgid ""
 "The selected profile command has been changed manually.\n"
 "Do you want to apply it during the conversion process?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:909
 msgid "Don't show this dialog again"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:1054
 msgid ""
 "Batch processing items\n"
 "Destination\n"
@@ -2942,11 +2157,9 @@ msgid ""
 "Clip duration"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:54
 msgid "Images need to be resized, please use Resize function."
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:73
 msgid ""
 "\n"
 "1. Import one or more image files such as JPG, PNG and BMP formats, then select one.\n"
@@ -2964,38 +2177,29 @@ msgid ""
 "will be saved in a folder named 'Still_Images' with a progressive digit, in the path you specify."
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:129
 msgid "Enable a single still image"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:162
 msgid ""
 "Force original aspect ratio using\n"
 "padding rather than stretching"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:170
 msgid "Include audio file"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:173
 msgid "Play the video until audio track finishes"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:180
-#: ../../vdms_panels/sequence_to_video.py:439
 msgid "Open audio file"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:199
 msgid "Additional arguments"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:454
 msgid "Open Audio File"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:466
 #, python-brace-format
 msgid ""
 "Invalid file: '{}'\n"
@@ -3003,7 +2207,6 @@ msgid ""
 "{}"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:471
 #, python-brace-format
 msgid ""
 "Invalid file: '{}'\n"
@@ -3011,21 +2214,14 @@ msgid ""
 "It doesn't appear to be an audio file."
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:560
-#: ../../vdms_panels/sequence_to_video.py:587
-#: ../../vdms_panels/video_to_sequence.py:511
 #, python-brace-format
 msgid "Invalid file: '{}'"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:570
-#: ../../vdms_panels/sequence_to_video.py:595
 #, python-brace-format
 msgid "Unsupported format '{}'"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:576
-#: ../../vdms_panels/sequence_to_video.py:600
 #, python-brace-format
 msgid ""
 "File does not exist:\n"
@@ -3033,15 +2229,9 @@ msgid ""
 "\"{}\"\n"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:577
 msgid "ERROR"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:707
-msgid "Shortest"
-msgstr ""
-
-#: ../../vdms_panels/sequence_to_video.py:715
 msgid ""
 "Items to concatenate\n"
 "Output filename\n"
@@ -3057,7 +2247,6 @@ msgid ""
 "Overall video duration"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:50
 msgid ""
 "\n"
 "1. Import one or more video files, then select one.\n"
@@ -3074,51 +2263,39 @@ msgid ""
 "with a progressive digit, in the path you specify."
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:86
 msgid "Create thumbnails"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:87
 msgid "Create tiled mosaics"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:88
 msgid "Create animated GIF"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:90
 msgid "Options"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:119
 msgid "Output format:"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:131
 msgid "Rows:"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:141
 msgid "Columns:"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:205
 msgid "Other unofficial resources:"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:229
 msgid "Set FPS control from 0.1 to 30.0 fps. The higher this value, the more images will be extracted."
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:232
 msgid "Spaces around the mosaic tiles. From 0 to 32 pixels"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:234
 msgid "Spaces around the mosaic borders. From 0 to 32 pixels"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:626
 msgid ""
 "Selected File\n"
 "Output Format\n"
@@ -3134,58 +2311,45 @@ msgid ""
 "Duration"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:118
 msgid "Audio encoder settings, mapping and filters"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:128
 msgid "Audio Encoder"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:137
 msgid "Settings"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:148
 msgid "Index Selection:"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:157
 msgid "Map:"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:180
 msgid "Normalization"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:191
 msgid "Volume detect"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:195
 msgid "Volume Statistics"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:199
 msgid "Target level:"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:264
 msgid "Gets maximum volume and average volume data in dBFS, then calculates the offset amount for audio normalization."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:267
 msgid "Limiter for the maximum peak level or the mean level (when switch to RMS) in dBFS. From -99.0 to +0.0; default for PEAK level is -1.0; default for RMS is -20.0"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:271
 msgid ""
 "Normally on a video with correctly indexed streams and having one or more audio streams, the first audio stream should be indexed at \"1\", the second at \"2\" and so on (the video stream on the other hand is always indexed at \"0\"). In this case it is recommended to select the desired stream by setting a specific index, e.g \"1\" for for the first available audio stream.\n"
 "\n"
 "Set this control to \"Auto\" if the source file is simply an audio track."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:280
 msgid ""
 "\"Auto\" keeps all audio streams and processes only the one selected by the \"Index Selection\" control.\n"
 "\n"
@@ -3194,70 +2358,55 @@ msgid ""
 "\"Index Only\" processes only the audio stream selected by the \"Index Selection\" control and removes all others from the video"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:288
 msgid "Integrated Loudness Target in LUFS. From -70.0 to -5.0, default is -16.0"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:291
 msgid "Maximum True Peak in dBTP. From -1.5 to +0.0, default is -2.0"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:294
 msgid "Loudness Range Target in LUFS. From +1.0 to +20.0, default is +11.0"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:297
 msgid "Play the audio stream selected in the \"Index Selection\" control. Using this function you can test the result of audio normalization."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:503
 msgid "Selected index does not exist or does not contain any audio streams"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:508
 #, python-brace-format
 msgid ""
 "ERROR: Missing audio stream:\n"
 "\"{}\""
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:726
 msgid "PEAK level normalization, which will produce a maximum peak level equal to the set target level."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:729
 msgid "RMS-based normalization, which according to mean volume calculates the amount of gain to reach same average power signal."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:733
 msgid ""
 "Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements the EBU R128 algorithm.\n"
 "Ideal for live normalization. It produces worse results than the High-quality two-pass Loudnorm normalization, but is faster."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:740
 msgid ""
 "High-quality two-pass Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements\n"
 "the EBU R128 algorithm. Ideal for postprocessing."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:789
 msgid "You need to import at least one file"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:63
 msgid "Subtitle Mapping:"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:77
 msgid "Copy Chapters"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:79
 msgid "Copy Metadata"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:85
 msgid ""
 "Select \"All\" to include any source file subtitles in the output video.\n"
 "\n"
@@ -3266,147 +2415,63 @@ msgid ""
 "This option is automatically ignored for output audio files."
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:90
 msgid "Copy the chapter markers as is from source file. This option is automatically ignored for output audio files."
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:93
 msgid "Copy all incoming metadata from source file, such as audio/video tags, titles, unique marks, and so on."
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:108
 msgid "Additional options"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:89
-#: ../../vdms_panels/video_encoders/av1_svt.py:120
-#: ../../vdms_panels/video_encoders/avc_x264.py:90
-#: ../../vdms_panels/video_encoders/hevc_x265.py:98
-#: ../../vdms_panels/video_encoders/mpeg4.py:71
-#: ../../vdms_panels/video_encoders/vp9_webm.py:131
 msgid "Reload"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:101
-#: ../../vdms_panels/video_encoders/av1_svt.py:129
-#: ../../vdms_panels/video_encoders/avc_x264.py:101
-#: ../../vdms_panels/video_encoders/hevc_x265.py:109
-#: ../../vdms_panels/video_encoders/mpeg4.py:82
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:97
-#: ../../vdms_panels/video_encoders/vp9_webm.py:141
 msgid "Optimize for Web"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:247
-#: ../../vdms_panels/video_encoders/av1_svt.py:313
-#: ../../vdms_panels/video_encoders/avc_x264.py:242
-#: ../../vdms_panels/video_encoders/hevc_x265.py:250
-#: ../../vdms_panels/video_encoders/mpeg4.py:198
-#: ../../vdms_panels/video_encoders/vp9_webm.py:288
 msgid "Reloads the selected video encoder settings. Changes will be discarded."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:250
-#: ../../vdms_panels/video_encoders/avc_x264.py:273
-#: ../../vdms_panels/video_encoders/hevc_x265.py:277
-#: ../../vdms_panels/video_encoders/vp9_webm.py:291
 msgid "Constant rate factor. Lower values correspond to higher quality and greater file size. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:254
-#: ../../vdms_panels/video_encoders/av1_svt.py:357
-#: ../../vdms_panels/video_encoders/vp9_webm.py:295
 msgid "Number of tile rows to use, default changes per resolution"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:256
-#: ../../vdms_panels/video_encoders/av1_svt.py:359
-#: ../../vdms_panels/video_encoders/vp9_webm.py:297
 msgid "Number of tile columns to use, default changes per resolution"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:259
-#: ../../vdms_panels/video_encoders/av1_svt.py:368
-#: ../../vdms_panels/video_encoders/avc_x264.py:253
-#: ../../vdms_panels/video_encoders/hevc_x265.py:261
-#: ../../vdms_panels/video_encoders/mpeg4.py:201
-#: ../../vdms_panels/video_encoders/vp9_webm.py:300
 msgid "Set the Group Of Picture (GOP). Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:262
-#: ../../vdms_panels/video_encoders/av1_svt.py:371
-#: ../../vdms_panels/video_encoders/avc_x264.py:256
-#: ../../vdms_panels/video_encoders/hevc_x265.py:264
-#: ../../vdms_panels/video_encoders/mpeg4.py:204
-#: ../../vdms_panels/video_encoders/vp9_webm.py:303
 msgid "It can reduce the file size, but takes longer."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:264
-#: ../../vdms_panels/video_encoders/av1_svt.py:373
-#: ../../vdms_panels/video_encoders/avc_x264.py:258
-#: ../../vdms_panels/video_encoders/hevc_x265.py:266
-#: ../../vdms_panels/video_encoders/mpeg4.py:206
-#: ../../vdms_panels/video_encoders/vp9_webm.py:305
 msgid "Set minimum bitrate tolerance. Most useful in setting up a CBR encode. It is of little use otherwise. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:268
-#: ../../vdms_panels/video_encoders/av1_svt.py:377
-#: ../../vdms_panels/video_encoders/avc_x264.py:262
-#: ../../vdms_panels/video_encoders/hevc_x265.py:270
-#: ../../vdms_panels/video_encoders/mpeg4.py:210
-#: ../../vdms_panels/video_encoders/vp9_webm.py:309
 msgid "Specifies a maximum tolerance. Requires bufsize to be set. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:271
-#: ../../vdms_panels/video_encoders/av1_svt.py:380
-#: ../../vdms_panels/video_encoders/avc_x264.py:265
-#: ../../vdms_panels/video_encoders/hevc_x265.py:273
-#: ../../vdms_panels/video_encoders/mpeg4.py:213
-#: ../../vdms_panels/video_encoders/vp9_webm.py:312
 msgid "Set ratecontrol buffer size, which determines the variability of the output bitrate. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:275
-#: ../../vdms_panels/video_encoders/av1_svt.py:384
-#: ../../vdms_panels/video_encoders/avc_x264.py:277
-#: ../../vdms_panels/video_encoders/hevc_x265.py:281
-#: ../../vdms_panels/video_encoders/mpeg4.py:231
-#: ../../vdms_panels/video_encoders/vp9_webm.py:316
 msgid "Specifies the target (average) bit rate for the encoder to use. Higher value = higher quality. Set -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:279
-#: ../../vdms_panels/video_encoders/av1_svt.py:388
-#: ../../vdms_panels/video_encoders/avc_x264.py:281
-#: ../../vdms_panels/video_encoders/hevc_x265.py:285
-#: ../../vdms_panels/video_encoders/mpeg4.py:235
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:131
-#: ../../vdms_panels/video_encoders/vp9_webm.py:320
 msgid "Video width and video height ratio."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:281
-#: ../../vdms_panels/video_encoders/av1_svt.py:390
-#: ../../vdms_panels/video_encoders/avc_x264.py:283
-#: ../../vdms_panels/video_encoders/hevc_x265.py:287
-#: ../../vdms_panels/video_encoders/mpeg4.py:237
-#: ../../vdms_panels/video_encoders/vp9_webm.py:322
 msgid "Frame rate (frames per second). Frames repeat a given number of times per second. In some countries this is 30 for NTSC, other countries (like Italy) use 25 for PAL"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:285
 msgid "Quality/Speed ratio modifier. CPU Used sets how efficient the compression will be. Lower values mean slower encoding with better quality, and vice-versa. Valid values are from 0 to 8 inclusive."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:290
 msgid "Quality and compression efficiency vs speed trade-off. \"good\" is the default and recommended for most applications; \"realtime\" is recommended for live/fast encoding (live streaming, video conferencing, etc); \"allintra\" for All Intra encoding."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:297
 msgid ""
 "Row Multi-Threading enables row-based multi-threading which maximizes CPU usage.\n"
 "\n"
@@ -3415,7 +2480,6 @@ msgid ""
 "Enabling Row Multi-Threading is only faster when the CPU has more threads than the number of encoded tiles."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:316
 msgid ""
 "presets 1-3 represent extremely high efficiency, for use when encode time is not important and quality/size of the resulting video file is critical.\n"
 "\n"
@@ -3426,7 +2490,6 @@ msgid ""
 "Preset 13 is even faster but not intended for direct human consumption--it can be used, for example, as a per-scene quality metric in VOD applications. One should use the lowest preset that is tolerable."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:327
 msgid ""
 "Constant rate factor. This parameter governs the quality/size trade-off.\n"
 "\n"
@@ -3437,7 +2500,6 @@ msgid ""
 "Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:334
 msgid ""
 "The \"Film Grain\" parameter allows SVT-AV1 to detect and delete film grain from the source video, and replace it with synthetic grain of the same character, resulting in significant bitrate savings.\n"
 "\n"
@@ -3450,80 +2512,57 @@ msgid ""
 "If the source video does not have natural grain, this parameter can be set to -1 to disable it or at least 0."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:346
 msgid ""
 "If enabled, the \"Film Grain Denoiser\" option can mitigate the detail removal caused by high \"Film Grain\" values required to preserve the look of very grainy films\n"
 "\n"
 "By default, the denoised frames are passed to be encoded as the final pictures, enabling this feature will lead to the original frames to be used instead. "
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:353
 msgid "Enables encoder optimization to produce faster (less CPU intensive) bit streams to decode, similar to the fastdecode tuning in x264 and x265."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:362
-#: ../../vdms_panels/video_encoders/avc_x264.py:247
-#: ../../vdms_panels/video_encoders/hevc_x265.py:255
 msgid "Set profile restrictions"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:364
-#: ../../vdms_panels/video_encoders/avc_x264.py:249
-#: ../../vdms_panels/video_encoders/hevc_x265.py:257
 msgid "Specify level for a selected profile"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:366
-#: ../../vdms_panels/video_encoders/avc_x264.py:251
-#: ../../vdms_panels/video_encoders/hevc_x265.py:259
 msgid "Tune the encoding params"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/avc_x264.py:245
-#: ../../vdms_panels/video_encoders/hevc_x265.py:253
 msgid "Set the encoding preset (default \"medium\")"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/avc_x264.py:269
 msgid "specifies the target (average) bit rate for the encoder to use. Higher value = higher quality. Set -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:217
 msgid "Variable Bit Rate. From 0-30, with 1 being highest quality/largest filesize and 30 being the lowest quality/smallest filesize. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:222
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:133
 msgid "Frames repeat a given number of times per second. In some countries this is 30 for NTSC, other countries (like Italy) use 25 for PAL"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:226
 msgid "The default FourCC stored in an MPEG-4-coded file will be FMP4. If you want a different FourCC, set this option to xvid to force the FourCC xvid to be stored as the video FourCC rather than the default."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:162
 msgid "Copy Video Codec"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:163
 msgid ""
 "This will just copy the video track as is, without any video re-encoding.\n"
 "You will only be able to change output format, select other audio encoders and\n"
 "a few other options."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_no_enc.py:74
 msgid "Video export disabled"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_no_enc.py:75
 msgid ""
 "The Media target you just selected will only allow you to export files as audio tracks.\n"
 "You can then process audio source files only or extract indexed audio streams on\n"
 "video files."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:326
 msgid ""
 "Speed sets how efficient the compression will be.\n"
 "\n"
@@ -3536,7 +2575,6 @@ msgid ""
 "When the Quality is set to realtime, the available values for Speed are 0 to 8."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:335
 msgid ""
 "Time to spend encoding.\n"
 "\n"
@@ -3547,35 +2585,30 @@ msgid ""
 "\"realtime\" is recommended for live / fast encoding."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:341
-msgid "If enabled, adds support for row based multithreading which greatly enhances the number of threads the encoder can utilise. This improves encoding speed significantly on systems that are otherwise underutilised when encoding VP9. Since the amount of additional threads depends on the number of \"tiles\", which itself depends on the video resolution, encoding higher resolution videos will see a larger performance improvement."
+msgid ""
+"If enabled, adds support for row based multithreading which greatly enhances the number of threads the encoder can utilise. This improves encoding speed significantly on systems that are otherwise underutilised when encoding VP9. Since the amount of additional threads depends on the number of \"tiles\", which itself depends on the video resolution, encoding higher resolution videos will see a "
+"larger performance improvement."
 msgstr ""
 
-#: ../../vdms_utils/presets_manager_utils.py:46
 #, python-brace-format
 msgid "Supports ({0}) formats only, not ({1})"
 msgstr ""
 
-#: ../../vdms_utils/presets_manager_utils.py:49
 msgid "File formats not supported by the selected profile"
 msgstr ""
 
-#: ../../vdms_utils/presets_manager_utils.py:52
 msgid "Warning"
 msgstr ""
 
-#: ../../vdms_utils/presets_manager_utils.py:90
 msgid ""
 "No presets found.\n"
 "\n"
 "Possible solution: open the Presets Manager panel, go to the presets column and try to click the \"Restore all...\" button"
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:54
 msgid "Import queue file"
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:89
 #, python-brace-format
 msgid ""
 "ERROR: invalid data found loading queue file.\n"
@@ -3584,25 +2617,20 @@ msgid ""
 "Cannot contain multiple occurrences in `destination` keys value."
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:118
 msgid "Videomass - Add Items to Queue"
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:119
 msgid ""
 "Multiple items with identical names and destination paths cannot coexist.\n"
 "Please choose one of the following actions:"
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:123
 msgid "Replace occurrences with items from the imported queue."
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:124
 msgid "Add only the currently missing items to the queue."
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:125
 msgid "Remove the current queue and replace it with the imported one."
 msgstr ""
 
@@ -3613,5 +2641,8 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "Subtitle Mapping"
+#~ msgstr ""
+
+#~ msgid "Shortest"
 #~ msgstr ""
 

--- a/videomass/data/locale/ar_SA/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/ar_SA/LC_MESSAGES/videomass.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-30 11:02+0200\n"
+"POT-Creation-Date: 2025-07-30 15:28+0200\n"
 "PO-Revision-Date: 2024-07-17 16:34+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ar_SA\n"
@@ -2633,16 +2633,4 @@ msgstr ""
 
 msgid "Remove the current queue and replace it with the imported one."
 msgstr ""
-
-#~ msgid "Some text boxes are still incomplete"
-#~ msgstr ""
-
-#~ msgid "FFplay"
-#~ msgstr ""
-
-#~ msgid "Subtitle Mapping"
-#~ msgstr ""
-
-#~ msgid "Shortest"
-#~ msgstr ""
 

--- a/videomass/data/locale/cs_CZ/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/cs_CZ/LC_MESSAGES/videomass.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-30 11:02+0200\n"
+"POT-Creation-Date: 2025-07-30 15:28+0200\n"
 "PO-Revision-Date: 2024-07-17 16:33+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: cs_CZ\n"
@@ -2633,16 +2633,4 @@ msgstr ""
 
 msgid "Remove the current queue and replace it with the imported one."
 msgstr ""
-
-#~ msgid "Some text boxes are still incomplete"
-#~ msgstr ""
-
-#~ msgid "FFplay"
-#~ msgstr ""
-
-#~ msgid "Subtitle Mapping"
-#~ msgstr ""
-
-#~ msgid "Shortest"
-#~ msgstr ""
 

--- a/videomass/data/locale/cs_CZ/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/cs_CZ/LC_MESSAGES/videomass.po
@@ -1,13 +1,13 @@
-# Czech (Czechia) translations for PROJECT.
-# Copyright (C) 2024 ORGANIZATION
-# This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+# Czech (Czechia) translations for Videomass.
+# Copyright (C) 2025 ORGANIZATION
+# This file is distributed under the same license as the Videomass project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-26 15:04+0200\n"
+"POT-Creation-Date: 2025-07-30 11:02+0200\n"
 "PO-Revision-Date: 2024-07-17 16:33+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: cs_CZ\n"
@@ -18,7 +18,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
-#: ../../gui_app.py:196
 #, python-brace-format
 msgid ""
 "Unexpected error while deleting file contents:\n"
@@ -26,162 +25,111 @@ msgid ""
 "{0}"
 msgstr ""
 
-#: ../../vdms_dialogs/about_dialog.py:52
 msgid "Cross-platform graphical user interface for FFmpeg\n"
 msgstr ""
 
-#: ../../vdms_dialogs/audioproperties.py:224
 msgid "Videomass supports mono and stereo audio channels. If you are not sure set to \"Auto\" and source values will be copied."
 msgstr ""
 
-#: ../../vdms_dialogs/audioproperties.py:228
 msgid "The audio Rate (or sample-rate) is the sound sampling frequency and is measured in Hertz. The higher the frequency, the more true it will be to the sound source and the more the file will increase in size. For audio CD playback, set a sampling frequency of 44100 kHz. If you are not sure, set to \"Auto\" and source values will be copied."
 msgstr ""
 
-#: ../../vdms_dialogs/audioproperties.py:237
 msgid "The audio bitrate affects the file compression and thus the quality of listening. The higher the value, the higher the quality."
 msgstr ""
 
-#: ../../vdms_dialogs/audioproperties.py:241
 msgid "Bit depth is the number of bits of information in each sample, and it directly corresponds to the resolution of each sample. Bit depth is only meaningful in reference to a PCM digital signal. Non-PCM formats, such as lossy compression formats, do not have associated bit depths."
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:74 ../../vdms_dialogs/queuedlg.py:120
 msgid "When finished, once the operations have been completed successfully:"
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:80 ../../vdms_dialogs/queuedlg.py:126
 msgid "Trash the source files"
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:84 ../../vdms_dialogs/queuedlg.py:130
 msgid "Clear the File List"
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:91 ../../vdms_dialogs/queuedlg.py:142
-#: ../../vdms_main/main_frame.py:1322
 msgid "Run"
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:97
 msgid "Videomass - Batch Mode"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:47
 msgid "FFmpeg encoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:48
 msgid "supported encoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:50
 msgid "FFmpeg decoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:51
 msgid "supported decoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:77
-#: ../../vdms_panels/av_conversions.py:293
 msgid "Video"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:87
-#: ../../vdms_panels/av_conversions.py:305
 msgid "Audio"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:97
 msgid "Subtitle"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:114
-#: ../../vdms_dialogs/ffmpeg_codecs.py:123
-#: ../../vdms_dialogs/ffmpeg_codecs.py:132
-#: ../../vdms_dialogs/ffmpeg_formats.py:112
-#: ../../vdms_dialogs/ffmpeg_formats.py:115
-#: ../../vdms_dialogs/ffmpeg_formats.py:118
 msgid "description"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:72
 msgid "Informations"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:83
 msgid "Flags settings"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:93
 msgid "Flags enabled"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:103
 msgid "Flags disabled"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:116
 msgid "FFmpeg configuration"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:124
 msgid "flags"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:125 ../../vdms_dialogs/ffmpeg_conf.py:129
-#: ../../vdms_dialogs/ffmpeg_conf.py:133
 msgid "options"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:128 ../../vdms_dialogs/ffmpeg_conf.py:132
 msgid "status"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:167
 msgid "FFprobe   ...not found !"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:175
 msgid "FFplay   ...not found !"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:205
-#: ../../vdms_panels/sequence_to_video.py:706
-#: ../../vdms_panels/video_to_sequence.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:216
-#: ../../vdms_panels/sequence_to_video.py:706
-#: ../../vdms_panels/video_to_sequence.py:610
 msgid "Disabled"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:71
 msgid "Demuxing only"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:82
 msgid "Muxing only"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:93
 msgid "Demuxing/Muxing support"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:104
 msgid "FFmpeg file formats"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:111
-#: ../../vdms_dialogs/ffmpeg_formats.py:114
-#: ../../vdms_dialogs/ffmpeg_formats.py:117
 msgid "supported formats"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:46
 msgid ""
 "Contextual help based on the argument entered in the additional text field.\n"
 "Each argument consists of the type and a type-specific name.\n"
@@ -196,117 +144,84 @@ msgid ""
 "Some examples:"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:68 ../../vdms_dialogs/ffmpeg_help.py:301
-#: ../../vdms_dialogs/ffmpeg_help.py:315
 msgid "Help topic"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:69
 msgid "List basic options"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:70
 msgid "List more options"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:71
 msgid "List all options (very long)"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:72
 msgid "Show available devices"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:73
 msgid "Show available bit stream filters"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:74
 msgid "Show available protocols"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:75
 msgid "Show available filters"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:76
 msgid "Show available pixel formats"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:77
 msgid "Show available audio sample formats"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:78
 msgid "Show available color names"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:79
 msgid "List sources of the input device"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:80
 msgid "List sinks of the output device"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:81
 msgid "Show available HW acceleration methods"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:82
 msgid "Show license"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:117 ../../vdms_dialogs/filter_scale.py:76
-#: ../../vdms_dialogs/shownormlist.py:98 ../../vdms_dialogs/shownormlist.py:107
-#: ../../vdms_dialogs/shownormlist.py:116 ../../vdms_miniframes/timeline.py:263
-#: ../../vdms_miniframes/timeline.py:283 ../../vdms_panels/concatenate.py:117
-#: ../../vdms_panels/sequence_to_video.py:117
-#: ../../vdms_panels/video_to_sequence.py:81
 msgid "Read me"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:123 ../../vdms_main/main_frame.py:534
 msgid "Show configuration"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:127 ../../vdms_main/main_frame.py:542
 msgid "Encoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:131 ../../vdms_main/main_frame.py:545
 msgid "Decoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:135 ../../vdms_main/main_frame.py:538
 msgid "Muxers and Demuxers"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:165
 msgid "help topic list"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:184
 msgid "Type the argument here and confirm with the enter key on your keyboard"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:192
 msgid "The search function allows you to find entries in the current topic"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:195
 msgid "Ignore case"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:196
 msgid "Ignore case distinctions: characters with different case will match."
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:206
 msgid "FFmpeg help topics"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:254
 msgid ""
 "This is a multifunctional search tool useful for local help searches\n"
 "on multiple FFmpeg topics and options. The search control, to\n"
@@ -319,942 +234,647 @@ msgid ""
 "with those features."
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:320 ../../vdms_dialogs/ffmpeg_help.py:345
-#: ../../vdms_dialogs/ffmpeg_help.py:371
 msgid ""
 "\n"
 "  ..Nothing available"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:391
 msgid ""
 "\n"
 "  ..Not found"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:91
 msgid "Before"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:97
 msgid "After"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:103
-#: ../../vdms_dialogs/filter_crop.py:239
 msgid "Search for a specific frame"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:117
-#: ../../vdms_dialogs/filter_crop.py:253
 msgid "Load"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:120
 msgid "Color EQ"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:126
 msgid "Contrast:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:134
-#: ../../vdms_dialogs/filter_colorcorrection.py:148
 msgid "-100 to +100, default value 0"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:139
 msgid "Brightness:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:158
 msgid "Saturation:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:166
 msgid "0 to 300, default value 100"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:170
 msgid "Gamma:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:179
 msgid "0 to 100, default value 10"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:187
-#: ../../vdms_dialogs/filter_crop.py:306
-#: ../../vdms_dialogs/filter_deinterlace.py:209
-#: ../../vdms_dialogs/filter_denoisers.py:110
-#: ../../vdms_dialogs/filter_scale.py:210 ../../vdms_dialogs/filter_stab.py:316
-#: ../../vdms_dialogs/filter_transpose.py:105
-#: ../../vdms_miniframes/timeline.py:262 ../../vdms_miniframes/timeline.py:281
 msgid "Reset"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:207
 msgid "Color Correction EQ Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:343
-#: ../../vdms_dialogs/filter_colorcorrection.py:383
-#: ../../vdms_dialogs/filter_colorcorrection.py:390
-#: ../../vdms_dialogs/filter_crop.py:417 ../../vdms_dialogs/filter_scale.py:287
-#: ../../vdms_dialogs/filter_scale.py:394 ../../vdms_dialogs/filter_stab.py:473
-#: ../../vdms_dialogs/filter_stab.py:483 ../../vdms_dialogs/filter_stab.py:494
-#: ../../vdms_dialogs/filter_transpose.py:182
-#: ../../vdms_dialogs/mediainfo.py:245 ../../vdms_dialogs/mediainfo.py:265
-#: ../../vdms_dialogs/mediainfo.py:285 ../../vdms_dialogs/mediainfo.py:305
-#: ../../vdms_dialogs/setting_profiles.py:281
-#: ../../vdms_dialogs/setting_profiles.py:289 ../../vdms_io/checkup.py:45
-#: ../../vdms_io/checkup.py:93 ../../vdms_io/io_tools.py:144
-#: ../../vdms_main/main_frame.py:904 ../../vdms_main/main_frame.py:939
-#: ../../vdms_main/main_frame.py:961 ../../vdms_main/main_frame.py:979
-#: ../../vdms_main/main_frame.py:999
-#: ../../vdms_panels/audio_encoders/acodecs.py:510
-#: ../../vdms_panels/audio_encoders/acodecs.py:800
-#: ../../vdms_panels/concatenate.py:186
-#: ../../vdms_panels/long_processing_task.py:60
-#: ../../vdms_panels/presets_manager.py:426
-#: ../../vdms_panels/presets_manager.py:490
-#: ../../vdms_panels/presets_manager.py:560
-#: ../../vdms_panels/presets_manager.py:599
-#: ../../vdms_panels/presets_manager.py:619
-#: ../../vdms_panels/presets_manager.py:657
-#: ../../vdms_panels/presets_manager.py:701
-#: ../../vdms_panels/presets_manager.py:714
-#: ../../vdms_panels/presets_manager.py:721
-#: ../../vdms_panels/presets_manager.py:756
-#: ../../vdms_panels/presets_manager.py:785
-#: ../../vdms_panels/presets_manager.py:791
-#: ../../vdms_panels/sequence_to_video.py:467
-#: ../../vdms_panels/sequence_to_video.py:473
-#: ../../vdms_panels/sequence_to_video.py:561
-#: ../../vdms_panels/sequence_to_video.py:571
-#: ../../vdms_panels/sequence_to_video.py:588
-#: ../../vdms_panels/sequence_to_video.py:596
-#: ../../vdms_panels/sequence_to_video.py:602
-#: ../../vdms_panels/sequence_to_video.py:643
-#: ../../vdms_panels/sequence_to_video.py:689
-#: ../../vdms_panels/video_to_sequence.py:512
-#: ../../vdms_panels/video_to_sequence.py:583
-#: ../../vdms_threads/ffplay_file.py:43
-#: ../../vdms_utils/presets_manager_utils.py:86
-#: ../../vdms_utils/presets_manager_utils.py:95
-#: ../../vdms_utils/queue_utils.py:68 ../../vdms_utils/queue_utils.py:82
-#: ../../vdms_utils/queue_utils.py:95
 msgid "Videomass - Error!"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:228 ../../vdms_dialogs/filter_scale.py:109
 #, python-brace-format
 msgid "Source size: {0} x {1} pixels"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:236
 msgid "Crop color"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:256
 msgid "Cropping area selection "
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:261 ../../vdms_dialogs/filter_scale.py:121
 msgid "Height"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:281
 msgid "Center"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:292 ../../vdms_dialogs/filter_scale.py:121
 msgid "Width"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:334
 msgid "Crop Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:335
 msgid "Choose the color to draw the cropping area"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:337
 msgid "Crop to width"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:338
 msgid "Move vertically (set to -1 to center the vertical axis)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:340
 msgid "Move horizontally (set to -1 to center the horizontal axis)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:342
 msgid "Crop to height"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:56
 msgid "Advanced Options"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:57
-#: ../../vdms_panels/av_conversions.py:351
 msgid "Deinterlace"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:59
 msgid "Interlace"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:63
 msgid "Deinterlaces with w3fdif filter"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:77
 msgid "Deinterlaces with yadif filter"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:101
 msgid "Interlaces with interlace filter"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:118
 msgid "Deinterlacing and Interlacing"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:144
 msgid "Deinterlace the input video with `w3fdif` filter"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:146
 msgid "Set the interlacing filter coefficients."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:148
-#: ../../vdms_dialogs/filter_deinterlace.py:158
 msgid "Specify which frames to deinterlace."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:150
 msgid "Deinterlace the input video with `yadif` filter. Using FFmpeg, this is the best and fastest choice"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:153
 msgid ""
 "mode\n"
 "The interlacing mode to adopt."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:155
 msgid ""
 "parity\n"
 "The picture field parity assumed for the input interlaced video."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:160
 msgid "Simple interlacing filter from progressive contents."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:162
 msgid ""
 "scan:\n"
 "determines whether the interlaced frame is taken from the even (tff - default) or odd (bff) lines of the progressive frame."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:166
 msgid ""
 "lowpass:\n"
 "Enable (default) or disable the vertical lowpass filter to avoid twitter interlacing and reduce moire patterns.\n"
 "Default is no setting."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:56
 msgid "Denoiser Filters"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:60
 msgid "Enable nlmeans denoiser"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:73
 msgid "nlmeans options"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:82
 msgid "Enable hqdn3d denoiser"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:91
 msgid "hqdn3d options"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:116
 msgid "Denoiser Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:117
 msgid ""
 "nlmeans:\n"
 "Denoise frames using Non-Local Means algorithm is capable of restoring video sequences, even with strong noise. It is ideal for enhancing the quality of old VHS tapes."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:122
 msgid ""
 "hqdn3d:\n"
 "This is a high precision/quality 3d denoise filter. It aims to reduce image noise, producing smooth images and making still images really still. It should enhance compressibility."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:81
 msgid "View result"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:85
 msgid "New size in pixels"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:89
 msgid "Width:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:99
 msgid "Height:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:115
 msgid "Constrain proportions (keep aspect ratio)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:120
 msgid "Which dimension to adjust?"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:129
 msgid "Aspect Ratio"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:132
 msgid "Setdar filter (display aspect ratio) example 16/9, 4/3 "
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:137
-#: ../../vdms_dialogs/filter_scale.py:171
 msgid "Numerator"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:162
-#: ../../vdms_dialogs/filter_scale.py:196
 msgid "Denominator"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:166
 msgid "Setsar filter (sample aspect ratio) example 1/1"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:217
 msgid "Resize Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:218
 msgid "Scale filter, set to 0 to disable"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:221
 msgid "Display Aspect Ratio. Set to 0 to disable"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:224
 msgid ""
 "Sample (aka Pixel) Aspect Ratio.\n"
 "Set to 0 to disable"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:366
 msgid ""
 "If you want to keep the aspect ratio, select \"Constrain proportions\" below and\n"
 "specify only one dimension, either width or height, and set the other dimension\n"
 "to -1 or -2 (some codecs require -2, so you should do some testing first)."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:81
 msgid "Enable stabilizer"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:83
 msgid "Create a side-by-side comparison video"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:88
 msgid "Create a snapshot"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:106
-#: ../../vdms_panels/audio_encoders/acodecs.py:167
 msgid "Preview"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:109
 msgid "Duration seconds:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:118
 msgid "Video Detect"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:176
 msgid "[TRIPOD] Enable tripod mode if checked"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:183
 msgid "Video transform"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:202
 msgid "[OPTALGO] optimization algorithm"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:224
 msgid "[CROP] Specify how to deal with borders at movement compensation"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:231
 msgid "[INVERT] Invert transforms if checked"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:234
 msgid "[RELATIVE] Consider transforms as relative to previous frame if checked, absolute if unchecked"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:279
 msgid "Specify type of interpolation"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:287
 msgid "[TRIPOD2] virtual tripod mode, equivalent to relative=unchecked:smoothing=0"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:294
 msgid "Unsharp filter:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:323
 msgid "Seek to a position on the video."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:325
 msgid "Make a snapshot of the video with the settings made."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:327
 msgid "Set the snapshot duration from 3 to 15 seconds from the seek position, default is 5 seconds."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:331
 msgid "Set how shaky the video is and how quick the camera is. A value of 1 means little shakiness, a value of 10 means strong shakiness. Default value is 5."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:335
 msgid "Set the accuracy of the detection process. A value of 1 means low accuracy, a value of 15 means high accuracy. Default value is 15."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:339
 msgid "Set stepsize of the search process. The region around minimum is scanned with 1 pixel resolution. Default value is 6."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:343
 msgid "Set minimum contrast. Below this value a local measurement field is discarded. The range is 0-1. Default value is 0.25."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:346
 msgid "Set reference frame number for tripod mode. If enabled, the motion of the frames is compared to a reference frame in the filtered stream, identified by the specified number. The idea is to compensate all movements in a more-or-less static scene and keep the camera view absolutely still. The frames are counted starting from 1."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:355
-msgid "Set the number of frames (value*2 + 1) used for lowpass filtering the camera movements. Default value is 15. For example a number of 10 means that 21 frames are used (10 in the past and 10 in the future) to smoothen the motion in the video. A larger value leads to a smoother video, but limits the acceleration of the camera (pan/tilt movements). 0 is a special case where a static camera is simulated."
+msgid ""
+"Set the number of frames (value*2 + 1) used for lowpass filtering the camera movements. Default value is 15. For example a number of 10 means that 21 frames are used (10 in the past and 10 in the future) to smoothen the motion in the video. A larger value leads to a smoother video, but limits the acceleration of the camera (pan/tilt movements). 0 is a special case where a static camera is "
+"simulated."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:363
 msgid "Set the camera path optimization algorithm. Values are: `gauss`: gaussian kernel low-pass filter on camera motion (default), and `avg`: averaging on transformations"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:367
 msgid "Set maximal angle in radians (degree*PI/180) to rotate frames. Default value is -1, meaning no limit."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:370
 msgid "Specify how to deal with borders that may be visible due to movement compensation. Values are: `keep` keep image information from previous frame (default), `black` fill the border black"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:375
 msgid "Invert transforms if checked. Default is unchecked."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:377
 msgid "Consider transforms as relative to previous frame if checked, absolute if unchecked. Default is checked."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:380
 msgid "Set percentage to zoom. A positive value will result in a zoom-in effect, a negative value in a zoom-out effect. Default value is 0 (no zoom)."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:384
 msgid "Set optimal zooming to avoid borders. Accepted values are: `0` disabled, `1` optimal static zoom value is determined (only very strong movements will lead to visible borders) (default), `2` optimal adaptive zoom value is determined (no borders will be visible), see zoomspeed. Note that the value given at zoom is added to the one calculated here."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:391
 msgid "Set percent to zoom maximally each frame (enabled when optzoom is set to 2). Range is from 0 to 5, default value is 0.25."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:395
 msgid "Specify type of interpolation. Available values are: `no` no interpolation, `linear` linear only horizontal, `bilinear` linear in both directions (default), `bicubic` cubic in both directions (slow)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:400
 msgid "Enable virtual tripod mode if checked, which is equivalent to relative=0:smoothing=0. Default is unchecked. Use also tripod option of vidstabdetect."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:405
 msgid "Sharpen or blur the input video. Note the use of the unsharp filter which is always recommended."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:409
 msgid "Video Stabilizer Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:541 ../../vdms_io/io_tools.py:73
 msgid "Videomass - Loading..."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:542
 msgid ""
 "Please wait,\n"
 "This process will take a few seconds."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:80
-#: ../../vdms_dialogs/filter_transpose.py:293
 msgid "Default position"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:86
 msgid "Rotation setting"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:94
 msgid "90° (left)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:96
 msgid "90° (right)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:100
 msgid "180°"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:115
 msgid "Transpose Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:229
 msgid "Rotate 90 degrees right"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:251
 msgid "Rotate 180 degrees"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:272
 msgid "Rotate 90 degrees left"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:82
 msgid "Format"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:96
 msgid "Video Stream"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:109
 msgid "Audio Streams"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:122
 msgid "Subtitle Streams"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:126
 msgid "Copy to clipboard"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:137
 msgid "FILE SELECTION"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:139 ../../vdms_dialogs/mediainfo.py:142
-#: ../../vdms_dialogs/mediainfo.py:145 ../../vdms_dialogs/mediainfo.py:148
-#: ../../vdms_main/main_frame.py:1318
 msgid "Properties"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:140 ../../vdms_dialogs/mediainfo.py:143
-#: ../../vdms_dialogs/mediainfo.py:146 ../../vdms_dialogs/mediainfo.py:149
 msgid "Values"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:152
 msgid "Streams Properties"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:244
 msgid "Unable to open the clipboard on Format tab"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:263
 msgid "Unable to open the clipboard on Video Streams tab"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:283
 msgid "Unable to open the clipboard on Audio Streams tab"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:303
 msgid "Unable to open the clipboard on Subtitle Streams tab"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:90
 msgid "Where do you prefer to save your transcodes?"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:101 ../../vdms_dialogs/preferences.py:128
-#: ../../vdms_dialogs/preferences.py:149 ../../vdms_dialogs/preferences.py:161
-#: ../../vdms_dialogs/preferences.py:173 ../../vdms_panels/filedrop.py:284
 msgid "Change"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:103
-#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:602
-#: ../../vdms_panels/presets_manager.py:1050
 msgid "Same destination paths as source files"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:108
 msgid "Assign optional suffix to destination file names:"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:114
 msgid "File removal preferences"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:118
 msgid "Trash the source files after successful encoding"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:131
 msgid "File Preferences"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:138
 msgid "Location of executables"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:140
 msgid ""
 "FFmpeg can be built by enabling/disabling its options and this depends on your needs.\n"
 "For some use cases it is possible to provide a custom build of FFmpeg where you can specify\n"
 "it in this preferences tab."
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:147
 msgid "Enable a custom location to run FFmpeg"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:159
 msgid "Enable a custom location to run FFprobe"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:171
 msgid "Enable a custom location to run FFplay"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:183
 msgid "FFmpeg"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:189
 msgid "Look and Feel (requires application restart)"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:194
 msgid "Icon themes"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:208
 msgid "At the top of window (default)"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:209
 msgid "At the bottom of window"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:210
 msgid "At the right of window"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:211
 msgid "At the left of window"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:213
 msgid "Place the toolbar"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:222
 msgid "Toolbar's icons size:"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:236
 msgid "Application Language (requires application restart)"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:248
 msgid "Look and Language"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:254
 msgid "Upon exiting the application"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:259
 msgid "Always ask me to confirm"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:261
 msgid "Clean the log files"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:264
 msgid "Remove cached files"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:268
 msgid "On operations completion"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:271
 msgid "These settings will remain active until the application is closed, If necessary, remember to reactivate them."
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:276
 msgid "Exit the application"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:279
 msgid "Shutdown the system"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:283
 msgid "SUDO password:"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:292
 msgid "Exit and Shutdown"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:298
 msgid "Specify the character encoding format"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:301
 msgid ""
 "Although UTF-8 is the default and most widely used standard encoding format, it is not the only encoding format available.\n"
 "Some file metadata may still contain non-UTF-8 character encodings resulting in the error \"'utf-8' codec can't decode bytes...\".\n"
 "If you know the encoding format the file was written in, you can try specifying it here, e.g. ISO 8859-1, ISO 8859-16, etc."
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:311
 msgid "Character encoding:"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:320
 msgid "Default application directories"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:324
 msgid "Configuration directory"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:337
 msgid "Cache directory"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:349
 msgid "Log directory"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:363
 msgid "Advanced"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:369
 msgid ""
 "The following settings affect output messages and the log messages during transcoding processes.\n"
 "Be careful, by changing these settings some functions of the application may not work correctly,\n"
 "change only if you know what you are doing.\n"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:376
 msgid "Set logging level flags used by FFmpeg"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:383
 msgid "Set logging level flags used by FFplay"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:391
 msgid "FFmpeg logging levels"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:437
 msgid "By assigning an additional suffix you could avoid overwriting files"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:440
 msgid "Type sudo password here, only for Unix-like operating systems, not for MS Windows"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:443
 msgid "Preferences"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:596 ../../vdms_dialogs/preferences.py:676
-#: ../../vdms_main/main_frame.py:879 ../../vdms_main/main_frame.py:1060
 msgid "Choose Destination"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:627
 msgid "Enter only alphanumeric characters. You can also use the hyphen (\"-\") and the underscore (\"_\"). Spaces are not allowed."
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:642
-#: ../../vdms_dialogs/setting_profiles.py:257
-#: ../../vdms_dialogs/setting_profiles.py:264
-#: ../../vdms_dialogs/setting_profiles.py:286
-#: ../../vdms_dialogs/setting_profiles.py:309 ../../vdms_main/main_frame.py:399
-#: ../../vdms_main/main_frame.py:421 ../../vdms_panels/av_conversions.py:605
-#: ../../vdms_panels/av_conversions.py:612
-#: ../../vdms_panels/sequence_to_video.py:352
-#: ../../vdms_panels/video_to_sequence.py:399
 msgid "Videomass - Warning!"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:731 ../../vdms_dialogs/preferences.py:771
-#: ../../vdms_dialogs/preferences.py:811 ../../vdms_dialogs/wizard_dlg.py:365
-#: ../../vdms_dialogs/wizard_dlg.py:384 ../../vdms_dialogs/wizard_dlg.py:403
 #, python-brace-format
 msgid "{} location"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:36
-#: ../../vdms_dialogs/setting_profiles.py:38
 msgid "One-Pass, Do not start with `ffmpeg -i filename`; do not end with `output-filename`"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:40
-#: ../../vdms_dialogs/setting_profiles.py:42
 msgid "Two-Pass (optional), Do not start with `ffmpeg -i filename`; do not end with `output-filename`"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:59
 msgid "Videomass - Edit the selected item in the queue"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:71
-#: ../../vdms_dialogs/setting_profiles.py:92
 msgid "Pre-input arguments for One-Pass (optional)"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:82
-#: ../../vdms_dialogs/setting_profiles.py:151
-#: ../../vdms_panels/presets_manager.py:255
 msgid "FFmpeg arguments for one-pass encoding"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:88
-#: ../../vdms_dialogs/setting_profiles.py:158
-#: ../../vdms_panels/presets_manager.py:259
 msgid "Any optional arguments to add before input file on the one-pass encoding, e.g required names of some hardware accelerations like -hwaccel to use with CUDA."
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:102
-#: ../../vdms_dialogs/setting_profiles.py:98
 msgid "Pre-input arguments for Two-Pass (optional)"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:113
-#: ../../vdms_dialogs/setting_profiles.py:152
-#: ../../vdms_panels/presets_manager.py:257
 msgid "FFmpeg arguments for two-pass encoding"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:120
-#: ../../vdms_dialogs/setting_profiles.py:162
-#: ../../vdms_panels/presets_manager.py:263
 msgid "Any optional arguments to add before input file on the two-pass encoding, e.g required names of some hardware accelerations like -hwaccel to use with CUDA."
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:65 ../../vdms_main/main_frame.py:508
-#: ../../vdms_panels/presets_manager.py:189
-#: ../../vdms_panels/video_to_sequence.py:171
 msgid "Edit"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:68
 msgid "Remove"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:71
 msgid "Remove all"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:74
 msgid ""
 "Export\n"
 "queue file"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:77
 msgid ""
 "Import\n"
 "queue file"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:85 ../../vdms_panels/filedrop.py:273
 msgid "Destination file name"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:137
 msgid "Remove all items in the queue"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:151
 msgid "Videomass - Queue"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:228
 msgid "Export queue file"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:296 ../../vdms_panels/av_conversions.py:1192
-#: ../../vdms_panels/presets_manager.py:1044
-#: ../../vdms_panels/video_to_sequence.py:600
 msgid "Same as source"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:301
 msgid ""
 "Source\n"
 "File destination\n"
@@ -1265,186 +885,129 @@ msgid ""
 "Clip duration"
 msgstr ""
 
-#: ../../vdms_dialogs/renamer.py:76
 msgid "# will be replaced by ascending numbers starting with:"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:87
 msgid "Font Size"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:111
 msgid "Font Color"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:121
 msgid "Shadow Color"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:132
 msgid "Show text box"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:136
 msgid "Box Color"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:156
 msgid "The timestamp size does not auto-adjust to the video size, you have to set the size here"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:160 ../../vdms_main/main_frame.py:559
 msgid "Timestamp settings"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:46
 msgid "Supported Formats list (optional). Do not include the `.`"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:47
 msgid "Output Format. Empty to copy format and codec. Do not include the `.`"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:70
 msgid "Profile Name"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:74
-#: ../../vdms_panels/presets_manager.py:404
 msgid "Description"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:149
 msgid "A short profile name"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:150
 msgid "A long description of the profile"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:153
 msgid "One or more comma-separated format names compatible with this profile"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:155
 msgid "Output format extension. Leave empty to copy codec and format"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:256
 msgid "Incomplete profile assignments"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:263
 msgid "Formats must be comma-separated"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:279
-#: ../../vdms_utils/queue_utils.py:80
 #, python-brace-format
 msgid ""
 "ERROR: Keys mismatched for requested data.\n"
 "Invalid file: «{0}»"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:285
-#: ../../vdms_dialogs/setting_profiles.py:308
 msgid "Profile already stored with same name"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:293
 msgid "Profile stored successfully!"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:311
 msgid "Profile change successful!"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:80
 msgid "Log file list"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:82 ../../vdms_dialogs/showlogs.py:116
 msgid "Log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:105
 msgid "Refresh log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:107
 msgid "Clear log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:160
 msgid "Select a log file"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:167
 msgid "Are you sure you want to clear the selected log file?"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:168 ../../vdms_dialogs/wizard_dlg.py:251
-#: ../../vdms_io/checkup.py:68 ../../vdms_main/main_frame.py:205
-#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1685
-#: ../../vdms_panels/presets_manager.py:349
-#: ../../vdms_panels/presets_manager.py:550
-#: ../../vdms_panels/presets_manager.py:590
-#: ../../vdms_panels/presets_manager.py:649
-#: ../../vdms_panels/presets_manager.py:684
-#: ../../vdms_panels/presets_manager.py:749
-#: ../../vdms_panels/presets_manager.py:775
-#: ../../vdms_panels/presets_manager.py:874
-#: ../../vdms_panels/presets_manager.py:904
 msgid "Please confirm"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:83
 msgid "File name"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:84
 msgid "Max volume dBFS"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:85
 msgid "Mean volume dBFS"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:86
 msgid "Offset dBFS"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:87
 msgid "Result dBFS"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:92
 msgid "Post-normalization references:"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:102
 msgid "=  Clipped peaks"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:111
 msgid "=  No changes"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:121
 msgid "=  Below max peak"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:166
-#: ../../vdms_panels/audio_encoders/acodecs.py:841
 msgid "RMS-based volume statistics"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:191
-#: ../../vdms_panels/audio_encoders/acodecs.py:839
 msgid "PEAK-based volume statistics"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:216
 msgid ""
 "...It means the resulting audio will be clipped,\n"
 "because its volume is higher than the maximum 0 db\n"
@@ -1452,34 +1015,28 @@ msgid ""
 "sound distorted."
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:242
 msgid ""
 "...It means the resulting audio will not change,\n"
 "because it's equal to the source."
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:266
 msgid ""
 "...It means an audio signal will be produced with\n"
 "a lower volume than the source."
 msgstr ""
 
-#: ../../vdms_dialogs/videomass_check_version.py:63
 msgid "Get Latest Version"
 msgstr ""
 
-#: ../../vdms_dialogs/videomass_check_version.py:67
 msgid "Checking for newer version"
 msgstr ""
 
-#: ../../vdms_dialogs/videomass_check_version.py:95
 msgid ""
 "\n"
 "\n"
 "New releases fix bugs and offer new features."
 msgstr ""
 
-#: ../../vdms_dialogs/videomass_check_version.py:96
 #, python-brace-format
 msgid ""
 "\n"
@@ -1488,7 +1045,6 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../../vdms_dialogs/while_playing.py:37
 msgid ""
 "q, ESC\n"
 "f\n"
@@ -1511,115 +1067,89 @@ msgid ""
 "left mouse double-click"
 msgstr ""
 
-#: ../../vdms_dialogs/while_playing.py:92
 msgid "Shortcut keys while playing with FFplay"
 msgstr ""
 
-#: ../../vdms_dialogs/widget_utils.py:120 ../../vdms_main/main_frame.py:1326
 msgid "Stop"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:63
 msgid "Please take a moment to set up the application"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:64
 msgid "Click the \"Next\" button to get started"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:79
 msgid "Welcome to the Videomass Wizard!"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:123
 msgid "Videomass is an application based on FFmpeg\n"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:125
 msgid "If FFmpeg is not on your computer, this application will be unusable"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:128
 msgid ""
 "If you have already installed FFmpeg on your operating system,\n"
 "click the \"Auto-detection\" button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:131
 msgid ""
 "If you want to use a version of FFmpeg located on your filesystem\n"
 "but not installed on your operating system,\n"
 "click the \"Locate\" button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:162
 msgid "Auto-detection"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:164
 msgid "Locate"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:214
 msgid "Click the \"Next\" button"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:235
 #, python-brace-format
 msgid "'{}' is not installed on your computer. Install it or indicate another location by clicking the 'Locate' button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:249
 msgid ""
 "Videomass already seems to include FFmpeg.\n"
 "\n"
 "Do you want to use that?"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:275
 msgid "Locating FFmpeg executables\n"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:277
 msgid ""
 "\"ffmpeg\", \"ffprobe\" and \"ffplay\" are required. Complete all\n"
 "the text boxes below by clicking on the respective buttons."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:437
 msgid "Wizard completed successfully!\n"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:438
 msgid "Remember that you can always change these settings later, through the Preferences dialog."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:440
 msgid "Thank You!"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:441
 msgid "To exit click the \"Finish\" button"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:527
 msgid "< Previous"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:530 ../../vdms_dialogs/wizard_dlg.py:613
 msgid "Next >"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:535
 msgid "Videomass Wizard"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:563 ../../vdms_dialogs/wizard_dlg.py:586
-#: ../../vdms_dialogs/wizard_dlg.py:591
 msgid "Finish"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:44 ../../vdms_io/checkup.py:92
 #, python-brace-format
 msgid ""
 "Output folder does not exist:\n"
@@ -1627,432 +1157,326 @@ msgid ""
 "\"{}\"\n"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:65
 msgid "Files already exist, do you want to overwrite them?"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:67
 msgid "Already exist"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:81
 msgid "Not found"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:82 ../../vdms_panels/filedrop.py:196
 msgid "Error list"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:83
 msgid "File(s) not found"
 msgstr ""
 
-#: ../../vdms_io/io_tools.py:56
 #, python-format
 msgid "File does not exist or is invalid:  %s"
 msgstr ""
 
-#: ../../vdms_io/io_tools.py:74
 msgid ""
 "Wait....\n"
 "Audio peak analysis."
 msgstr ""
 
-#: ../../vdms_io/io_tools.py:179
 msgid "Videomass - Downloading..."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1409
-#: ../../vdms_main/main_frame.py:1441
 msgid "Ready"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:203
 msgid ""
 "Not all items in the queue were completed.\n"
 "\n"
 "Would you like to keep them in the queue?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:224
 #, python-brace-format
 msgid "Queue ({0})"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:229 ../../vdms_main/main_frame.py:1334
 msgid "Queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:396 ../../vdms_main/main_frame.py:418
 msgid "There are still active windows with running processes, make sure you finish your work before exit."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:403
 msgid "Are you sure you want to exit the application?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:405
 msgid "Exit"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:463
 msgid "Import files\tCtrl+O"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:466
 msgid "Open destination folder of encodings\tCtrl+D"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:469
 msgid "Load queue file"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:470
 msgid "Load a previously exported queue file"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:473
 msgid "Open trash"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:474
 msgid "Open the Videomass trash folder"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:476
 msgid "Empty trash"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:477
 msgid "Delete all files in the Videomass trash folder"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:480
 msgid "Exit\tCtrl+Q"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:481
 msgid "Completely exit the application"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:482
 msgid "File"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:486 ../../vdms_panels/filedrop.py:340
-#: ../../vdms_panels/filedrop.py:381
 msgid "Rename selected file\tCtrl+R"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:487
 msgid "Rename the destination of the selected file"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:490 ../../vdms_panels/filedrop.py:341
-#: ../../vdms_panels/filedrop.py:384
 msgid "Batch rename files\tCtrl+B"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:491
 msgid "Numerically renames the destination of all items in the list"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:496 ../../vdms_panels/filedrop.py:343
-#: ../../vdms_panels/filedrop.py:388
 msgid "Remove selected entry\tDEL"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:497
 msgid "Remove the selected file from the list"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:500 ../../vdms_panels/filedrop.py:344
-#: ../../vdms_panels/filedrop.py:391
 msgid "Clear list\tShift+DEL"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:501
 msgid "Clear the file list"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:506
 msgid "Preferences\tCtrl+P"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:507
 msgid "Application preferences"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:512
 msgid "Find FFmpeg topics"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:513
 msgid "A useful tool to search for FFmpeg help topics and options"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:518
 msgid "Check for preset updates"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:519
 #, python-brace-format
 msgid "Check for new presets updates from {0}"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:521
 msgid "Get latest presets"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:522
 #, python-brace-format
 msgid "Get the latest presets from {0}"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:525
 msgid "Work notes\tCtrl+N"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:526
 msgid "Read and write useful notes and reminders."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:528
 msgid "Tools"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:535
 msgid "Show FFmpeg's built-in configuration capabilities"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:539
 msgid "Muxers and demuxers available on your version of FFmpeg"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:543
 msgid "Encoders available on your version of FFmpeg"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:546
 msgid "Decoders available on your version of FFmpeg"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:550
 msgid "Enable timestamps on playback"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:551
 msgid "Displays timestamp when playing media with FFplay"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:554
 msgid "Auto-exit after playback"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:555
 msgid "If checked, the FFplay window will auto-close when playback is complete"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:559
 msgid "Customize the timestamp style"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:562
 msgid "While playing..."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:563
 msgid "Show useful shortcut keys when playing or previewing using FFplay"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:567
 msgid "Show timeline editor\tCtrl+T"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:568
 msgid "Set duration or trim slices of time to remove unwanted parts from your files"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:572
 msgid "View"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:579
 msgid "Home panel\tCtrl+Shift+H"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:580
 msgid "Go to the «Home» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:583
 msgid "Presets Manager\tCtrl+Shift+P"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:584
 msgid "Go to the «Presets Manager» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:586
 msgid "A/V Conversions\tCtrl+Shift+V"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:587
 msgid "Go to the «A/V Conversions» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:589
 msgid "Concatenate Demuxer\tCtrl+Shift+D"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:590
 msgid "Go to the «Concatenate Demuxer» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:593
 msgid "Still Image Maker\tCtrl+Shift+I"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:594
 msgid "Go to the «Still Image Maker» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:596
 msgid "From Movie to Pictures\tCtrl+Shift+S"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:597
 msgid "Go to the «From Movie to Pictures» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:600
 msgid "Output monitor\tCtrl+Shift+O"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:601
 msgid "Keeps track of the output for debugging errors"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:603
 msgid "Go"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:607
 msgid "User guide"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:611
 msgid "System version"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:612
 msgid "Get version about your operating system, version of Python and wxPython."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:616
 msgid "Show log files\tCtrl+L"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:617
 msgid "Viewing log messages"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:620
 msgid "Issue tracker"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:624
 msgid "Contribute to the project"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:627
 msgid "Sponsor this project"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:628
 msgid "Become a developer supporter"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:629
 msgid "Donate"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:630
 msgid "Donate to the app developer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:634
 msgid "Other projects by the developer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:650
 msgid "About Videomass"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:651
 msgid "Check for newer version"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:652
 msgid "Check for the latest Videomass version"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:654
 msgid "Help"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:729
 msgid "Import files"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:752
 msgid "No default folder has been set for the destination of the encodings. The current setting is \"Same destination paths as source files\"."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:784 ../../vdms_main/main_frame.py:809
 #, python-brace-format
 msgid ""
 "'{}':\n"
 "No such file or directory"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:797
 msgid "Are you sure to empty trash folder?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:805
 #, python-brace-format
 msgid ""
 "'{}':\n"
 "There are no files to delete."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:862
 #, python-brace-format
 msgid "Installed release v{0}. A new presets release is available {1}"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:866
 #, python-brace-format
 msgid "Installed release v{0}. No new updates found."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:896
 msgid ""
 "Wait....\n"
 "The archive is being downloaded"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:908
 #, python-brace-format
 msgid "Successfully downloaded to \"{0}\""
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1120
 msgid "Some changes require restarting the application."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1126
 #, python-brace-format
 msgid ""
 "{0}\n"
@@ -2060,214 +1484,159 @@ msgid ""
 "Do you want to restart the application now?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1128
 msgid "Restart Videomass?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1207
 #, python-brace-format
 msgid "A new release is available - v.{0}\n"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1210
 msgid "You are using a development version that has not yet been released!\n"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1213
 msgid "Congratulation! You are already using the latest version.\n"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1301
 msgid "Previous panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1302
 msgid "Back"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1305
 msgid "Next panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1306
 msgid "Next"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1309
 msgid "Home panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1310
 msgid "Home"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1313
 msgid "Play the selected imput file"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1314
 msgid "Play"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1317
 msgid "Get informative data about imported media streams"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1321
 msgid "Start batch processing"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1325
 msgid "Stops current process"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1329
 msgid "Add an item to Queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1330
 msgid "Add to Queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1333
 msgid "Show queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1408 ../../vdms_panels/presets_manager.py:569
 msgid "Videomass"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1442
 msgid "Videomass - File List"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1459
 msgid "Videomass - AV Conversions"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1488
 msgid "Videomass - Presets Manager"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1518
 msgid "Videomass - Concatenate Demuxer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1547
 msgid "Videomass - From Movie to Pictures"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1576
 msgid "Videomass - Still Image Maker"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1660 ../../vdms_panels/av_conversions.py:577
-#: ../../vdms_panels/filedrop.py:500 ../../vdms_panels/filedrop.py:616
-#: ../../vdms_panels/sequence_to_video.py:322
-#: ../../vdms_panels/video_to_sequence.py:369
-#: ../../vdms_panels/video_to_sequence.py:501
 msgid "Have to select an item in the file list first"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1682
 msgid ""
 "An item with the same destination file already exists.\n"
 "\n"
 "Do you want to replace it by adding the new item to the queue?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1703
 msgid "Videomass - FFmpeg Message Monitoring"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1828
 #, python-brace-format
 msgid "The system will turn off in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1829
 msgid "Videomass - Shutdown!"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1836
 msgid "Error while shutting down. Please see file log for details."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1848
 #, python-brace-format
 msgid "Exiting the application in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1849
 msgid "Videomass - Exiting!"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:46
 msgid "Start point adjustment"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:48
 msgid "End point adjustment"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:105
 msgid "Hours"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:106
 msgid "Minutes"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:107
 msgid "Seconds"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:108
 msgid "Milliseconds"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:189 ../../vdms_miniframes/timeline.py:312
 msgid "No source duration:"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:208 ../../vdms_miniframes/timeline.py:298
-#: ../../vdms_miniframes/timeline.py:333 ../../vdms_miniframes/timeline.py:338
-#: ../../vdms_miniframes/timeline.py:441
 #, python-brace-format
 msgid "{0} {1}  |  Segment Duration: {2}"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:260 ../../vdms_miniframes/timeline.py:277
 msgid "End adjustment"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:261 ../../vdms_miniframes/timeline.py:279
 msgid "Start adjustment"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:320
 msgid "Source duration:"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:387
 msgid "WARNING: Invalid selection, out of range."
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:461
 msgid ""
 "Start by dragging the bottom left handle,\n"
 "or right-click for options."
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:497
 msgid "Start"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:498
 msgid "End"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:548
 msgid ""
 "The timeline editor is a tool that allows you to trim slices of time on selected imported media (see File List panel).\n"
 "\n"
@@ -2280,39 +1649,30 @@ msgid ""
 "The \"Start\"/\"End\" duration values always refer to the initial position of the timeline: 00:00:00.000. For other informations as the segment duration and warnings, please refer to the status bar messages."
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:565
 msgid "Timeline Editor Usage"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:153
 msgid "Media:"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:169
 msgid "Container:"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:180
 msgid "Save profile"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:183
 msgid "Target"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:316
 msgid "Miscellaneous"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:323
 msgid "Save as a new profile of the Presets Manager."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:325
 msgid "Available video encoders. \"Copy\" means that the video stream will not be re-encoded and will allow you (depending on the encoder) to change the container, audio codec and a few other parameters."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:330
 msgid ""
 "Container format. It is usually represented by the file extension (output format).\n"
 "\n"
@@ -2321,73 +1681,53 @@ msgid ""
 "If the media target is set to \"Audio\", you can extract only the audio streams from videos, or simply convert audio source files."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:338
 msgid ""
 "Set output files target: \"Video\" to save output files as video files; \"Audio\" to save files using an audio encoder and format.\n"
 "\n"
 "Note that by using \"Audio\" as the target, you will still be able to work on the video source files but you will only be able to extract the audio streams, convert them and apply audio filters such as normalization."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:346
 msgid "Preview video filters"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:347
 msgid "Disable active filters"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:348
-#: ../../vdms_panels/sequence_to_video.py:156
-#: ../../vdms_panels/video_to_sequence.py:113
 msgid "Resize"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:349
 msgid "Crop"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:350
 msgid "Transpose"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:352
 msgid "Denoise"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:353
 msgid "Stabilize"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:354
 msgid "Equalize"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:517
 msgid "Unable to preview Video Stabilizer filter"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:602
 msgid ""
 "Unsupported file:\n"
 "Missing decoder or library? Check FFmpeg configuration."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:611
-#: ../../vdms_panels/sequence_to_video.py:351
-#: ../../vdms_panels/video_to_sequence.py:398
 msgid "The file is not a frame or a video file"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:434
-#: ../../vdms_panels/av_conversions.py:861
 msgid "Undetected volume values! Click the \"Volume detect\" button to analyze audio volume data."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1186
 msgid "Off"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1203
 msgid ""
 "Batch processing items\n"
 "Destination\n"
@@ -2402,109 +1742,81 @@ msgid ""
 "Clip duration"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1246
-#: ../../vdms_panels/presets_manager.py:814
 #, python-brace-format
 msgid "Write profile on «{0}»"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1266
-#: ../../vdms_panels/presets_manager.py:513
 msgid "Enter name for new preset"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1276
-#: ../../vdms_panels/presets_manager.py:524
 msgid "Invalid file name, make sure to provide a valid name including the «.json» extension"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1284
 #, python-brace-format
 msgid "Cannot save current data in file «{}»."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1289
 msgid "Open Videomass preset"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1307
 msgid "Videomass - Save new profile"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1308
 msgid "Where do you want to save this profile?"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1309
 msgid "Save the profile to a new preset"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1310
 msgid "Save the profile to an existing preset"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:69
 msgid "Welcome to Videomass"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:71
 #, python-brace-format
 msgid "Version {}"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:82
 msgid "Presets Manager"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:85
 msgid "AV-Conversions"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:88
 msgid "Concatenate media files"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:91
 msgid "Still Image Maker"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:94
 msgid "From Movie to Pictures"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:123
 msgid "Create, edit and use quickly your favorite FFmpeg presets and profiles with full formats support and codecs."
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:127
 msgid "A set of useful tools for audio and video conversions. Save your profiles and reuse them with Presets Manager."
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:131
 msgid "Concatenate multiple media files based on import order without re-encoding"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:134
 msgid "Create video from a sequence of images, based on import order, with the ability to add an audio file."
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:137
 msgid "Extract images (frames) from your movies in JPG, PNG, BMP, GIF formats."
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:47
 msgid "At least two files are required to perform concatenation."
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:63
 msgid "Invalid data found"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:68
 msgid "The files do not have the same \"codec_types\", same \"sample_rate\" or same \"width\" or \"height\". Unable to proceed."
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:84
 msgid ""
 "\n"
 "- The concatenation function is performed only with Audio files or only with Video files.\n"
@@ -2520,17 +1832,12 @@ msgid ""
 "- Audio files must have exactly the same formats, same codecs with equal sample rate."
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:125
 msgid "Videomass Documentation:"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:136
-#: ../../vdms_panels/sequence_to_video.py:212
-#: ../../vdms_panels/video_to_sequence.py:181
 msgid "Official FFmpeg documentation:"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:253
 msgid ""
 "Items to concatenate\n"
 "File destination\n"
@@ -2539,250 +1846,188 @@ msgid ""
 "Duration"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:45
 msgid "File has illegal characters like:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:46
 msgid "Invalid character found in path name: (\")"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:47
 msgid "Directories are not allowed, just add files, please."
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:48
 msgid "File without format extension: please give an appropriate extension to the file name, example '.mkv', '.avi', '.mp3', etc."
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:84
 #, python-brace-format
 msgid "Name has illegal characters like: {0}"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:85
 msgid "Name already in use:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:185
 msgid "Duplicate file, it has already been added to the list."
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:197
 msgid "Rejected files"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:269
 msgid "Source file"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:270
 msgid "Duration"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:271
 msgid "Media type"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:272
 msgid "Size"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:405
 msgid "Drag one or more files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:282
 msgid "Save to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:306
 msgid "Set a new destination folder for encodings"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:308
 msgid "Encodings destination folder"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:394
 msgid "Play file"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:408
 msgid "Drag two or more Audio/Video files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:412
 msgid "Drag one or more Image files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:415
 msgid "Drag one or more Video files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:623
 msgid "Rename the file destination"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:624
 msgid "Rename the selected file to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:638 ../../vdms_panels/filedrop.py:648
-#: ../../vdms_panels/filedrop.py:679
 msgid "Add Files"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:655
 msgid "Rename in batch"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:656
 #, python-brace-format
 msgid "Rename the {0} items to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:658
 msgid "New Name #"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:114
 msgid "Sorry, all task failed !"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:115
 msgid "The process was stopped due to a fatal error."
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:116
 msgid "Interrupted Process !"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:117
 msgid "Successfully completed !"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:118
 msgid "Not everything was successful."
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:148
 msgid "Encoding Status"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:152
 msgid "Current Log"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:354
 msgid "Fatal Error !"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:363
 msgid "Get your files at the destination you specified"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:377
 msgid "For more details please read the Current Log."
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:380
 msgid "...Finished"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:399
 msgid "Please wait... interruption in progress"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:402
 msgid "...Interrupted"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:166
 msgid "Presets"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:180
 msgid "Write"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:184
 msgid "Delete"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:194
 msgid "Duplicate"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:199
 msgid "Profiles"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:206
 msgid "One-Pass Encoding"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:218
 msgid "Two-Pass Encoding"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:232
 msgid "Choose a preset and view its profiles"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:233
 msgid "Write a new profile and save it in the selected preset"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:235
 msgid "Delete the selected profile"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:236
 msgid "Edit the selected profile"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:237
 msgid "Duplicate the selected profile"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:238
 msgid "Create new preset"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:240
 msgid "Remove selected preset"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:242
 msgid "Backup selected preset"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:244
 msgid "Backup the presets folder"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:246
 msgid "Restore a preset"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:248
 msgid "Restore a presets folder"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:250
 msgid "Resets the selected preset to default values"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:252
 msgid "Reset all presets to default values"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:254
 msgid "Refresh the presets list"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:338
 #, python-brace-format
 msgid ""
 "Outdated presets version found: v{1}\n"
@@ -2796,28 +2041,22 @@ msgid ""
 "Do you want to perform this update now?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:403
 msgid "Name"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:405
 msgid "Output Format"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:406
 msgid "Supported Format List"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:531
 #, python-brace-format
 msgid "Cannot save current data in file '{}'."
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:535
 msgid "You just successfully created a new preset!"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:547
 #, python-brace-format
 msgid ""
 "Are you sure you want to remove \"{}\" preset?\n"
@@ -2825,7 +2064,6 @@ msgid ""
 " It will be moved to the \"Removals\" subfolder inside the presets folder."
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:558
 #, python-brace-format
 msgid ""
 "{}\n"
@@ -2833,72 +2071,55 @@ msgid ""
 "Sorry, removal failed, cannot continue.."
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:568
 #, python-brace-format
 msgid "The preset \"{0}\" was successfully removed"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:583
-#: ../../vdms_panels/presets_manager.py:612
 msgid "Open a destination folder"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:588
 msgid "A file with this name already exists, do you want to overwrite it?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:602
-#: ../../vdms_panels/presets_manager.py:622
 msgid "Backup completed successfully"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:631
 msgid "Open the preset you want to restore"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:645
 msgid ""
 "This preset already exists and is about to be updated. Don't worry, it will keep all your saved profiles.\n"
 "\n"
 "Do you want to continue?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:663
 msgid "Restore successful"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:681
 msgid ""
 "This will update the presets database. Don't worry, it will keep all your saved profiles.\n"
 "\n"
 "Do you want to continue?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:689
 msgid "Open the presets folder to restore"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:725
 msgid "The presets database has been successfully updated"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:740
 msgid "The selected preset is not part of Videomass's default presets."
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:745
 msgid ""
 "Be careful! The selected preset will be overwritten with the default one. Your profiles may be deleted!\n"
 "\n"
 "Do you want to continue?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:760
-#: ../../vdms_panels/presets_manager.py:794
 msgid "Successful recovery"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:769
 msgid ""
 "Be careful! This action will restore all presets to default ones. Your profiles may be deleted!\n"
 "\n"
@@ -2907,30 +2128,24 @@ msgid ""
 "Do you want to continue?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:833
 #, python-brace-format
 msgid "Edit profile on «{0}»"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:872
 msgid "Are you sure you want to delete the selected profile? It will no longer be possible to recover it."
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:891
 msgid "First select a profile in the list"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:899
 msgid ""
 "The selected profile command has been changed manually.\n"
 "Do you want to apply it during the conversion process?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:909
 msgid "Don't show this dialog again"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:1054
 msgid ""
 "Batch processing items\n"
 "Destination\n"
@@ -2942,11 +2157,9 @@ msgid ""
 "Clip duration"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:54
 msgid "Images need to be resized, please use Resize function."
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:73
 msgid ""
 "\n"
 "1. Import one or more image files such as JPG, PNG and BMP formats, then select one.\n"
@@ -2964,38 +2177,29 @@ msgid ""
 "will be saved in a folder named 'Still_Images' with a progressive digit, in the path you specify."
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:129
 msgid "Enable a single still image"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:162
 msgid ""
 "Force original aspect ratio using\n"
 "padding rather than stretching"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:170
 msgid "Include audio file"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:173
 msgid "Play the video until audio track finishes"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:180
-#: ../../vdms_panels/sequence_to_video.py:439
 msgid "Open audio file"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:199
 msgid "Additional arguments"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:454
 msgid "Open Audio File"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:466
 #, python-brace-format
 msgid ""
 "Invalid file: '{}'\n"
@@ -3003,7 +2207,6 @@ msgid ""
 "{}"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:471
 #, python-brace-format
 msgid ""
 "Invalid file: '{}'\n"
@@ -3011,21 +2214,14 @@ msgid ""
 "It doesn't appear to be an audio file."
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:560
-#: ../../vdms_panels/sequence_to_video.py:587
-#: ../../vdms_panels/video_to_sequence.py:511
 #, python-brace-format
 msgid "Invalid file: '{}'"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:570
-#: ../../vdms_panels/sequence_to_video.py:595
 #, python-brace-format
 msgid "Unsupported format '{}'"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:576
-#: ../../vdms_panels/sequence_to_video.py:600
 #, python-brace-format
 msgid ""
 "File does not exist:\n"
@@ -3033,15 +2229,9 @@ msgid ""
 "\"{}\"\n"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:577
 msgid "ERROR"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:707
-msgid "Shortest"
-msgstr ""
-
-#: ../../vdms_panels/sequence_to_video.py:715
 msgid ""
 "Items to concatenate\n"
 "Output filename\n"
@@ -3057,7 +2247,6 @@ msgid ""
 "Overall video duration"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:50
 msgid ""
 "\n"
 "1. Import one or more video files, then select one.\n"
@@ -3074,51 +2263,39 @@ msgid ""
 "with a progressive digit, in the path you specify."
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:86
 msgid "Create thumbnails"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:87
 msgid "Create tiled mosaics"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:88
 msgid "Create animated GIF"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:90
 msgid "Options"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:119
 msgid "Output format:"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:131
 msgid "Rows:"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:141
 msgid "Columns:"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:205
 msgid "Other unofficial resources:"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:229
 msgid "Set FPS control from 0.1 to 30.0 fps. The higher this value, the more images will be extracted."
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:232
 msgid "Spaces around the mosaic tiles. From 0 to 32 pixels"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:234
 msgid "Spaces around the mosaic borders. From 0 to 32 pixels"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:626
 msgid ""
 "Selected File\n"
 "Output Format\n"
@@ -3134,58 +2311,45 @@ msgid ""
 "Duration"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:118
 msgid "Audio encoder settings, mapping and filters"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:128
 msgid "Audio Encoder"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:137
 msgid "Settings"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:148
 msgid "Index Selection:"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:157
 msgid "Map:"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:180
 msgid "Normalization"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:191
 msgid "Volume detect"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:195
 msgid "Volume Statistics"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:199
 msgid "Target level:"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:264
 msgid "Gets maximum volume and average volume data in dBFS, then calculates the offset amount for audio normalization."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:267
 msgid "Limiter for the maximum peak level or the mean level (when switch to RMS) in dBFS. From -99.0 to +0.0; default for PEAK level is -1.0; default for RMS is -20.0"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:271
 msgid ""
 "Normally on a video with correctly indexed streams and having one or more audio streams, the first audio stream should be indexed at \"1\", the second at \"2\" and so on (the video stream on the other hand is always indexed at \"0\"). In this case it is recommended to select the desired stream by setting a specific index, e.g \"1\" for for the first available audio stream.\n"
 "\n"
 "Set this control to \"Auto\" if the source file is simply an audio track."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:280
 msgid ""
 "\"Auto\" keeps all audio streams and processes only the one selected by the \"Index Selection\" control.\n"
 "\n"
@@ -3194,70 +2358,55 @@ msgid ""
 "\"Index Only\" processes only the audio stream selected by the \"Index Selection\" control and removes all others from the video"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:288
 msgid "Integrated Loudness Target in LUFS. From -70.0 to -5.0, default is -16.0"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:291
 msgid "Maximum True Peak in dBTP. From -1.5 to +0.0, default is -2.0"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:294
 msgid "Loudness Range Target in LUFS. From +1.0 to +20.0, default is +11.0"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:297
 msgid "Play the audio stream selected in the \"Index Selection\" control. Using this function you can test the result of audio normalization."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:503
 msgid "Selected index does not exist or does not contain any audio streams"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:508
 #, python-brace-format
 msgid ""
 "ERROR: Missing audio stream:\n"
 "\"{}\""
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:726
 msgid "PEAK level normalization, which will produce a maximum peak level equal to the set target level."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:729
 msgid "RMS-based normalization, which according to mean volume calculates the amount of gain to reach same average power signal."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:733
 msgid ""
 "Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements the EBU R128 algorithm.\n"
 "Ideal for live normalization. It produces worse results than the High-quality two-pass Loudnorm normalization, but is faster."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:740
 msgid ""
 "High-quality two-pass Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements\n"
 "the EBU R128 algorithm. Ideal for postprocessing."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:789
 msgid "You need to import at least one file"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:63
 msgid "Subtitle Mapping:"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:77
 msgid "Copy Chapters"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:79
 msgid "Copy Metadata"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:85
 msgid ""
 "Select \"All\" to include any source file subtitles in the output video.\n"
 "\n"
@@ -3266,147 +2415,63 @@ msgid ""
 "This option is automatically ignored for output audio files."
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:90
 msgid "Copy the chapter markers as is from source file. This option is automatically ignored for output audio files."
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:93
 msgid "Copy all incoming metadata from source file, such as audio/video tags, titles, unique marks, and so on."
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:108
 msgid "Additional options"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:89
-#: ../../vdms_panels/video_encoders/av1_svt.py:120
-#: ../../vdms_panels/video_encoders/avc_x264.py:90
-#: ../../vdms_panels/video_encoders/hevc_x265.py:98
-#: ../../vdms_panels/video_encoders/mpeg4.py:71
-#: ../../vdms_panels/video_encoders/vp9_webm.py:131
 msgid "Reload"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:101
-#: ../../vdms_panels/video_encoders/av1_svt.py:129
-#: ../../vdms_panels/video_encoders/avc_x264.py:101
-#: ../../vdms_panels/video_encoders/hevc_x265.py:109
-#: ../../vdms_panels/video_encoders/mpeg4.py:82
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:97
-#: ../../vdms_panels/video_encoders/vp9_webm.py:141
 msgid "Optimize for Web"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:247
-#: ../../vdms_panels/video_encoders/av1_svt.py:313
-#: ../../vdms_panels/video_encoders/avc_x264.py:242
-#: ../../vdms_panels/video_encoders/hevc_x265.py:250
-#: ../../vdms_panels/video_encoders/mpeg4.py:198
-#: ../../vdms_panels/video_encoders/vp9_webm.py:288
 msgid "Reloads the selected video encoder settings. Changes will be discarded."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:250
-#: ../../vdms_panels/video_encoders/avc_x264.py:273
-#: ../../vdms_panels/video_encoders/hevc_x265.py:277
-#: ../../vdms_panels/video_encoders/vp9_webm.py:291
 msgid "Constant rate factor. Lower values correspond to higher quality and greater file size. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:254
-#: ../../vdms_panels/video_encoders/av1_svt.py:357
-#: ../../vdms_panels/video_encoders/vp9_webm.py:295
 msgid "Number of tile rows to use, default changes per resolution"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:256
-#: ../../vdms_panels/video_encoders/av1_svt.py:359
-#: ../../vdms_panels/video_encoders/vp9_webm.py:297
 msgid "Number of tile columns to use, default changes per resolution"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:259
-#: ../../vdms_panels/video_encoders/av1_svt.py:368
-#: ../../vdms_panels/video_encoders/avc_x264.py:253
-#: ../../vdms_panels/video_encoders/hevc_x265.py:261
-#: ../../vdms_panels/video_encoders/mpeg4.py:201
-#: ../../vdms_panels/video_encoders/vp9_webm.py:300
 msgid "Set the Group Of Picture (GOP). Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:262
-#: ../../vdms_panels/video_encoders/av1_svt.py:371
-#: ../../vdms_panels/video_encoders/avc_x264.py:256
-#: ../../vdms_panels/video_encoders/hevc_x265.py:264
-#: ../../vdms_panels/video_encoders/mpeg4.py:204
-#: ../../vdms_panels/video_encoders/vp9_webm.py:303
 msgid "It can reduce the file size, but takes longer."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:264
-#: ../../vdms_panels/video_encoders/av1_svt.py:373
-#: ../../vdms_panels/video_encoders/avc_x264.py:258
-#: ../../vdms_panels/video_encoders/hevc_x265.py:266
-#: ../../vdms_panels/video_encoders/mpeg4.py:206
-#: ../../vdms_panels/video_encoders/vp9_webm.py:305
 msgid "Set minimum bitrate tolerance. Most useful in setting up a CBR encode. It is of little use otherwise. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:268
-#: ../../vdms_panels/video_encoders/av1_svt.py:377
-#: ../../vdms_panels/video_encoders/avc_x264.py:262
-#: ../../vdms_panels/video_encoders/hevc_x265.py:270
-#: ../../vdms_panels/video_encoders/mpeg4.py:210
-#: ../../vdms_panels/video_encoders/vp9_webm.py:309
 msgid "Specifies a maximum tolerance. Requires bufsize to be set. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:271
-#: ../../vdms_panels/video_encoders/av1_svt.py:380
-#: ../../vdms_panels/video_encoders/avc_x264.py:265
-#: ../../vdms_panels/video_encoders/hevc_x265.py:273
-#: ../../vdms_panels/video_encoders/mpeg4.py:213
-#: ../../vdms_panels/video_encoders/vp9_webm.py:312
 msgid "Set ratecontrol buffer size, which determines the variability of the output bitrate. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:275
-#: ../../vdms_panels/video_encoders/av1_svt.py:384
-#: ../../vdms_panels/video_encoders/avc_x264.py:277
-#: ../../vdms_panels/video_encoders/hevc_x265.py:281
-#: ../../vdms_panels/video_encoders/mpeg4.py:231
-#: ../../vdms_panels/video_encoders/vp9_webm.py:316
 msgid "Specifies the target (average) bit rate for the encoder to use. Higher value = higher quality. Set -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:279
-#: ../../vdms_panels/video_encoders/av1_svt.py:388
-#: ../../vdms_panels/video_encoders/avc_x264.py:281
-#: ../../vdms_panels/video_encoders/hevc_x265.py:285
-#: ../../vdms_panels/video_encoders/mpeg4.py:235
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:131
-#: ../../vdms_panels/video_encoders/vp9_webm.py:320
 msgid "Video width and video height ratio."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:281
-#: ../../vdms_panels/video_encoders/av1_svt.py:390
-#: ../../vdms_panels/video_encoders/avc_x264.py:283
-#: ../../vdms_panels/video_encoders/hevc_x265.py:287
-#: ../../vdms_panels/video_encoders/mpeg4.py:237
-#: ../../vdms_panels/video_encoders/vp9_webm.py:322
 msgid "Frame rate (frames per second). Frames repeat a given number of times per second. In some countries this is 30 for NTSC, other countries (like Italy) use 25 for PAL"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:285
 msgid "Quality/Speed ratio modifier. CPU Used sets how efficient the compression will be. Lower values mean slower encoding with better quality, and vice-versa. Valid values are from 0 to 8 inclusive."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:290
 msgid "Quality and compression efficiency vs speed trade-off. \"good\" is the default and recommended for most applications; \"realtime\" is recommended for live/fast encoding (live streaming, video conferencing, etc); \"allintra\" for All Intra encoding."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:297
 msgid ""
 "Row Multi-Threading enables row-based multi-threading which maximizes CPU usage.\n"
 "\n"
@@ -3415,7 +2480,6 @@ msgid ""
 "Enabling Row Multi-Threading is only faster when the CPU has more threads than the number of encoded tiles."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:316
 msgid ""
 "presets 1-3 represent extremely high efficiency, for use when encode time is not important and quality/size of the resulting video file is critical.\n"
 "\n"
@@ -3426,7 +2490,6 @@ msgid ""
 "Preset 13 is even faster but not intended for direct human consumption--it can be used, for example, as a per-scene quality metric in VOD applications. One should use the lowest preset that is tolerable."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:327
 msgid ""
 "Constant rate factor. This parameter governs the quality/size trade-off.\n"
 "\n"
@@ -3437,7 +2500,6 @@ msgid ""
 "Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:334
 msgid ""
 "The \"Film Grain\" parameter allows SVT-AV1 to detect and delete film grain from the source video, and replace it with synthetic grain of the same character, resulting in significant bitrate savings.\n"
 "\n"
@@ -3450,80 +2512,57 @@ msgid ""
 "If the source video does not have natural grain, this parameter can be set to -1 to disable it or at least 0."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:346
 msgid ""
 "If enabled, the \"Film Grain Denoiser\" option can mitigate the detail removal caused by high \"Film Grain\" values required to preserve the look of very grainy films\n"
 "\n"
 "By default, the denoised frames are passed to be encoded as the final pictures, enabling this feature will lead to the original frames to be used instead. "
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:353
 msgid "Enables encoder optimization to produce faster (less CPU intensive) bit streams to decode, similar to the fastdecode tuning in x264 and x265."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:362
-#: ../../vdms_panels/video_encoders/avc_x264.py:247
-#: ../../vdms_panels/video_encoders/hevc_x265.py:255
 msgid "Set profile restrictions"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:364
-#: ../../vdms_panels/video_encoders/avc_x264.py:249
-#: ../../vdms_panels/video_encoders/hevc_x265.py:257
 msgid "Specify level for a selected profile"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:366
-#: ../../vdms_panels/video_encoders/avc_x264.py:251
-#: ../../vdms_panels/video_encoders/hevc_x265.py:259
 msgid "Tune the encoding params"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/avc_x264.py:245
-#: ../../vdms_panels/video_encoders/hevc_x265.py:253
 msgid "Set the encoding preset (default \"medium\")"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/avc_x264.py:269
 msgid "specifies the target (average) bit rate for the encoder to use. Higher value = higher quality. Set -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:217
 msgid "Variable Bit Rate. From 0-30, with 1 being highest quality/largest filesize and 30 being the lowest quality/smallest filesize. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:222
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:133
 msgid "Frames repeat a given number of times per second. In some countries this is 30 for NTSC, other countries (like Italy) use 25 for PAL"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:226
 msgid "The default FourCC stored in an MPEG-4-coded file will be FMP4. If you want a different FourCC, set this option to xvid to force the FourCC xvid to be stored as the video FourCC rather than the default."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:162
 msgid "Copy Video Codec"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:163
 msgid ""
 "This will just copy the video track as is, without any video re-encoding.\n"
 "You will only be able to change output format, select other audio encoders and\n"
 "a few other options."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_no_enc.py:74
 msgid "Video export disabled"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_no_enc.py:75
 msgid ""
 "The Media target you just selected will only allow you to export files as audio tracks.\n"
 "You can then process audio source files only or extract indexed audio streams on\n"
 "video files."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:326
 msgid ""
 "Speed sets how efficient the compression will be.\n"
 "\n"
@@ -3536,7 +2575,6 @@ msgid ""
 "When the Quality is set to realtime, the available values for Speed are 0 to 8."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:335
 msgid ""
 "Time to spend encoding.\n"
 "\n"
@@ -3547,35 +2585,30 @@ msgid ""
 "\"realtime\" is recommended for live / fast encoding."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:341
-msgid "If enabled, adds support for row based multithreading which greatly enhances the number of threads the encoder can utilise. This improves encoding speed significantly on systems that are otherwise underutilised when encoding VP9. Since the amount of additional threads depends on the number of \"tiles\", which itself depends on the video resolution, encoding higher resolution videos will see a larger performance improvement."
+msgid ""
+"If enabled, adds support for row based multithreading which greatly enhances the number of threads the encoder can utilise. This improves encoding speed significantly on systems that are otherwise underutilised when encoding VP9. Since the amount of additional threads depends on the number of \"tiles\", which itself depends on the video resolution, encoding higher resolution videos will see a "
+"larger performance improvement."
 msgstr ""
 
-#: ../../vdms_utils/presets_manager_utils.py:46
 #, python-brace-format
 msgid "Supports ({0}) formats only, not ({1})"
 msgstr ""
 
-#: ../../vdms_utils/presets_manager_utils.py:49
 msgid "File formats not supported by the selected profile"
 msgstr ""
 
-#: ../../vdms_utils/presets_manager_utils.py:52
 msgid "Warning"
 msgstr ""
 
-#: ../../vdms_utils/presets_manager_utils.py:90
 msgid ""
 "No presets found.\n"
 "\n"
 "Possible solution: open the Presets Manager panel, go to the presets column and try to click the \"Restore all...\" button"
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:54
 msgid "Import queue file"
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:89
 #, python-brace-format
 msgid ""
 "ERROR: invalid data found loading queue file.\n"
@@ -3584,25 +2617,20 @@ msgid ""
 "Cannot contain multiple occurrences in `destination` keys value."
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:118
 msgid "Videomass - Add Items to Queue"
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:119
 msgid ""
 "Multiple items with identical names and destination paths cannot coexist.\n"
 "Please choose one of the following actions:"
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:123
 msgid "Replace occurrences with items from the imported queue."
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:124
 msgid "Add only the currently missing items to the queue."
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:125
 msgid "Remove the current queue and replace it with the imported one."
 msgstr ""
 
@@ -3613,5 +2641,8 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "Subtitle Mapping"
+#~ msgstr ""
+
+#~ msgid "Shortest"
 #~ msgstr ""
 

--- a/videomass/data/locale/de_DE/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/de_DE/LC_MESSAGES/videomass.po
@@ -1,13 +1,13 @@
-# German (Germany) translations for PROJECT.
-# Copyright (C) 2024 ORGANIZATION
-# This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+# German (Germany) translations for Videomass.
+# Copyright (C) 2025 ORGANIZATION
+# This file is distributed under the same license as the Videomass project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-26 15:04+0200\n"
+"POT-Creation-Date: 2025-07-30 11:02+0200\n"
 "PO-Revision-Date: 2024-07-17 16:40+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de_DE\n"
@@ -18,7 +18,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
-#: ../../gui_app.py:196
 #, python-brace-format
 msgid ""
 "Unexpected error while deleting file contents:\n"
@@ -26,162 +25,111 @@ msgid ""
 "{0}"
 msgstr ""
 
-#: ../../vdms_dialogs/about_dialog.py:52
 msgid "Cross-platform graphical user interface for FFmpeg\n"
 msgstr ""
 
-#: ../../vdms_dialogs/audioproperties.py:224
 msgid "Videomass supports mono and stereo audio channels. If you are not sure set to \"Auto\" and source values will be copied."
 msgstr ""
 
-#: ../../vdms_dialogs/audioproperties.py:228
 msgid "The audio Rate (or sample-rate) is the sound sampling frequency and is measured in Hertz. The higher the frequency, the more true it will be to the sound source and the more the file will increase in size. For audio CD playback, set a sampling frequency of 44100 kHz. If you are not sure, set to \"Auto\" and source values will be copied."
 msgstr ""
 
-#: ../../vdms_dialogs/audioproperties.py:237
 msgid "The audio bitrate affects the file compression and thus the quality of listening. The higher the value, the higher the quality."
 msgstr ""
 
-#: ../../vdms_dialogs/audioproperties.py:241
 msgid "Bit depth is the number of bits of information in each sample, and it directly corresponds to the resolution of each sample. Bit depth is only meaningful in reference to a PCM digital signal. Non-PCM formats, such as lossy compression formats, do not have associated bit depths."
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:74 ../../vdms_dialogs/queuedlg.py:120
 msgid "When finished, once the operations have been completed successfully:"
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:80 ../../vdms_dialogs/queuedlg.py:126
 msgid "Trash the source files"
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:84 ../../vdms_dialogs/queuedlg.py:130
 msgid "Clear the File List"
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:91 ../../vdms_dialogs/queuedlg.py:142
-#: ../../vdms_main/main_frame.py:1322
 msgid "Run"
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:97
 msgid "Videomass - Batch Mode"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:47
 msgid "FFmpeg encoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:48
 msgid "supported encoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:50
 msgid "FFmpeg decoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:51
 msgid "supported decoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:77
-#: ../../vdms_panels/av_conversions.py:293
 msgid "Video"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:87
-#: ../../vdms_panels/av_conversions.py:305
 msgid "Audio"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:97
 msgid "Subtitle"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:114
-#: ../../vdms_dialogs/ffmpeg_codecs.py:123
-#: ../../vdms_dialogs/ffmpeg_codecs.py:132
-#: ../../vdms_dialogs/ffmpeg_formats.py:112
-#: ../../vdms_dialogs/ffmpeg_formats.py:115
-#: ../../vdms_dialogs/ffmpeg_formats.py:118
 msgid "description"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:72
 msgid "Informations"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:83
 msgid "Flags settings"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:93
 msgid "Flags enabled"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:103
 msgid "Flags disabled"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:116
 msgid "FFmpeg configuration"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:124
 msgid "flags"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:125 ../../vdms_dialogs/ffmpeg_conf.py:129
-#: ../../vdms_dialogs/ffmpeg_conf.py:133
 msgid "options"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:128 ../../vdms_dialogs/ffmpeg_conf.py:132
 msgid "status"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:167
 msgid "FFprobe   ...not found !"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:175
 msgid "FFplay   ...not found !"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:205
-#: ../../vdms_panels/sequence_to_video.py:706
-#: ../../vdms_panels/video_to_sequence.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:216
-#: ../../vdms_panels/sequence_to_video.py:706
-#: ../../vdms_panels/video_to_sequence.py:610
 msgid "Disabled"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:71
 msgid "Demuxing only"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:82
 msgid "Muxing only"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:93
 msgid "Demuxing/Muxing support"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:104
 msgid "FFmpeg file formats"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:111
-#: ../../vdms_dialogs/ffmpeg_formats.py:114
-#: ../../vdms_dialogs/ffmpeg_formats.py:117
 msgid "supported formats"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:46
 msgid ""
 "Contextual help based on the argument entered in the additional text field.\n"
 "Each argument consists of the type and a type-specific name.\n"
@@ -196,117 +144,84 @@ msgid ""
 "Some examples:"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:68 ../../vdms_dialogs/ffmpeg_help.py:301
-#: ../../vdms_dialogs/ffmpeg_help.py:315
 msgid "Help topic"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:69
 msgid "List basic options"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:70
 msgid "List more options"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:71
 msgid "List all options (very long)"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:72
 msgid "Show available devices"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:73
 msgid "Show available bit stream filters"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:74
 msgid "Show available protocols"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:75
 msgid "Show available filters"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:76
 msgid "Show available pixel formats"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:77
 msgid "Show available audio sample formats"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:78
 msgid "Show available color names"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:79
 msgid "List sources of the input device"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:80
 msgid "List sinks of the output device"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:81
 msgid "Show available HW acceleration methods"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:82
 msgid "Show license"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:117 ../../vdms_dialogs/filter_scale.py:76
-#: ../../vdms_dialogs/shownormlist.py:98 ../../vdms_dialogs/shownormlist.py:107
-#: ../../vdms_dialogs/shownormlist.py:116 ../../vdms_miniframes/timeline.py:263
-#: ../../vdms_miniframes/timeline.py:283 ../../vdms_panels/concatenate.py:117
-#: ../../vdms_panels/sequence_to_video.py:117
-#: ../../vdms_panels/video_to_sequence.py:81
 msgid "Read me"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:123 ../../vdms_main/main_frame.py:534
 msgid "Show configuration"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:127 ../../vdms_main/main_frame.py:542
 msgid "Encoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:131 ../../vdms_main/main_frame.py:545
 msgid "Decoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:135 ../../vdms_main/main_frame.py:538
 msgid "Muxers and Demuxers"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:165
 msgid "help topic list"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:184
 msgid "Type the argument here and confirm with the enter key on your keyboard"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:192
 msgid "The search function allows you to find entries in the current topic"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:195
 msgid "Ignore case"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:196
 msgid "Ignore case distinctions: characters with different case will match."
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:206
 msgid "FFmpeg help topics"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:254
 msgid ""
 "This is a multifunctional search tool useful for local help searches\n"
 "on multiple FFmpeg topics and options. The search control, to\n"
@@ -319,942 +234,647 @@ msgid ""
 "with those features."
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:320 ../../vdms_dialogs/ffmpeg_help.py:345
-#: ../../vdms_dialogs/ffmpeg_help.py:371
 msgid ""
 "\n"
 "  ..Nothing available"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:391
 msgid ""
 "\n"
 "  ..Not found"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:91
 msgid "Before"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:97
 msgid "After"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:103
-#: ../../vdms_dialogs/filter_crop.py:239
 msgid "Search for a specific frame"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:117
-#: ../../vdms_dialogs/filter_crop.py:253
 msgid "Load"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:120
 msgid "Color EQ"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:126
 msgid "Contrast:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:134
-#: ../../vdms_dialogs/filter_colorcorrection.py:148
 msgid "-100 to +100, default value 0"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:139
 msgid "Brightness:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:158
 msgid "Saturation:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:166
 msgid "0 to 300, default value 100"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:170
 msgid "Gamma:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:179
 msgid "0 to 100, default value 10"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:187
-#: ../../vdms_dialogs/filter_crop.py:306
-#: ../../vdms_dialogs/filter_deinterlace.py:209
-#: ../../vdms_dialogs/filter_denoisers.py:110
-#: ../../vdms_dialogs/filter_scale.py:210 ../../vdms_dialogs/filter_stab.py:316
-#: ../../vdms_dialogs/filter_transpose.py:105
-#: ../../vdms_miniframes/timeline.py:262 ../../vdms_miniframes/timeline.py:281
 msgid "Reset"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:207
 msgid "Color Correction EQ Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:343
-#: ../../vdms_dialogs/filter_colorcorrection.py:383
-#: ../../vdms_dialogs/filter_colorcorrection.py:390
-#: ../../vdms_dialogs/filter_crop.py:417 ../../vdms_dialogs/filter_scale.py:287
-#: ../../vdms_dialogs/filter_scale.py:394 ../../vdms_dialogs/filter_stab.py:473
-#: ../../vdms_dialogs/filter_stab.py:483 ../../vdms_dialogs/filter_stab.py:494
-#: ../../vdms_dialogs/filter_transpose.py:182
-#: ../../vdms_dialogs/mediainfo.py:245 ../../vdms_dialogs/mediainfo.py:265
-#: ../../vdms_dialogs/mediainfo.py:285 ../../vdms_dialogs/mediainfo.py:305
-#: ../../vdms_dialogs/setting_profiles.py:281
-#: ../../vdms_dialogs/setting_profiles.py:289 ../../vdms_io/checkup.py:45
-#: ../../vdms_io/checkup.py:93 ../../vdms_io/io_tools.py:144
-#: ../../vdms_main/main_frame.py:904 ../../vdms_main/main_frame.py:939
-#: ../../vdms_main/main_frame.py:961 ../../vdms_main/main_frame.py:979
-#: ../../vdms_main/main_frame.py:999
-#: ../../vdms_panels/audio_encoders/acodecs.py:510
-#: ../../vdms_panels/audio_encoders/acodecs.py:800
-#: ../../vdms_panels/concatenate.py:186
-#: ../../vdms_panels/long_processing_task.py:60
-#: ../../vdms_panels/presets_manager.py:426
-#: ../../vdms_panels/presets_manager.py:490
-#: ../../vdms_panels/presets_manager.py:560
-#: ../../vdms_panels/presets_manager.py:599
-#: ../../vdms_panels/presets_manager.py:619
-#: ../../vdms_panels/presets_manager.py:657
-#: ../../vdms_panels/presets_manager.py:701
-#: ../../vdms_panels/presets_manager.py:714
-#: ../../vdms_panels/presets_manager.py:721
-#: ../../vdms_panels/presets_manager.py:756
-#: ../../vdms_panels/presets_manager.py:785
-#: ../../vdms_panels/presets_manager.py:791
-#: ../../vdms_panels/sequence_to_video.py:467
-#: ../../vdms_panels/sequence_to_video.py:473
-#: ../../vdms_panels/sequence_to_video.py:561
-#: ../../vdms_panels/sequence_to_video.py:571
-#: ../../vdms_panels/sequence_to_video.py:588
-#: ../../vdms_panels/sequence_to_video.py:596
-#: ../../vdms_panels/sequence_to_video.py:602
-#: ../../vdms_panels/sequence_to_video.py:643
-#: ../../vdms_panels/sequence_to_video.py:689
-#: ../../vdms_panels/video_to_sequence.py:512
-#: ../../vdms_panels/video_to_sequence.py:583
-#: ../../vdms_threads/ffplay_file.py:43
-#: ../../vdms_utils/presets_manager_utils.py:86
-#: ../../vdms_utils/presets_manager_utils.py:95
-#: ../../vdms_utils/queue_utils.py:68 ../../vdms_utils/queue_utils.py:82
-#: ../../vdms_utils/queue_utils.py:95
 msgid "Videomass - Error!"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:228 ../../vdms_dialogs/filter_scale.py:109
 #, python-brace-format
 msgid "Source size: {0} x {1} pixels"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:236
 msgid "Crop color"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:256
 msgid "Cropping area selection "
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:261 ../../vdms_dialogs/filter_scale.py:121
 msgid "Height"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:281
 msgid "Center"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:292 ../../vdms_dialogs/filter_scale.py:121
 msgid "Width"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:334
 msgid "Crop Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:335
 msgid "Choose the color to draw the cropping area"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:337
 msgid "Crop to width"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:338
 msgid "Move vertically (set to -1 to center the vertical axis)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:340
 msgid "Move horizontally (set to -1 to center the horizontal axis)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:342
 msgid "Crop to height"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:56
 msgid "Advanced Options"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:57
-#: ../../vdms_panels/av_conversions.py:351
 msgid "Deinterlace"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:59
 msgid "Interlace"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:63
 msgid "Deinterlaces with w3fdif filter"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:77
 msgid "Deinterlaces with yadif filter"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:101
 msgid "Interlaces with interlace filter"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:118
 msgid "Deinterlacing and Interlacing"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:144
 msgid "Deinterlace the input video with `w3fdif` filter"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:146
 msgid "Set the interlacing filter coefficients."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:148
-#: ../../vdms_dialogs/filter_deinterlace.py:158
 msgid "Specify which frames to deinterlace."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:150
 msgid "Deinterlace the input video with `yadif` filter. Using FFmpeg, this is the best and fastest choice"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:153
 msgid ""
 "mode\n"
 "The interlacing mode to adopt."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:155
 msgid ""
 "parity\n"
 "The picture field parity assumed for the input interlaced video."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:160
 msgid "Simple interlacing filter from progressive contents."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:162
 msgid ""
 "scan:\n"
 "determines whether the interlaced frame is taken from the even (tff - default) or odd (bff) lines of the progressive frame."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:166
 msgid ""
 "lowpass:\n"
 "Enable (default) or disable the vertical lowpass filter to avoid twitter interlacing and reduce moire patterns.\n"
 "Default is no setting."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:56
 msgid "Denoiser Filters"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:60
 msgid "Enable nlmeans denoiser"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:73
 msgid "nlmeans options"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:82
 msgid "Enable hqdn3d denoiser"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:91
 msgid "hqdn3d options"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:116
 msgid "Denoiser Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:117
 msgid ""
 "nlmeans:\n"
 "Denoise frames using Non-Local Means algorithm is capable of restoring video sequences, even with strong noise. It is ideal for enhancing the quality of old VHS tapes."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:122
 msgid ""
 "hqdn3d:\n"
 "This is a high precision/quality 3d denoise filter. It aims to reduce image noise, producing smooth images and making still images really still. It should enhance compressibility."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:81
 msgid "View result"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:85
 msgid "New size in pixels"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:89
 msgid "Width:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:99
 msgid "Height:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:115
 msgid "Constrain proportions (keep aspect ratio)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:120
 msgid "Which dimension to adjust?"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:129
 msgid "Aspect Ratio"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:132
 msgid "Setdar filter (display aspect ratio) example 16/9, 4/3 "
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:137
-#: ../../vdms_dialogs/filter_scale.py:171
 msgid "Numerator"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:162
-#: ../../vdms_dialogs/filter_scale.py:196
 msgid "Denominator"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:166
 msgid "Setsar filter (sample aspect ratio) example 1/1"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:217
 msgid "Resize Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:218
 msgid "Scale filter, set to 0 to disable"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:221
 msgid "Display Aspect Ratio. Set to 0 to disable"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:224
 msgid ""
 "Sample (aka Pixel) Aspect Ratio.\n"
 "Set to 0 to disable"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:366
 msgid ""
 "If you want to keep the aspect ratio, select \"Constrain proportions\" below and\n"
 "specify only one dimension, either width or height, and set the other dimension\n"
 "to -1 or -2 (some codecs require -2, so you should do some testing first)."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:81
 msgid "Enable stabilizer"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:83
 msgid "Create a side-by-side comparison video"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:88
 msgid "Create a snapshot"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:106
-#: ../../vdms_panels/audio_encoders/acodecs.py:167
 msgid "Preview"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:109
 msgid "Duration seconds:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:118
 msgid "Video Detect"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:176
 msgid "[TRIPOD] Enable tripod mode if checked"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:183
 msgid "Video transform"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:202
 msgid "[OPTALGO] optimization algorithm"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:224
 msgid "[CROP] Specify how to deal with borders at movement compensation"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:231
 msgid "[INVERT] Invert transforms if checked"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:234
 msgid "[RELATIVE] Consider transforms as relative to previous frame if checked, absolute if unchecked"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:279
 msgid "Specify type of interpolation"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:287
 msgid "[TRIPOD2] virtual tripod mode, equivalent to relative=unchecked:smoothing=0"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:294
 msgid "Unsharp filter:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:323
 msgid "Seek to a position on the video."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:325
 msgid "Make a snapshot of the video with the settings made."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:327
 msgid "Set the snapshot duration from 3 to 15 seconds from the seek position, default is 5 seconds."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:331
 msgid "Set how shaky the video is and how quick the camera is. A value of 1 means little shakiness, a value of 10 means strong shakiness. Default value is 5."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:335
 msgid "Set the accuracy of the detection process. A value of 1 means low accuracy, a value of 15 means high accuracy. Default value is 15."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:339
 msgid "Set stepsize of the search process. The region around minimum is scanned with 1 pixel resolution. Default value is 6."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:343
 msgid "Set minimum contrast. Below this value a local measurement field is discarded. The range is 0-1. Default value is 0.25."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:346
 msgid "Set reference frame number for tripod mode. If enabled, the motion of the frames is compared to a reference frame in the filtered stream, identified by the specified number. The idea is to compensate all movements in a more-or-less static scene and keep the camera view absolutely still. The frames are counted starting from 1."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:355
-msgid "Set the number of frames (value*2 + 1) used for lowpass filtering the camera movements. Default value is 15. For example a number of 10 means that 21 frames are used (10 in the past and 10 in the future) to smoothen the motion in the video. A larger value leads to a smoother video, but limits the acceleration of the camera (pan/tilt movements). 0 is a special case where a static camera is simulated."
+msgid ""
+"Set the number of frames (value*2 + 1) used for lowpass filtering the camera movements. Default value is 15. For example a number of 10 means that 21 frames are used (10 in the past and 10 in the future) to smoothen the motion in the video. A larger value leads to a smoother video, but limits the acceleration of the camera (pan/tilt movements). 0 is a special case where a static camera is "
+"simulated."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:363
 msgid "Set the camera path optimization algorithm. Values are: `gauss`: gaussian kernel low-pass filter on camera motion (default), and `avg`: averaging on transformations"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:367
 msgid "Set maximal angle in radians (degree*PI/180) to rotate frames. Default value is -1, meaning no limit."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:370
 msgid "Specify how to deal with borders that may be visible due to movement compensation. Values are: `keep` keep image information from previous frame (default), `black` fill the border black"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:375
 msgid "Invert transforms if checked. Default is unchecked."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:377
 msgid "Consider transforms as relative to previous frame if checked, absolute if unchecked. Default is checked."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:380
 msgid "Set percentage to zoom. A positive value will result in a zoom-in effect, a negative value in a zoom-out effect. Default value is 0 (no zoom)."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:384
 msgid "Set optimal zooming to avoid borders. Accepted values are: `0` disabled, `1` optimal static zoom value is determined (only very strong movements will lead to visible borders) (default), `2` optimal adaptive zoom value is determined (no borders will be visible), see zoomspeed. Note that the value given at zoom is added to the one calculated here."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:391
 msgid "Set percent to zoom maximally each frame (enabled when optzoom is set to 2). Range is from 0 to 5, default value is 0.25."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:395
 msgid "Specify type of interpolation. Available values are: `no` no interpolation, `linear` linear only horizontal, `bilinear` linear in both directions (default), `bicubic` cubic in both directions (slow)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:400
 msgid "Enable virtual tripod mode if checked, which is equivalent to relative=0:smoothing=0. Default is unchecked. Use also tripod option of vidstabdetect."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:405
 msgid "Sharpen or blur the input video. Note the use of the unsharp filter which is always recommended."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:409
 msgid "Video Stabilizer Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:541 ../../vdms_io/io_tools.py:73
 msgid "Videomass - Loading..."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:542
 msgid ""
 "Please wait,\n"
 "This process will take a few seconds."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:80
-#: ../../vdms_dialogs/filter_transpose.py:293
 msgid "Default position"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:86
 msgid "Rotation setting"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:94
 msgid "90° (left)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:96
 msgid "90° (right)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:100
 msgid "180°"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:115
 msgid "Transpose Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:229
 msgid "Rotate 90 degrees right"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:251
 msgid "Rotate 180 degrees"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:272
 msgid "Rotate 90 degrees left"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:82
 msgid "Format"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:96
 msgid "Video Stream"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:109
 msgid "Audio Streams"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:122
 msgid "Subtitle Streams"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:126
 msgid "Copy to clipboard"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:137
 msgid "FILE SELECTION"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:139 ../../vdms_dialogs/mediainfo.py:142
-#: ../../vdms_dialogs/mediainfo.py:145 ../../vdms_dialogs/mediainfo.py:148
-#: ../../vdms_main/main_frame.py:1318
 msgid "Properties"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:140 ../../vdms_dialogs/mediainfo.py:143
-#: ../../vdms_dialogs/mediainfo.py:146 ../../vdms_dialogs/mediainfo.py:149
 msgid "Values"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:152
 msgid "Streams Properties"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:244
 msgid "Unable to open the clipboard on Format tab"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:263
 msgid "Unable to open the clipboard on Video Streams tab"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:283
 msgid "Unable to open the clipboard on Audio Streams tab"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:303
 msgid "Unable to open the clipboard on Subtitle Streams tab"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:90
 msgid "Where do you prefer to save your transcodes?"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:101 ../../vdms_dialogs/preferences.py:128
-#: ../../vdms_dialogs/preferences.py:149 ../../vdms_dialogs/preferences.py:161
-#: ../../vdms_dialogs/preferences.py:173 ../../vdms_panels/filedrop.py:284
 msgid "Change"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:103
-#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:602
-#: ../../vdms_panels/presets_manager.py:1050
 msgid "Same destination paths as source files"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:108
 msgid "Assign optional suffix to destination file names:"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:114
 msgid "File removal preferences"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:118
 msgid "Trash the source files after successful encoding"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:131
 msgid "File Preferences"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:138
 msgid "Location of executables"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:140
 msgid ""
 "FFmpeg can be built by enabling/disabling its options and this depends on your needs.\n"
 "For some use cases it is possible to provide a custom build of FFmpeg where you can specify\n"
 "it in this preferences tab."
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:147
 msgid "Enable a custom location to run FFmpeg"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:159
 msgid "Enable a custom location to run FFprobe"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:171
 msgid "Enable a custom location to run FFplay"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:183
 msgid "FFmpeg"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:189
 msgid "Look and Feel (requires application restart)"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:194
 msgid "Icon themes"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:208
 msgid "At the top of window (default)"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:209
 msgid "At the bottom of window"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:210
 msgid "At the right of window"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:211
 msgid "At the left of window"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:213
 msgid "Place the toolbar"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:222
 msgid "Toolbar's icons size:"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:236
 msgid "Application Language (requires application restart)"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:248
 msgid "Look and Language"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:254
 msgid "Upon exiting the application"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:259
 msgid "Always ask me to confirm"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:261
 msgid "Clean the log files"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:264
 msgid "Remove cached files"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:268
 msgid "On operations completion"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:271
 msgid "These settings will remain active until the application is closed, If necessary, remember to reactivate them."
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:276
 msgid "Exit the application"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:279
 msgid "Shutdown the system"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:283
 msgid "SUDO password:"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:292
 msgid "Exit and Shutdown"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:298
 msgid "Specify the character encoding format"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:301
 msgid ""
 "Although UTF-8 is the default and most widely used standard encoding format, it is not the only encoding format available.\n"
 "Some file metadata may still contain non-UTF-8 character encodings resulting in the error \"'utf-8' codec can't decode bytes...\".\n"
 "If you know the encoding format the file was written in, you can try specifying it here, e.g. ISO 8859-1, ISO 8859-16, etc."
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:311
 msgid "Character encoding:"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:320
 msgid "Default application directories"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:324
 msgid "Configuration directory"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:337
 msgid "Cache directory"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:349
 msgid "Log directory"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:363
 msgid "Advanced"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:369
 msgid ""
 "The following settings affect output messages and the log messages during transcoding processes.\n"
 "Be careful, by changing these settings some functions of the application may not work correctly,\n"
 "change only if you know what you are doing.\n"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:376
 msgid "Set logging level flags used by FFmpeg"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:383
 msgid "Set logging level flags used by FFplay"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:391
 msgid "FFmpeg logging levels"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:437
 msgid "By assigning an additional suffix you could avoid overwriting files"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:440
 msgid "Type sudo password here, only for Unix-like operating systems, not for MS Windows"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:443
 msgid "Preferences"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:596 ../../vdms_dialogs/preferences.py:676
-#: ../../vdms_main/main_frame.py:879 ../../vdms_main/main_frame.py:1060
 msgid "Choose Destination"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:627
 msgid "Enter only alphanumeric characters. You can also use the hyphen (\"-\") and the underscore (\"_\"). Spaces are not allowed."
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:642
-#: ../../vdms_dialogs/setting_profiles.py:257
-#: ../../vdms_dialogs/setting_profiles.py:264
-#: ../../vdms_dialogs/setting_profiles.py:286
-#: ../../vdms_dialogs/setting_profiles.py:309 ../../vdms_main/main_frame.py:399
-#: ../../vdms_main/main_frame.py:421 ../../vdms_panels/av_conversions.py:605
-#: ../../vdms_panels/av_conversions.py:612
-#: ../../vdms_panels/sequence_to_video.py:352
-#: ../../vdms_panels/video_to_sequence.py:399
 msgid "Videomass - Warning!"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:731 ../../vdms_dialogs/preferences.py:771
-#: ../../vdms_dialogs/preferences.py:811 ../../vdms_dialogs/wizard_dlg.py:365
-#: ../../vdms_dialogs/wizard_dlg.py:384 ../../vdms_dialogs/wizard_dlg.py:403
 #, python-brace-format
 msgid "{} location"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:36
-#: ../../vdms_dialogs/setting_profiles.py:38
 msgid "One-Pass, Do not start with `ffmpeg -i filename`; do not end with `output-filename`"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:40
-#: ../../vdms_dialogs/setting_profiles.py:42
 msgid "Two-Pass (optional), Do not start with `ffmpeg -i filename`; do not end with `output-filename`"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:59
 msgid "Videomass - Edit the selected item in the queue"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:71
-#: ../../vdms_dialogs/setting_profiles.py:92
 msgid "Pre-input arguments for One-Pass (optional)"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:82
-#: ../../vdms_dialogs/setting_profiles.py:151
-#: ../../vdms_panels/presets_manager.py:255
 msgid "FFmpeg arguments for one-pass encoding"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:88
-#: ../../vdms_dialogs/setting_profiles.py:158
-#: ../../vdms_panels/presets_manager.py:259
 msgid "Any optional arguments to add before input file on the one-pass encoding, e.g required names of some hardware accelerations like -hwaccel to use with CUDA."
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:102
-#: ../../vdms_dialogs/setting_profiles.py:98
 msgid "Pre-input arguments for Two-Pass (optional)"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:113
-#: ../../vdms_dialogs/setting_profiles.py:152
-#: ../../vdms_panels/presets_manager.py:257
 msgid "FFmpeg arguments for two-pass encoding"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:120
-#: ../../vdms_dialogs/setting_profiles.py:162
-#: ../../vdms_panels/presets_manager.py:263
 msgid "Any optional arguments to add before input file on the two-pass encoding, e.g required names of some hardware accelerations like -hwaccel to use with CUDA."
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:65 ../../vdms_main/main_frame.py:508
-#: ../../vdms_panels/presets_manager.py:189
-#: ../../vdms_panels/video_to_sequence.py:171
 msgid "Edit"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:68
 msgid "Remove"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:71
 msgid "Remove all"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:74
 msgid ""
 "Export\n"
 "queue file"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:77
 msgid ""
 "Import\n"
 "queue file"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:85 ../../vdms_panels/filedrop.py:273
 msgid "Destination file name"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:137
 msgid "Remove all items in the queue"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:151
 msgid "Videomass - Queue"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:228
 msgid "Export queue file"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:296 ../../vdms_panels/av_conversions.py:1192
-#: ../../vdms_panels/presets_manager.py:1044
-#: ../../vdms_panels/video_to_sequence.py:600
 msgid "Same as source"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:301
 msgid ""
 "Source\n"
 "File destination\n"
@@ -1265,186 +885,129 @@ msgid ""
 "Clip duration"
 msgstr ""
 
-#: ../../vdms_dialogs/renamer.py:76
 msgid "# will be replaced by ascending numbers starting with:"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:87
 msgid "Font Size"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:111
 msgid "Font Color"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:121
 msgid "Shadow Color"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:132
 msgid "Show text box"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:136
 msgid "Box Color"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:156
 msgid "The timestamp size does not auto-adjust to the video size, you have to set the size here"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:160 ../../vdms_main/main_frame.py:559
 msgid "Timestamp settings"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:46
 msgid "Supported Formats list (optional). Do not include the `.`"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:47
 msgid "Output Format. Empty to copy format and codec. Do not include the `.`"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:70
 msgid "Profile Name"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:74
-#: ../../vdms_panels/presets_manager.py:404
 msgid "Description"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:149
 msgid "A short profile name"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:150
 msgid "A long description of the profile"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:153
 msgid "One or more comma-separated format names compatible with this profile"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:155
 msgid "Output format extension. Leave empty to copy codec and format"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:256
 msgid "Incomplete profile assignments"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:263
 msgid "Formats must be comma-separated"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:279
-#: ../../vdms_utils/queue_utils.py:80
 #, python-brace-format
 msgid ""
 "ERROR: Keys mismatched for requested data.\n"
 "Invalid file: «{0}»"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:285
-#: ../../vdms_dialogs/setting_profiles.py:308
 msgid "Profile already stored with same name"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:293
 msgid "Profile stored successfully!"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:311
 msgid "Profile change successful!"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:80
 msgid "Log file list"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:82 ../../vdms_dialogs/showlogs.py:116
 msgid "Log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:105
 msgid "Refresh log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:107
 msgid "Clear log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:160
 msgid "Select a log file"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:167
 msgid "Are you sure you want to clear the selected log file?"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:168 ../../vdms_dialogs/wizard_dlg.py:251
-#: ../../vdms_io/checkup.py:68 ../../vdms_main/main_frame.py:205
-#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1685
-#: ../../vdms_panels/presets_manager.py:349
-#: ../../vdms_panels/presets_manager.py:550
-#: ../../vdms_panels/presets_manager.py:590
-#: ../../vdms_panels/presets_manager.py:649
-#: ../../vdms_panels/presets_manager.py:684
-#: ../../vdms_panels/presets_manager.py:749
-#: ../../vdms_panels/presets_manager.py:775
-#: ../../vdms_panels/presets_manager.py:874
-#: ../../vdms_panels/presets_manager.py:904
 msgid "Please confirm"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:83
 msgid "File name"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:84
 msgid "Max volume dBFS"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:85
 msgid "Mean volume dBFS"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:86
 msgid "Offset dBFS"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:87
 msgid "Result dBFS"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:92
 msgid "Post-normalization references:"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:102
 msgid "=  Clipped peaks"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:111
 msgid "=  No changes"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:121
 msgid "=  Below max peak"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:166
-#: ../../vdms_panels/audio_encoders/acodecs.py:841
 msgid "RMS-based volume statistics"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:191
-#: ../../vdms_panels/audio_encoders/acodecs.py:839
 msgid "PEAK-based volume statistics"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:216
 msgid ""
 "...It means the resulting audio will be clipped,\n"
 "because its volume is higher than the maximum 0 db\n"
@@ -1452,34 +1015,28 @@ msgid ""
 "sound distorted."
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:242
 msgid ""
 "...It means the resulting audio will not change,\n"
 "because it's equal to the source."
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:266
 msgid ""
 "...It means an audio signal will be produced with\n"
 "a lower volume than the source."
 msgstr ""
 
-#: ../../vdms_dialogs/videomass_check_version.py:63
 msgid "Get Latest Version"
 msgstr ""
 
-#: ../../vdms_dialogs/videomass_check_version.py:67
 msgid "Checking for newer version"
 msgstr ""
 
-#: ../../vdms_dialogs/videomass_check_version.py:95
 msgid ""
 "\n"
 "\n"
 "New releases fix bugs and offer new features."
 msgstr ""
 
-#: ../../vdms_dialogs/videomass_check_version.py:96
 #, python-brace-format
 msgid ""
 "\n"
@@ -1488,7 +1045,6 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../../vdms_dialogs/while_playing.py:37
 msgid ""
 "q, ESC\n"
 "f\n"
@@ -1511,115 +1067,89 @@ msgid ""
 "left mouse double-click"
 msgstr ""
 
-#: ../../vdms_dialogs/while_playing.py:92
 msgid "Shortcut keys while playing with FFplay"
 msgstr ""
 
-#: ../../vdms_dialogs/widget_utils.py:120 ../../vdms_main/main_frame.py:1326
 msgid "Stop"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:63
 msgid "Please take a moment to set up the application"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:64
 msgid "Click the \"Next\" button to get started"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:79
 msgid "Welcome to the Videomass Wizard!"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:123
 msgid "Videomass is an application based on FFmpeg\n"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:125
 msgid "If FFmpeg is not on your computer, this application will be unusable"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:128
 msgid ""
 "If you have already installed FFmpeg on your operating system,\n"
 "click the \"Auto-detection\" button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:131
 msgid ""
 "If you want to use a version of FFmpeg located on your filesystem\n"
 "but not installed on your operating system,\n"
 "click the \"Locate\" button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:162
 msgid "Auto-detection"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:164
 msgid "Locate"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:214
 msgid "Click the \"Next\" button"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:235
 #, python-brace-format
 msgid "'{}' is not installed on your computer. Install it or indicate another location by clicking the 'Locate' button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:249
 msgid ""
 "Videomass already seems to include FFmpeg.\n"
 "\n"
 "Do you want to use that?"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:275
 msgid "Locating FFmpeg executables\n"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:277
 msgid ""
 "\"ffmpeg\", \"ffprobe\" and \"ffplay\" are required. Complete all\n"
 "the text boxes below by clicking on the respective buttons."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:437
 msgid "Wizard completed successfully!\n"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:438
 msgid "Remember that you can always change these settings later, through the Preferences dialog."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:440
 msgid "Thank You!"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:441
 msgid "To exit click the \"Finish\" button"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:527
 msgid "< Previous"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:530 ../../vdms_dialogs/wizard_dlg.py:613
 msgid "Next >"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:535
 msgid "Videomass Wizard"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:563 ../../vdms_dialogs/wizard_dlg.py:586
-#: ../../vdms_dialogs/wizard_dlg.py:591
 msgid "Finish"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:44 ../../vdms_io/checkup.py:92
 #, python-brace-format
 msgid ""
 "Output folder does not exist:\n"
@@ -1627,432 +1157,326 @@ msgid ""
 "\"{}\"\n"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:65
 msgid "Files already exist, do you want to overwrite them?"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:67
 msgid "Already exist"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:81
 msgid "Not found"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:82 ../../vdms_panels/filedrop.py:196
 msgid "Error list"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:83
 msgid "File(s) not found"
 msgstr ""
 
-#: ../../vdms_io/io_tools.py:56
 #, python-format
 msgid "File does not exist or is invalid:  %s"
 msgstr ""
 
-#: ../../vdms_io/io_tools.py:74
 msgid ""
 "Wait....\n"
 "Audio peak analysis."
 msgstr ""
 
-#: ../../vdms_io/io_tools.py:179
 msgid "Videomass - Downloading..."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1409
-#: ../../vdms_main/main_frame.py:1441
 msgid "Ready"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:203
 msgid ""
 "Not all items in the queue were completed.\n"
 "\n"
 "Would you like to keep them in the queue?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:224
 #, python-brace-format
 msgid "Queue ({0})"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:229 ../../vdms_main/main_frame.py:1334
 msgid "Queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:396 ../../vdms_main/main_frame.py:418
 msgid "There are still active windows with running processes, make sure you finish your work before exit."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:403
 msgid "Are you sure you want to exit the application?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:405
 msgid "Exit"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:463
 msgid "Import files\tCtrl+O"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:466
 msgid "Open destination folder of encodings\tCtrl+D"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:469
 msgid "Load queue file"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:470
 msgid "Load a previously exported queue file"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:473
 msgid "Open trash"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:474
 msgid "Open the Videomass trash folder"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:476
 msgid "Empty trash"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:477
 msgid "Delete all files in the Videomass trash folder"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:480
 msgid "Exit\tCtrl+Q"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:481
 msgid "Completely exit the application"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:482
 msgid "File"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:486 ../../vdms_panels/filedrop.py:340
-#: ../../vdms_panels/filedrop.py:381
 msgid "Rename selected file\tCtrl+R"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:487
 msgid "Rename the destination of the selected file"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:490 ../../vdms_panels/filedrop.py:341
-#: ../../vdms_panels/filedrop.py:384
 msgid "Batch rename files\tCtrl+B"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:491
 msgid "Numerically renames the destination of all items in the list"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:496 ../../vdms_panels/filedrop.py:343
-#: ../../vdms_panels/filedrop.py:388
 msgid "Remove selected entry\tDEL"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:497
 msgid "Remove the selected file from the list"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:500 ../../vdms_panels/filedrop.py:344
-#: ../../vdms_panels/filedrop.py:391
 msgid "Clear list\tShift+DEL"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:501
 msgid "Clear the file list"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:506
 msgid "Preferences\tCtrl+P"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:507
 msgid "Application preferences"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:512
 msgid "Find FFmpeg topics"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:513
 msgid "A useful tool to search for FFmpeg help topics and options"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:518
 msgid "Check for preset updates"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:519
 #, python-brace-format
 msgid "Check for new presets updates from {0}"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:521
 msgid "Get latest presets"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:522
 #, python-brace-format
 msgid "Get the latest presets from {0}"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:525
 msgid "Work notes\tCtrl+N"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:526
 msgid "Read and write useful notes and reminders."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:528
 msgid "Tools"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:535
 msgid "Show FFmpeg's built-in configuration capabilities"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:539
 msgid "Muxers and demuxers available on your version of FFmpeg"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:543
 msgid "Encoders available on your version of FFmpeg"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:546
 msgid "Decoders available on your version of FFmpeg"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:550
 msgid "Enable timestamps on playback"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:551
 msgid "Displays timestamp when playing media with FFplay"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:554
 msgid "Auto-exit after playback"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:555
 msgid "If checked, the FFplay window will auto-close when playback is complete"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:559
 msgid "Customize the timestamp style"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:562
 msgid "While playing..."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:563
 msgid "Show useful shortcut keys when playing or previewing using FFplay"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:567
 msgid "Show timeline editor\tCtrl+T"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:568
 msgid "Set duration or trim slices of time to remove unwanted parts from your files"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:572
 msgid "View"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:579
 msgid "Home panel\tCtrl+Shift+H"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:580
 msgid "Go to the «Home» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:583
 msgid "Presets Manager\tCtrl+Shift+P"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:584
 msgid "Go to the «Presets Manager» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:586
 msgid "A/V Conversions\tCtrl+Shift+V"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:587
 msgid "Go to the «A/V Conversions» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:589
 msgid "Concatenate Demuxer\tCtrl+Shift+D"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:590
 msgid "Go to the «Concatenate Demuxer» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:593
 msgid "Still Image Maker\tCtrl+Shift+I"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:594
 msgid "Go to the «Still Image Maker» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:596
 msgid "From Movie to Pictures\tCtrl+Shift+S"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:597
 msgid "Go to the «From Movie to Pictures» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:600
 msgid "Output monitor\tCtrl+Shift+O"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:601
 msgid "Keeps track of the output for debugging errors"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:603
 msgid "Go"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:607
 msgid "User guide"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:611
 msgid "System version"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:612
 msgid "Get version about your operating system, version of Python and wxPython."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:616
 msgid "Show log files\tCtrl+L"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:617
 msgid "Viewing log messages"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:620
 msgid "Issue tracker"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:624
 msgid "Contribute to the project"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:627
 msgid "Sponsor this project"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:628
 msgid "Become a developer supporter"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:629
 msgid "Donate"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:630
 msgid "Donate to the app developer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:634
 msgid "Other projects by the developer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:650
 msgid "About Videomass"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:651
 msgid "Check for newer version"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:652
 msgid "Check for the latest Videomass version"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:654
 msgid "Help"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:729
 msgid "Import files"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:752
 msgid "No default folder has been set for the destination of the encodings. The current setting is \"Same destination paths as source files\"."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:784 ../../vdms_main/main_frame.py:809
 #, python-brace-format
 msgid ""
 "'{}':\n"
 "No such file or directory"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:797
 msgid "Are you sure to empty trash folder?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:805
 #, python-brace-format
 msgid ""
 "'{}':\n"
 "There are no files to delete."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:862
 #, python-brace-format
 msgid "Installed release v{0}. A new presets release is available {1}"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:866
 #, python-brace-format
 msgid "Installed release v{0}. No new updates found."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:896
 msgid ""
 "Wait....\n"
 "The archive is being downloaded"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:908
 #, python-brace-format
 msgid "Successfully downloaded to \"{0}\""
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1120
 msgid "Some changes require restarting the application."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1126
 #, python-brace-format
 msgid ""
 "{0}\n"
@@ -2060,214 +1484,159 @@ msgid ""
 "Do you want to restart the application now?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1128
 msgid "Restart Videomass?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1207
 #, python-brace-format
 msgid "A new release is available - v.{0}\n"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1210
 msgid "You are using a development version that has not yet been released!\n"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1213
 msgid "Congratulation! You are already using the latest version.\n"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1301
 msgid "Previous panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1302
 msgid "Back"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1305
 msgid "Next panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1306
 msgid "Next"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1309
 msgid "Home panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1310
 msgid "Home"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1313
 msgid "Play the selected imput file"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1314
 msgid "Play"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1317
 msgid "Get informative data about imported media streams"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1321
 msgid "Start batch processing"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1325
 msgid "Stops current process"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1329
 msgid "Add an item to Queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1330
 msgid "Add to Queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1333
 msgid "Show queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1408 ../../vdms_panels/presets_manager.py:569
 msgid "Videomass"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1442
 msgid "Videomass - File List"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1459
 msgid "Videomass - AV Conversions"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1488
 msgid "Videomass - Presets Manager"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1518
 msgid "Videomass - Concatenate Demuxer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1547
 msgid "Videomass - From Movie to Pictures"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1576
 msgid "Videomass - Still Image Maker"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1660 ../../vdms_panels/av_conversions.py:577
-#: ../../vdms_panels/filedrop.py:500 ../../vdms_panels/filedrop.py:616
-#: ../../vdms_panels/sequence_to_video.py:322
-#: ../../vdms_panels/video_to_sequence.py:369
-#: ../../vdms_panels/video_to_sequence.py:501
 msgid "Have to select an item in the file list first"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1682
 msgid ""
 "An item with the same destination file already exists.\n"
 "\n"
 "Do you want to replace it by adding the new item to the queue?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1703
 msgid "Videomass - FFmpeg Message Monitoring"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1828
 #, python-brace-format
 msgid "The system will turn off in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1829
 msgid "Videomass - Shutdown!"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1836
 msgid "Error while shutting down. Please see file log for details."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1848
 #, python-brace-format
 msgid "Exiting the application in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1849
 msgid "Videomass - Exiting!"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:46
 msgid "Start point adjustment"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:48
 msgid "End point adjustment"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:105
 msgid "Hours"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:106
 msgid "Minutes"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:107
 msgid "Seconds"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:108
 msgid "Milliseconds"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:189 ../../vdms_miniframes/timeline.py:312
 msgid "No source duration:"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:208 ../../vdms_miniframes/timeline.py:298
-#: ../../vdms_miniframes/timeline.py:333 ../../vdms_miniframes/timeline.py:338
-#: ../../vdms_miniframes/timeline.py:441
 #, python-brace-format
 msgid "{0} {1}  |  Segment Duration: {2}"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:260 ../../vdms_miniframes/timeline.py:277
 msgid "End adjustment"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:261 ../../vdms_miniframes/timeline.py:279
 msgid "Start adjustment"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:320
 msgid "Source duration:"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:387
 msgid "WARNING: Invalid selection, out of range."
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:461
 msgid ""
 "Start by dragging the bottom left handle,\n"
 "or right-click for options."
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:497
 msgid "Start"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:498
 msgid "End"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:548
 msgid ""
 "The timeline editor is a tool that allows you to trim slices of time on selected imported media (see File List panel).\n"
 "\n"
@@ -2280,39 +1649,30 @@ msgid ""
 "The \"Start\"/\"End\" duration values always refer to the initial position of the timeline: 00:00:00.000. For other informations as the segment duration and warnings, please refer to the status bar messages."
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:565
 msgid "Timeline Editor Usage"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:153
 msgid "Media:"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:169
 msgid "Container:"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:180
 msgid "Save profile"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:183
 msgid "Target"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:316
 msgid "Miscellaneous"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:323
 msgid "Save as a new profile of the Presets Manager."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:325
 msgid "Available video encoders. \"Copy\" means that the video stream will not be re-encoded and will allow you (depending on the encoder) to change the container, audio codec and a few other parameters."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:330
 msgid ""
 "Container format. It is usually represented by the file extension (output format).\n"
 "\n"
@@ -2321,73 +1681,53 @@ msgid ""
 "If the media target is set to \"Audio\", you can extract only the audio streams from videos, or simply convert audio source files."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:338
 msgid ""
 "Set output files target: \"Video\" to save output files as video files; \"Audio\" to save files using an audio encoder and format.\n"
 "\n"
 "Note that by using \"Audio\" as the target, you will still be able to work on the video source files but you will only be able to extract the audio streams, convert them and apply audio filters such as normalization."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:346
 msgid "Preview video filters"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:347
 msgid "Disable active filters"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:348
-#: ../../vdms_panels/sequence_to_video.py:156
-#: ../../vdms_panels/video_to_sequence.py:113
 msgid "Resize"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:349
 msgid "Crop"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:350
 msgid "Transpose"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:352
 msgid "Denoise"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:353
 msgid "Stabilize"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:354
 msgid "Equalize"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:517
 msgid "Unable to preview Video Stabilizer filter"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:602
 msgid ""
 "Unsupported file:\n"
 "Missing decoder or library? Check FFmpeg configuration."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:611
-#: ../../vdms_panels/sequence_to_video.py:351
-#: ../../vdms_panels/video_to_sequence.py:398
 msgid "The file is not a frame or a video file"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:434
-#: ../../vdms_panels/av_conversions.py:861
 msgid "Undetected volume values! Click the \"Volume detect\" button to analyze audio volume data."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1186
 msgid "Off"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1203
 msgid ""
 "Batch processing items\n"
 "Destination\n"
@@ -2402,109 +1742,81 @@ msgid ""
 "Clip duration"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1246
-#: ../../vdms_panels/presets_manager.py:814
 #, python-brace-format
 msgid "Write profile on «{0}»"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1266
-#: ../../vdms_panels/presets_manager.py:513
 msgid "Enter name for new preset"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1276
-#: ../../vdms_panels/presets_manager.py:524
 msgid "Invalid file name, make sure to provide a valid name including the «.json» extension"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1284
 #, python-brace-format
 msgid "Cannot save current data in file «{}»."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1289
 msgid "Open Videomass preset"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1307
 msgid "Videomass - Save new profile"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1308
 msgid "Where do you want to save this profile?"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1309
 msgid "Save the profile to a new preset"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1310
 msgid "Save the profile to an existing preset"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:69
 msgid "Welcome to Videomass"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:71
 #, python-brace-format
 msgid "Version {}"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:82
 msgid "Presets Manager"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:85
 msgid "AV-Conversions"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:88
 msgid "Concatenate media files"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:91
 msgid "Still Image Maker"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:94
 msgid "From Movie to Pictures"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:123
 msgid "Create, edit and use quickly your favorite FFmpeg presets and profiles with full formats support and codecs."
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:127
 msgid "A set of useful tools for audio and video conversions. Save your profiles and reuse them with Presets Manager."
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:131
 msgid "Concatenate multiple media files based on import order without re-encoding"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:134
 msgid "Create video from a sequence of images, based on import order, with the ability to add an audio file."
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:137
 msgid "Extract images (frames) from your movies in JPG, PNG, BMP, GIF formats."
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:47
 msgid "At least two files are required to perform concatenation."
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:63
 msgid "Invalid data found"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:68
 msgid "The files do not have the same \"codec_types\", same \"sample_rate\" or same \"width\" or \"height\". Unable to proceed."
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:84
 msgid ""
 "\n"
 "- The concatenation function is performed only with Audio files or only with Video files.\n"
@@ -2520,17 +1832,12 @@ msgid ""
 "- Audio files must have exactly the same formats, same codecs with equal sample rate."
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:125
 msgid "Videomass Documentation:"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:136
-#: ../../vdms_panels/sequence_to_video.py:212
-#: ../../vdms_panels/video_to_sequence.py:181
 msgid "Official FFmpeg documentation:"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:253
 msgid ""
 "Items to concatenate\n"
 "File destination\n"
@@ -2539,250 +1846,188 @@ msgid ""
 "Duration"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:45
 msgid "File has illegal characters like:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:46
 msgid "Invalid character found in path name: (\")"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:47
 msgid "Directories are not allowed, just add files, please."
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:48
 msgid "File without format extension: please give an appropriate extension to the file name, example '.mkv', '.avi', '.mp3', etc."
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:84
 #, python-brace-format
 msgid "Name has illegal characters like: {0}"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:85
 msgid "Name already in use:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:185
 msgid "Duplicate file, it has already been added to the list."
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:197
 msgid "Rejected files"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:269
 msgid "Source file"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:270
 msgid "Duration"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:271
 msgid "Media type"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:272
 msgid "Size"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:405
 msgid "Drag one or more files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:282
 msgid "Save to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:306
 msgid "Set a new destination folder for encodings"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:308
 msgid "Encodings destination folder"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:394
 msgid "Play file"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:408
 msgid "Drag two or more Audio/Video files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:412
 msgid "Drag one or more Image files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:415
 msgid "Drag one or more Video files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:623
 msgid "Rename the file destination"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:624
 msgid "Rename the selected file to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:638 ../../vdms_panels/filedrop.py:648
-#: ../../vdms_panels/filedrop.py:679
 msgid "Add Files"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:655
 msgid "Rename in batch"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:656
 #, python-brace-format
 msgid "Rename the {0} items to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:658
 msgid "New Name #"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:114
 msgid "Sorry, all task failed !"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:115
 msgid "The process was stopped due to a fatal error."
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:116
 msgid "Interrupted Process !"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:117
 msgid "Successfully completed !"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:118
 msgid "Not everything was successful."
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:148
 msgid "Encoding Status"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:152
 msgid "Current Log"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:354
 msgid "Fatal Error !"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:363
 msgid "Get your files at the destination you specified"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:377
 msgid "For more details please read the Current Log."
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:380
 msgid "...Finished"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:399
 msgid "Please wait... interruption in progress"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:402
 msgid "...Interrupted"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:166
 msgid "Presets"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:180
 msgid "Write"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:184
 msgid "Delete"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:194
 msgid "Duplicate"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:199
 msgid "Profiles"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:206
 msgid "One-Pass Encoding"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:218
 msgid "Two-Pass Encoding"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:232
 msgid "Choose a preset and view its profiles"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:233
 msgid "Write a new profile and save it in the selected preset"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:235
 msgid "Delete the selected profile"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:236
 msgid "Edit the selected profile"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:237
 msgid "Duplicate the selected profile"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:238
 msgid "Create new preset"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:240
 msgid "Remove selected preset"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:242
 msgid "Backup selected preset"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:244
 msgid "Backup the presets folder"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:246
 msgid "Restore a preset"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:248
 msgid "Restore a presets folder"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:250
 msgid "Resets the selected preset to default values"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:252
 msgid "Reset all presets to default values"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:254
 msgid "Refresh the presets list"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:338
 #, python-brace-format
 msgid ""
 "Outdated presets version found: v{1}\n"
@@ -2796,28 +2041,22 @@ msgid ""
 "Do you want to perform this update now?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:403
 msgid "Name"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:405
 msgid "Output Format"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:406
 msgid "Supported Format List"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:531
 #, python-brace-format
 msgid "Cannot save current data in file '{}'."
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:535
 msgid "You just successfully created a new preset!"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:547
 #, python-brace-format
 msgid ""
 "Are you sure you want to remove \"{}\" preset?\n"
@@ -2825,7 +2064,6 @@ msgid ""
 " It will be moved to the \"Removals\" subfolder inside the presets folder."
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:558
 #, python-brace-format
 msgid ""
 "{}\n"
@@ -2833,72 +2071,55 @@ msgid ""
 "Sorry, removal failed, cannot continue.."
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:568
 #, python-brace-format
 msgid "The preset \"{0}\" was successfully removed"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:583
-#: ../../vdms_panels/presets_manager.py:612
 msgid "Open a destination folder"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:588
 msgid "A file with this name already exists, do you want to overwrite it?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:602
-#: ../../vdms_panels/presets_manager.py:622
 msgid "Backup completed successfully"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:631
 msgid "Open the preset you want to restore"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:645
 msgid ""
 "This preset already exists and is about to be updated. Don't worry, it will keep all your saved profiles.\n"
 "\n"
 "Do you want to continue?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:663
 msgid "Restore successful"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:681
 msgid ""
 "This will update the presets database. Don't worry, it will keep all your saved profiles.\n"
 "\n"
 "Do you want to continue?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:689
 msgid "Open the presets folder to restore"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:725
 msgid "The presets database has been successfully updated"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:740
 msgid "The selected preset is not part of Videomass's default presets."
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:745
 msgid ""
 "Be careful! The selected preset will be overwritten with the default one. Your profiles may be deleted!\n"
 "\n"
 "Do you want to continue?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:760
-#: ../../vdms_panels/presets_manager.py:794
 msgid "Successful recovery"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:769
 msgid ""
 "Be careful! This action will restore all presets to default ones. Your profiles may be deleted!\n"
 "\n"
@@ -2907,30 +2128,24 @@ msgid ""
 "Do you want to continue?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:833
 #, python-brace-format
 msgid "Edit profile on «{0}»"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:872
 msgid "Are you sure you want to delete the selected profile? It will no longer be possible to recover it."
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:891
 msgid "First select a profile in the list"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:899
 msgid ""
 "The selected profile command has been changed manually.\n"
 "Do you want to apply it during the conversion process?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:909
 msgid "Don't show this dialog again"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:1054
 msgid ""
 "Batch processing items\n"
 "Destination\n"
@@ -2942,11 +2157,9 @@ msgid ""
 "Clip duration"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:54
 msgid "Images need to be resized, please use Resize function."
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:73
 msgid ""
 "\n"
 "1. Import one or more image files such as JPG, PNG and BMP formats, then select one.\n"
@@ -2964,38 +2177,29 @@ msgid ""
 "will be saved in a folder named 'Still_Images' with a progressive digit, in the path you specify."
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:129
 msgid "Enable a single still image"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:162
 msgid ""
 "Force original aspect ratio using\n"
 "padding rather than stretching"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:170
 msgid "Include audio file"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:173
 msgid "Play the video until audio track finishes"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:180
-#: ../../vdms_panels/sequence_to_video.py:439
 msgid "Open audio file"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:199
 msgid "Additional arguments"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:454
 msgid "Open Audio File"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:466
 #, python-brace-format
 msgid ""
 "Invalid file: '{}'\n"
@@ -3003,7 +2207,6 @@ msgid ""
 "{}"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:471
 #, python-brace-format
 msgid ""
 "Invalid file: '{}'\n"
@@ -3011,21 +2214,14 @@ msgid ""
 "It doesn't appear to be an audio file."
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:560
-#: ../../vdms_panels/sequence_to_video.py:587
-#: ../../vdms_panels/video_to_sequence.py:511
 #, python-brace-format
 msgid "Invalid file: '{}'"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:570
-#: ../../vdms_panels/sequence_to_video.py:595
 #, python-brace-format
 msgid "Unsupported format '{}'"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:576
-#: ../../vdms_panels/sequence_to_video.py:600
 #, python-brace-format
 msgid ""
 "File does not exist:\n"
@@ -3033,15 +2229,9 @@ msgid ""
 "\"{}\"\n"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:577
 msgid "ERROR"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:707
-msgid "Shortest"
-msgstr ""
-
-#: ../../vdms_panels/sequence_to_video.py:715
 msgid ""
 "Items to concatenate\n"
 "Output filename\n"
@@ -3057,7 +2247,6 @@ msgid ""
 "Overall video duration"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:50
 msgid ""
 "\n"
 "1. Import one or more video files, then select one.\n"
@@ -3074,51 +2263,39 @@ msgid ""
 "with a progressive digit, in the path you specify."
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:86
 msgid "Create thumbnails"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:87
 msgid "Create tiled mosaics"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:88
 msgid "Create animated GIF"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:90
 msgid "Options"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:119
 msgid "Output format:"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:131
 msgid "Rows:"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:141
 msgid "Columns:"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:205
 msgid "Other unofficial resources:"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:229
 msgid "Set FPS control from 0.1 to 30.0 fps. The higher this value, the more images will be extracted."
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:232
 msgid "Spaces around the mosaic tiles. From 0 to 32 pixels"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:234
 msgid "Spaces around the mosaic borders. From 0 to 32 pixels"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:626
 msgid ""
 "Selected File\n"
 "Output Format\n"
@@ -3134,58 +2311,45 @@ msgid ""
 "Duration"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:118
 msgid "Audio encoder settings, mapping and filters"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:128
 msgid "Audio Encoder"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:137
 msgid "Settings"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:148
 msgid "Index Selection:"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:157
 msgid "Map:"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:180
 msgid "Normalization"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:191
 msgid "Volume detect"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:195
 msgid "Volume Statistics"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:199
 msgid "Target level:"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:264
 msgid "Gets maximum volume and average volume data in dBFS, then calculates the offset amount for audio normalization."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:267
 msgid "Limiter for the maximum peak level or the mean level (when switch to RMS) in dBFS. From -99.0 to +0.0; default for PEAK level is -1.0; default for RMS is -20.0"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:271
 msgid ""
 "Normally on a video with correctly indexed streams and having one or more audio streams, the first audio stream should be indexed at \"1\", the second at \"2\" and so on (the video stream on the other hand is always indexed at \"0\"). In this case it is recommended to select the desired stream by setting a specific index, e.g \"1\" for for the first available audio stream.\n"
 "\n"
 "Set this control to \"Auto\" if the source file is simply an audio track."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:280
 msgid ""
 "\"Auto\" keeps all audio streams and processes only the one selected by the \"Index Selection\" control.\n"
 "\n"
@@ -3194,70 +2358,55 @@ msgid ""
 "\"Index Only\" processes only the audio stream selected by the \"Index Selection\" control and removes all others from the video"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:288
 msgid "Integrated Loudness Target in LUFS. From -70.0 to -5.0, default is -16.0"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:291
 msgid "Maximum True Peak in dBTP. From -1.5 to +0.0, default is -2.0"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:294
 msgid "Loudness Range Target in LUFS. From +1.0 to +20.0, default is +11.0"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:297
 msgid "Play the audio stream selected in the \"Index Selection\" control. Using this function you can test the result of audio normalization."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:503
 msgid "Selected index does not exist or does not contain any audio streams"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:508
 #, python-brace-format
 msgid ""
 "ERROR: Missing audio stream:\n"
 "\"{}\""
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:726
 msgid "PEAK level normalization, which will produce a maximum peak level equal to the set target level."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:729
 msgid "RMS-based normalization, which according to mean volume calculates the amount of gain to reach same average power signal."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:733
 msgid ""
 "Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements the EBU R128 algorithm.\n"
 "Ideal for live normalization. It produces worse results than the High-quality two-pass Loudnorm normalization, but is faster."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:740
 msgid ""
 "High-quality two-pass Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements\n"
 "the EBU R128 algorithm. Ideal for postprocessing."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:789
 msgid "You need to import at least one file"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:63
 msgid "Subtitle Mapping:"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:77
 msgid "Copy Chapters"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:79
 msgid "Copy Metadata"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:85
 msgid ""
 "Select \"All\" to include any source file subtitles in the output video.\n"
 "\n"
@@ -3266,147 +2415,63 @@ msgid ""
 "This option is automatically ignored for output audio files."
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:90
 msgid "Copy the chapter markers as is from source file. This option is automatically ignored for output audio files."
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:93
 msgid "Copy all incoming metadata from source file, such as audio/video tags, titles, unique marks, and so on."
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:108
 msgid "Additional options"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:89
-#: ../../vdms_panels/video_encoders/av1_svt.py:120
-#: ../../vdms_panels/video_encoders/avc_x264.py:90
-#: ../../vdms_panels/video_encoders/hevc_x265.py:98
-#: ../../vdms_panels/video_encoders/mpeg4.py:71
-#: ../../vdms_panels/video_encoders/vp9_webm.py:131
 msgid "Reload"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:101
-#: ../../vdms_panels/video_encoders/av1_svt.py:129
-#: ../../vdms_panels/video_encoders/avc_x264.py:101
-#: ../../vdms_panels/video_encoders/hevc_x265.py:109
-#: ../../vdms_panels/video_encoders/mpeg4.py:82
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:97
-#: ../../vdms_panels/video_encoders/vp9_webm.py:141
 msgid "Optimize for Web"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:247
-#: ../../vdms_panels/video_encoders/av1_svt.py:313
-#: ../../vdms_panels/video_encoders/avc_x264.py:242
-#: ../../vdms_panels/video_encoders/hevc_x265.py:250
-#: ../../vdms_panels/video_encoders/mpeg4.py:198
-#: ../../vdms_panels/video_encoders/vp9_webm.py:288
 msgid "Reloads the selected video encoder settings. Changes will be discarded."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:250
-#: ../../vdms_panels/video_encoders/avc_x264.py:273
-#: ../../vdms_panels/video_encoders/hevc_x265.py:277
-#: ../../vdms_panels/video_encoders/vp9_webm.py:291
 msgid "Constant rate factor. Lower values correspond to higher quality and greater file size. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:254
-#: ../../vdms_panels/video_encoders/av1_svt.py:357
-#: ../../vdms_panels/video_encoders/vp9_webm.py:295
 msgid "Number of tile rows to use, default changes per resolution"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:256
-#: ../../vdms_panels/video_encoders/av1_svt.py:359
-#: ../../vdms_panels/video_encoders/vp9_webm.py:297
 msgid "Number of tile columns to use, default changes per resolution"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:259
-#: ../../vdms_panels/video_encoders/av1_svt.py:368
-#: ../../vdms_panels/video_encoders/avc_x264.py:253
-#: ../../vdms_panels/video_encoders/hevc_x265.py:261
-#: ../../vdms_panels/video_encoders/mpeg4.py:201
-#: ../../vdms_panels/video_encoders/vp9_webm.py:300
 msgid "Set the Group Of Picture (GOP). Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:262
-#: ../../vdms_panels/video_encoders/av1_svt.py:371
-#: ../../vdms_panels/video_encoders/avc_x264.py:256
-#: ../../vdms_panels/video_encoders/hevc_x265.py:264
-#: ../../vdms_panels/video_encoders/mpeg4.py:204
-#: ../../vdms_panels/video_encoders/vp9_webm.py:303
 msgid "It can reduce the file size, but takes longer."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:264
-#: ../../vdms_panels/video_encoders/av1_svt.py:373
-#: ../../vdms_panels/video_encoders/avc_x264.py:258
-#: ../../vdms_panels/video_encoders/hevc_x265.py:266
-#: ../../vdms_panels/video_encoders/mpeg4.py:206
-#: ../../vdms_panels/video_encoders/vp9_webm.py:305
 msgid "Set minimum bitrate tolerance. Most useful in setting up a CBR encode. It is of little use otherwise. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:268
-#: ../../vdms_panels/video_encoders/av1_svt.py:377
-#: ../../vdms_panels/video_encoders/avc_x264.py:262
-#: ../../vdms_panels/video_encoders/hevc_x265.py:270
-#: ../../vdms_panels/video_encoders/mpeg4.py:210
-#: ../../vdms_panels/video_encoders/vp9_webm.py:309
 msgid "Specifies a maximum tolerance. Requires bufsize to be set. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:271
-#: ../../vdms_panels/video_encoders/av1_svt.py:380
-#: ../../vdms_panels/video_encoders/avc_x264.py:265
-#: ../../vdms_panels/video_encoders/hevc_x265.py:273
-#: ../../vdms_panels/video_encoders/mpeg4.py:213
-#: ../../vdms_panels/video_encoders/vp9_webm.py:312
 msgid "Set ratecontrol buffer size, which determines the variability of the output bitrate. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:275
-#: ../../vdms_panels/video_encoders/av1_svt.py:384
-#: ../../vdms_panels/video_encoders/avc_x264.py:277
-#: ../../vdms_panels/video_encoders/hevc_x265.py:281
-#: ../../vdms_panels/video_encoders/mpeg4.py:231
-#: ../../vdms_panels/video_encoders/vp9_webm.py:316
 msgid "Specifies the target (average) bit rate for the encoder to use. Higher value = higher quality. Set -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:279
-#: ../../vdms_panels/video_encoders/av1_svt.py:388
-#: ../../vdms_panels/video_encoders/avc_x264.py:281
-#: ../../vdms_panels/video_encoders/hevc_x265.py:285
-#: ../../vdms_panels/video_encoders/mpeg4.py:235
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:131
-#: ../../vdms_panels/video_encoders/vp9_webm.py:320
 msgid "Video width and video height ratio."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:281
-#: ../../vdms_panels/video_encoders/av1_svt.py:390
-#: ../../vdms_panels/video_encoders/avc_x264.py:283
-#: ../../vdms_panels/video_encoders/hevc_x265.py:287
-#: ../../vdms_panels/video_encoders/mpeg4.py:237
-#: ../../vdms_panels/video_encoders/vp9_webm.py:322
 msgid "Frame rate (frames per second). Frames repeat a given number of times per second. In some countries this is 30 for NTSC, other countries (like Italy) use 25 for PAL"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:285
 msgid "Quality/Speed ratio modifier. CPU Used sets how efficient the compression will be. Lower values mean slower encoding with better quality, and vice-versa. Valid values are from 0 to 8 inclusive."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:290
 msgid "Quality and compression efficiency vs speed trade-off. \"good\" is the default and recommended for most applications; \"realtime\" is recommended for live/fast encoding (live streaming, video conferencing, etc); \"allintra\" for All Intra encoding."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:297
 msgid ""
 "Row Multi-Threading enables row-based multi-threading which maximizes CPU usage.\n"
 "\n"
@@ -3415,7 +2480,6 @@ msgid ""
 "Enabling Row Multi-Threading is only faster when the CPU has more threads than the number of encoded tiles."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:316
 msgid ""
 "presets 1-3 represent extremely high efficiency, for use when encode time is not important and quality/size of the resulting video file is critical.\n"
 "\n"
@@ -3426,7 +2490,6 @@ msgid ""
 "Preset 13 is even faster but not intended for direct human consumption--it can be used, for example, as a per-scene quality metric in VOD applications. One should use the lowest preset that is tolerable."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:327
 msgid ""
 "Constant rate factor. This parameter governs the quality/size trade-off.\n"
 "\n"
@@ -3437,7 +2500,6 @@ msgid ""
 "Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:334
 msgid ""
 "The \"Film Grain\" parameter allows SVT-AV1 to detect and delete film grain from the source video, and replace it with synthetic grain of the same character, resulting in significant bitrate savings.\n"
 "\n"
@@ -3450,80 +2512,57 @@ msgid ""
 "If the source video does not have natural grain, this parameter can be set to -1 to disable it or at least 0."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:346
 msgid ""
 "If enabled, the \"Film Grain Denoiser\" option can mitigate the detail removal caused by high \"Film Grain\" values required to preserve the look of very grainy films\n"
 "\n"
 "By default, the denoised frames are passed to be encoded as the final pictures, enabling this feature will lead to the original frames to be used instead. "
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:353
 msgid "Enables encoder optimization to produce faster (less CPU intensive) bit streams to decode, similar to the fastdecode tuning in x264 and x265."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:362
-#: ../../vdms_panels/video_encoders/avc_x264.py:247
-#: ../../vdms_panels/video_encoders/hevc_x265.py:255
 msgid "Set profile restrictions"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:364
-#: ../../vdms_panels/video_encoders/avc_x264.py:249
-#: ../../vdms_panels/video_encoders/hevc_x265.py:257
 msgid "Specify level for a selected profile"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:366
-#: ../../vdms_panels/video_encoders/avc_x264.py:251
-#: ../../vdms_panels/video_encoders/hevc_x265.py:259
 msgid "Tune the encoding params"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/avc_x264.py:245
-#: ../../vdms_panels/video_encoders/hevc_x265.py:253
 msgid "Set the encoding preset (default \"medium\")"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/avc_x264.py:269
 msgid "specifies the target (average) bit rate for the encoder to use. Higher value = higher quality. Set -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:217
 msgid "Variable Bit Rate. From 0-30, with 1 being highest quality/largest filesize and 30 being the lowest quality/smallest filesize. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:222
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:133
 msgid "Frames repeat a given number of times per second. In some countries this is 30 for NTSC, other countries (like Italy) use 25 for PAL"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:226
 msgid "The default FourCC stored in an MPEG-4-coded file will be FMP4. If you want a different FourCC, set this option to xvid to force the FourCC xvid to be stored as the video FourCC rather than the default."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:162
 msgid "Copy Video Codec"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:163
 msgid ""
 "This will just copy the video track as is, without any video re-encoding.\n"
 "You will only be able to change output format, select other audio encoders and\n"
 "a few other options."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_no_enc.py:74
 msgid "Video export disabled"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_no_enc.py:75
 msgid ""
 "The Media target you just selected will only allow you to export files as audio tracks.\n"
 "You can then process audio source files only or extract indexed audio streams on\n"
 "video files."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:326
 msgid ""
 "Speed sets how efficient the compression will be.\n"
 "\n"
@@ -3536,7 +2575,6 @@ msgid ""
 "When the Quality is set to realtime, the available values for Speed are 0 to 8."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:335
 msgid ""
 "Time to spend encoding.\n"
 "\n"
@@ -3547,35 +2585,30 @@ msgid ""
 "\"realtime\" is recommended for live / fast encoding."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:341
-msgid "If enabled, adds support for row based multithreading which greatly enhances the number of threads the encoder can utilise. This improves encoding speed significantly on systems that are otherwise underutilised when encoding VP9. Since the amount of additional threads depends on the number of \"tiles\", which itself depends on the video resolution, encoding higher resolution videos will see a larger performance improvement."
+msgid ""
+"If enabled, adds support for row based multithreading which greatly enhances the number of threads the encoder can utilise. This improves encoding speed significantly on systems that are otherwise underutilised when encoding VP9. Since the amount of additional threads depends on the number of \"tiles\", which itself depends on the video resolution, encoding higher resolution videos will see a "
+"larger performance improvement."
 msgstr ""
 
-#: ../../vdms_utils/presets_manager_utils.py:46
 #, python-brace-format
 msgid "Supports ({0}) formats only, not ({1})"
 msgstr ""
 
-#: ../../vdms_utils/presets_manager_utils.py:49
 msgid "File formats not supported by the selected profile"
 msgstr ""
 
-#: ../../vdms_utils/presets_manager_utils.py:52
 msgid "Warning"
 msgstr ""
 
-#: ../../vdms_utils/presets_manager_utils.py:90
 msgid ""
 "No presets found.\n"
 "\n"
 "Possible solution: open the Presets Manager panel, go to the presets column and try to click the \"Restore all...\" button"
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:54
 msgid "Import queue file"
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:89
 #, python-brace-format
 msgid ""
 "ERROR: invalid data found loading queue file.\n"
@@ -3584,25 +2617,20 @@ msgid ""
 "Cannot contain multiple occurrences in `destination` keys value."
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:118
 msgid "Videomass - Add Items to Queue"
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:119
 msgid ""
 "Multiple items with identical names and destination paths cannot coexist.\n"
 "Please choose one of the following actions:"
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:123
 msgid "Replace occurrences with items from the imported queue."
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:124
 msgid "Add only the currently missing items to the queue."
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:125
 msgid "Remove the current queue and replace it with the imported one."
 msgstr ""
 
@@ -3613,5 +2641,8 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "Subtitle Mapping"
+#~ msgstr ""
+
+#~ msgid "Shortest"
 #~ msgstr ""
 

--- a/videomass/data/locale/de_DE/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/de_DE/LC_MESSAGES/videomass.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-30 11:02+0200\n"
+"POT-Creation-Date: 2025-07-30 15:28+0200\n"
 "PO-Revision-Date: 2024-07-17 16:40+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de_DE\n"
@@ -2633,16 +2633,4 @@ msgstr ""
 
 msgid "Remove the current queue and replace it with the imported one."
 msgstr ""
-
-#~ msgid "Some text boxes are still incomplete"
-#~ msgstr ""
-
-#~ msgid "FFplay"
-#~ msgstr ""
-
-#~ msgid "Subtitle Mapping"
-#~ msgstr ""
-
-#~ msgid "Shortest"
-#~ msgstr ""
 

--- a/videomass/data/locale/en_US/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/en_US/LC_MESSAGES/videomass.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Videomass 5.0.18\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-30 11:02+0200\n"
+"POT-Creation-Date: 2025-07-30 15:28+0200\n"
 "PO-Revision-Date: 2024-07-03 18:44+0200\n"
 "Last-Translator: \n"
 "Language: en_US\n"
@@ -2633,16 +2633,4 @@ msgstr ""
 
 msgid "Remove the current queue and replace it with the imported one."
 msgstr ""
-
-#~ msgid "Some text boxes are still incomplete"
-#~ msgstr ""
-
-#~ msgid "FFplay"
-#~ msgstr ""
-
-#~ msgid "Subtitle Mapping"
-#~ msgstr ""
-
-#~ msgid "Shortest"
-#~ msgstr ""
 

--- a/videomass/data/locale/en_US/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/en_US/LC_MESSAGES/videomass.po
@@ -1,13 +1,13 @@
-# English translation for Videomass.
-# Copyleft -  2023 Gianluca Pernigotto
-# This file is distributed under the same license as the Videomass package
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+# English (United States) translations for Videomass.
+# Copyright (C) 2025 ORGANIZATION
+# This file is distributed under the same license as the Videomass project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Videomass 5.0.18\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-26 15:04+0200\n"
+"POT-Creation-Date: 2025-07-30 11:02+0200\n"
 "PO-Revision-Date: 2024-07-03 18:44+0200\n"
 "Last-Translator: \n"
 "Language: en_US\n"
@@ -18,7 +18,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
-#: ../../gui_app.py:196
 #, python-brace-format
 msgid ""
 "Unexpected error while deleting file contents:\n"
@@ -26,162 +25,111 @@ msgid ""
 "{0}"
 msgstr ""
 
-#: ../../vdms_dialogs/about_dialog.py:52
 msgid "Cross-platform graphical user interface for FFmpeg\n"
 msgstr ""
 
-#: ../../vdms_dialogs/audioproperties.py:224
 msgid "Videomass supports mono and stereo audio channels. If you are not sure set to \"Auto\" and source values will be copied."
 msgstr ""
 
-#: ../../vdms_dialogs/audioproperties.py:228
 msgid "The audio Rate (or sample-rate) is the sound sampling frequency and is measured in Hertz. The higher the frequency, the more true it will be to the sound source and the more the file will increase in size. For audio CD playback, set a sampling frequency of 44100 kHz. If you are not sure, set to \"Auto\" and source values will be copied."
 msgstr ""
 
-#: ../../vdms_dialogs/audioproperties.py:237
 msgid "The audio bitrate affects the file compression and thus the quality of listening. The higher the value, the higher the quality."
 msgstr ""
 
-#: ../../vdms_dialogs/audioproperties.py:241
 msgid "Bit depth is the number of bits of information in each sample, and it directly corresponds to the resolution of each sample. Bit depth is only meaningful in reference to a PCM digital signal. Non-PCM formats, such as lossy compression formats, do not have associated bit depths."
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:74 ../../vdms_dialogs/queuedlg.py:120
 msgid "When finished, once the operations have been completed successfully:"
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:80 ../../vdms_dialogs/queuedlg.py:126
 msgid "Trash the source files"
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:84 ../../vdms_dialogs/queuedlg.py:130
 msgid "Clear the File List"
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:91 ../../vdms_dialogs/queuedlg.py:142
-#: ../../vdms_main/main_frame.py:1322
 msgid "Run"
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:97
 msgid "Videomass - Batch Mode"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:47
 msgid "FFmpeg encoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:48
 msgid "supported encoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:50
 msgid "FFmpeg decoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:51
 msgid "supported decoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:77
-#: ../../vdms_panels/av_conversions.py:293
 msgid "Video"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:87
-#: ../../vdms_panels/av_conversions.py:305
 msgid "Audio"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:97
 msgid "Subtitle"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:114
-#: ../../vdms_dialogs/ffmpeg_codecs.py:123
-#: ../../vdms_dialogs/ffmpeg_codecs.py:132
-#: ../../vdms_dialogs/ffmpeg_formats.py:112
-#: ../../vdms_dialogs/ffmpeg_formats.py:115
-#: ../../vdms_dialogs/ffmpeg_formats.py:118
 msgid "description"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:72
 msgid "Informations"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:83
 msgid "Flags settings"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:93
 msgid "Flags enabled"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:103
 msgid "Flags disabled"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:116
 msgid "FFmpeg configuration"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:124
 msgid "flags"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:125 ../../vdms_dialogs/ffmpeg_conf.py:129
-#: ../../vdms_dialogs/ffmpeg_conf.py:133
 msgid "options"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:128 ../../vdms_dialogs/ffmpeg_conf.py:132
 msgid "status"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:167
 msgid "FFprobe   ...not found !"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:175
 msgid "FFplay   ...not found !"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:205
-#: ../../vdms_panels/sequence_to_video.py:706
-#: ../../vdms_panels/video_to_sequence.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:216
-#: ../../vdms_panels/sequence_to_video.py:706
-#: ../../vdms_panels/video_to_sequence.py:610
 msgid "Disabled"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:71
 msgid "Demuxing only"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:82
 msgid "Muxing only"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:93
 msgid "Demuxing/Muxing support"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:104
 msgid "FFmpeg file formats"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:111
-#: ../../vdms_dialogs/ffmpeg_formats.py:114
-#: ../../vdms_dialogs/ffmpeg_formats.py:117
 msgid "supported formats"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:46
 msgid ""
 "Contextual help based on the argument entered in the additional text field.\n"
 "Each argument consists of the type and a type-specific name.\n"
@@ -196,117 +144,84 @@ msgid ""
 "Some examples:"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:68 ../../vdms_dialogs/ffmpeg_help.py:301
-#: ../../vdms_dialogs/ffmpeg_help.py:315
 msgid "Help topic"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:69
 msgid "List basic options"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:70
 msgid "List more options"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:71
 msgid "List all options (very long)"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:72
 msgid "Show available devices"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:73
 msgid "Show available bit stream filters"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:74
 msgid "Show available protocols"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:75
 msgid "Show available filters"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:76
 msgid "Show available pixel formats"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:77
 msgid "Show available audio sample formats"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:78
 msgid "Show available color names"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:79
 msgid "List sources of the input device"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:80
 msgid "List sinks of the output device"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:81
 msgid "Show available HW acceleration methods"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:82
 msgid "Show license"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:117 ../../vdms_dialogs/filter_scale.py:76
-#: ../../vdms_dialogs/shownormlist.py:98 ../../vdms_dialogs/shownormlist.py:107
-#: ../../vdms_dialogs/shownormlist.py:116 ../../vdms_miniframes/timeline.py:263
-#: ../../vdms_miniframes/timeline.py:283 ../../vdms_panels/concatenate.py:117
-#: ../../vdms_panels/sequence_to_video.py:117
-#: ../../vdms_panels/video_to_sequence.py:81
 msgid "Read me"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:123 ../../vdms_main/main_frame.py:534
 msgid "Show configuration"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:127 ../../vdms_main/main_frame.py:542
 msgid "Encoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:131 ../../vdms_main/main_frame.py:545
 msgid "Decoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:135 ../../vdms_main/main_frame.py:538
 msgid "Muxers and Demuxers"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:165
 msgid "help topic list"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:184
 msgid "Type the argument here and confirm with the enter key on your keyboard"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:192
 msgid "The search function allows you to find entries in the current topic"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:195
 msgid "Ignore case"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:196
 msgid "Ignore case distinctions: characters with different case will match."
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:206
 msgid "FFmpeg help topics"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:254
 msgid ""
 "This is a multifunctional search tool useful for local help searches\n"
 "on multiple FFmpeg topics and options. The search control, to\n"
@@ -319,942 +234,647 @@ msgid ""
 "with those features."
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:320 ../../vdms_dialogs/ffmpeg_help.py:345
-#: ../../vdms_dialogs/ffmpeg_help.py:371
 msgid ""
 "\n"
 "  ..Nothing available"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:391
 msgid ""
 "\n"
 "  ..Not found"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:91
 msgid "Before"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:97
 msgid "After"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:103
-#: ../../vdms_dialogs/filter_crop.py:239
 msgid "Search for a specific frame"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:117
-#: ../../vdms_dialogs/filter_crop.py:253
 msgid "Load"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:120
 msgid "Color EQ"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:126
 msgid "Contrast:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:134
-#: ../../vdms_dialogs/filter_colorcorrection.py:148
 msgid "-100 to +100, default value 0"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:139
 msgid "Brightness:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:158
 msgid "Saturation:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:166
 msgid "0 to 300, default value 100"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:170
 msgid "Gamma:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:179
 msgid "0 to 100, default value 10"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:187
-#: ../../vdms_dialogs/filter_crop.py:306
-#: ../../vdms_dialogs/filter_deinterlace.py:209
-#: ../../vdms_dialogs/filter_denoisers.py:110
-#: ../../vdms_dialogs/filter_scale.py:210 ../../vdms_dialogs/filter_stab.py:316
-#: ../../vdms_dialogs/filter_transpose.py:105
-#: ../../vdms_miniframes/timeline.py:262 ../../vdms_miniframes/timeline.py:281
 msgid "Reset"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:207
 msgid "Color Correction EQ Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:343
-#: ../../vdms_dialogs/filter_colorcorrection.py:383
-#: ../../vdms_dialogs/filter_colorcorrection.py:390
-#: ../../vdms_dialogs/filter_crop.py:417 ../../vdms_dialogs/filter_scale.py:287
-#: ../../vdms_dialogs/filter_scale.py:394 ../../vdms_dialogs/filter_stab.py:473
-#: ../../vdms_dialogs/filter_stab.py:483 ../../vdms_dialogs/filter_stab.py:494
-#: ../../vdms_dialogs/filter_transpose.py:182
-#: ../../vdms_dialogs/mediainfo.py:245 ../../vdms_dialogs/mediainfo.py:265
-#: ../../vdms_dialogs/mediainfo.py:285 ../../vdms_dialogs/mediainfo.py:305
-#: ../../vdms_dialogs/setting_profiles.py:281
-#: ../../vdms_dialogs/setting_profiles.py:289 ../../vdms_io/checkup.py:45
-#: ../../vdms_io/checkup.py:93 ../../vdms_io/io_tools.py:144
-#: ../../vdms_main/main_frame.py:904 ../../vdms_main/main_frame.py:939
-#: ../../vdms_main/main_frame.py:961 ../../vdms_main/main_frame.py:979
-#: ../../vdms_main/main_frame.py:999
-#: ../../vdms_panels/audio_encoders/acodecs.py:510
-#: ../../vdms_panels/audio_encoders/acodecs.py:800
-#: ../../vdms_panels/concatenate.py:186
-#: ../../vdms_panels/long_processing_task.py:60
-#: ../../vdms_panels/presets_manager.py:426
-#: ../../vdms_panels/presets_manager.py:490
-#: ../../vdms_panels/presets_manager.py:560
-#: ../../vdms_panels/presets_manager.py:599
-#: ../../vdms_panels/presets_manager.py:619
-#: ../../vdms_panels/presets_manager.py:657
-#: ../../vdms_panels/presets_manager.py:701
-#: ../../vdms_panels/presets_manager.py:714
-#: ../../vdms_panels/presets_manager.py:721
-#: ../../vdms_panels/presets_manager.py:756
-#: ../../vdms_panels/presets_manager.py:785
-#: ../../vdms_panels/presets_manager.py:791
-#: ../../vdms_panels/sequence_to_video.py:467
-#: ../../vdms_panels/sequence_to_video.py:473
-#: ../../vdms_panels/sequence_to_video.py:561
-#: ../../vdms_panels/sequence_to_video.py:571
-#: ../../vdms_panels/sequence_to_video.py:588
-#: ../../vdms_panels/sequence_to_video.py:596
-#: ../../vdms_panels/sequence_to_video.py:602
-#: ../../vdms_panels/sequence_to_video.py:643
-#: ../../vdms_panels/sequence_to_video.py:689
-#: ../../vdms_panels/video_to_sequence.py:512
-#: ../../vdms_panels/video_to_sequence.py:583
-#: ../../vdms_threads/ffplay_file.py:43
-#: ../../vdms_utils/presets_manager_utils.py:86
-#: ../../vdms_utils/presets_manager_utils.py:95
-#: ../../vdms_utils/queue_utils.py:68 ../../vdms_utils/queue_utils.py:82
-#: ../../vdms_utils/queue_utils.py:95
 msgid "Videomass - Error!"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:228 ../../vdms_dialogs/filter_scale.py:109
 #, python-brace-format
 msgid "Source size: {0} x {1} pixels"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:236
 msgid "Crop color"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:256
 msgid "Cropping area selection "
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:261 ../../vdms_dialogs/filter_scale.py:121
 msgid "Height"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:281
 msgid "Center"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:292 ../../vdms_dialogs/filter_scale.py:121
 msgid "Width"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:334
 msgid "Crop Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:335
 msgid "Choose the color to draw the cropping area"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:337
 msgid "Crop to width"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:338
 msgid "Move vertically (set to -1 to center the vertical axis)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:340
 msgid "Move horizontally (set to -1 to center the horizontal axis)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:342
 msgid "Crop to height"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:56
 msgid "Advanced Options"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:57
-#: ../../vdms_panels/av_conversions.py:351
 msgid "Deinterlace"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:59
 msgid "Interlace"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:63
 msgid "Deinterlaces with w3fdif filter"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:77
 msgid "Deinterlaces with yadif filter"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:101
 msgid "Interlaces with interlace filter"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:118
 msgid "Deinterlacing and Interlacing"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:144
 msgid "Deinterlace the input video with `w3fdif` filter"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:146
 msgid "Set the interlacing filter coefficients."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:148
-#: ../../vdms_dialogs/filter_deinterlace.py:158
 msgid "Specify which frames to deinterlace."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:150
 msgid "Deinterlace the input video with `yadif` filter. Using FFmpeg, this is the best and fastest choice"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:153
 msgid ""
 "mode\n"
 "The interlacing mode to adopt."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:155
 msgid ""
 "parity\n"
 "The picture field parity assumed for the input interlaced video."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:160
 msgid "Simple interlacing filter from progressive contents."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:162
 msgid ""
 "scan:\n"
 "determines whether the interlaced frame is taken from the even (tff - default) or odd (bff) lines of the progressive frame."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:166
 msgid ""
 "lowpass:\n"
 "Enable (default) or disable the vertical lowpass filter to avoid twitter interlacing and reduce moire patterns.\n"
 "Default is no setting."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:56
 msgid "Denoiser Filters"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:60
 msgid "Enable nlmeans denoiser"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:73
 msgid "nlmeans options"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:82
 msgid "Enable hqdn3d denoiser"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:91
 msgid "hqdn3d options"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:116
 msgid "Denoiser Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:117
 msgid ""
 "nlmeans:\n"
 "Denoise frames using Non-Local Means algorithm is capable of restoring video sequences, even with strong noise. It is ideal for enhancing the quality of old VHS tapes."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:122
 msgid ""
 "hqdn3d:\n"
 "This is a high precision/quality 3d denoise filter. It aims to reduce image noise, producing smooth images and making still images really still. It should enhance compressibility."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:81
 msgid "View result"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:85
 msgid "New size in pixels"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:89
 msgid "Width:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:99
 msgid "Height:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:115
 msgid "Constrain proportions (keep aspect ratio)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:120
 msgid "Which dimension to adjust?"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:129
 msgid "Aspect Ratio"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:132
 msgid "Setdar filter (display aspect ratio) example 16/9, 4/3 "
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:137
-#: ../../vdms_dialogs/filter_scale.py:171
 msgid "Numerator"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:162
-#: ../../vdms_dialogs/filter_scale.py:196
 msgid "Denominator"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:166
 msgid "Setsar filter (sample aspect ratio) example 1/1"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:217
 msgid "Resize Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:218
 msgid "Scale filter, set to 0 to disable"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:221
 msgid "Display Aspect Ratio. Set to 0 to disable"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:224
 msgid ""
 "Sample (aka Pixel) Aspect Ratio.\n"
 "Set to 0 to disable"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:366
 msgid ""
 "If you want to keep the aspect ratio, select \"Constrain proportions\" below and\n"
 "specify only one dimension, either width or height, and set the other dimension\n"
 "to -1 or -2 (some codecs require -2, so you should do some testing first)."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:81
 msgid "Enable stabilizer"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:83
 msgid "Create a side-by-side comparison video"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:88
 msgid "Create a snapshot"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:106
-#: ../../vdms_panels/audio_encoders/acodecs.py:167
 msgid "Preview"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:109
 msgid "Duration seconds:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:118
 msgid "Video Detect"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:176
 msgid "[TRIPOD] Enable tripod mode if checked"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:183
 msgid "Video transform"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:202
 msgid "[OPTALGO] optimization algorithm"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:224
 msgid "[CROP] Specify how to deal with borders at movement compensation"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:231
 msgid "[INVERT] Invert transforms if checked"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:234
 msgid "[RELATIVE] Consider transforms as relative to previous frame if checked, absolute if unchecked"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:279
 msgid "Specify type of interpolation"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:287
 msgid "[TRIPOD2] virtual tripod mode, equivalent to relative=unchecked:smoothing=0"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:294
 msgid "Unsharp filter:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:323
 msgid "Seek to a position on the video."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:325
 msgid "Make a snapshot of the video with the settings made."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:327
 msgid "Set the snapshot duration from 3 to 15 seconds from the seek position, default is 5 seconds."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:331
 msgid "Set how shaky the video is and how quick the camera is. A value of 1 means little shakiness, a value of 10 means strong shakiness. Default value is 5."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:335
 msgid "Set the accuracy of the detection process. A value of 1 means low accuracy, a value of 15 means high accuracy. Default value is 15."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:339
 msgid "Set stepsize of the search process. The region around minimum is scanned with 1 pixel resolution. Default value is 6."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:343
 msgid "Set minimum contrast. Below this value a local measurement field is discarded. The range is 0-1. Default value is 0.25."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:346
 msgid "Set reference frame number for tripod mode. If enabled, the motion of the frames is compared to a reference frame in the filtered stream, identified by the specified number. The idea is to compensate all movements in a more-or-less static scene and keep the camera view absolutely still. The frames are counted starting from 1."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:355
-msgid "Set the number of frames (value*2 + 1) used for lowpass filtering the camera movements. Default value is 15. For example a number of 10 means that 21 frames are used (10 in the past and 10 in the future) to smoothen the motion in the video. A larger value leads to a smoother video, but limits the acceleration of the camera (pan/tilt movements). 0 is a special case where a static camera is simulated."
+msgid ""
+"Set the number of frames (value*2 + 1) used for lowpass filtering the camera movements. Default value is 15. For example a number of 10 means that 21 frames are used (10 in the past and 10 in the future) to smoothen the motion in the video. A larger value leads to a smoother video, but limits the acceleration of the camera (pan/tilt movements). 0 is a special case where a static camera is "
+"simulated."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:363
 msgid "Set the camera path optimization algorithm. Values are: `gauss`: gaussian kernel low-pass filter on camera motion (default), and `avg`: averaging on transformations"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:367
 msgid "Set maximal angle in radians (degree*PI/180) to rotate frames. Default value is -1, meaning no limit."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:370
 msgid "Specify how to deal with borders that may be visible due to movement compensation. Values are: `keep` keep image information from previous frame (default), `black` fill the border black"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:375
 msgid "Invert transforms if checked. Default is unchecked."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:377
 msgid "Consider transforms as relative to previous frame if checked, absolute if unchecked. Default is checked."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:380
 msgid "Set percentage to zoom. A positive value will result in a zoom-in effect, a negative value in a zoom-out effect. Default value is 0 (no zoom)."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:384
 msgid "Set optimal zooming to avoid borders. Accepted values are: `0` disabled, `1` optimal static zoom value is determined (only very strong movements will lead to visible borders) (default), `2` optimal adaptive zoom value is determined (no borders will be visible), see zoomspeed. Note that the value given at zoom is added to the one calculated here."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:391
 msgid "Set percent to zoom maximally each frame (enabled when optzoom is set to 2). Range is from 0 to 5, default value is 0.25."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:395
 msgid "Specify type of interpolation. Available values are: `no` no interpolation, `linear` linear only horizontal, `bilinear` linear in both directions (default), `bicubic` cubic in both directions (slow)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:400
 msgid "Enable virtual tripod mode if checked, which is equivalent to relative=0:smoothing=0. Default is unchecked. Use also tripod option of vidstabdetect."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:405
 msgid "Sharpen or blur the input video. Note the use of the unsharp filter which is always recommended."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:409
 msgid "Video Stabilizer Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:541 ../../vdms_io/io_tools.py:73
 msgid "Videomass - Loading..."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:542
 msgid ""
 "Please wait,\n"
 "This process will take a few seconds."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:80
-#: ../../vdms_dialogs/filter_transpose.py:293
 msgid "Default position"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:86
 msgid "Rotation setting"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:94
 msgid "90° (left)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:96
 msgid "90° (right)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:100
 msgid "180°"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:115
 msgid "Transpose Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:229
 msgid "Rotate 90 degrees right"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:251
 msgid "Rotate 180 degrees"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:272
 msgid "Rotate 90 degrees left"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:82
 msgid "Format"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:96
 msgid "Video Stream"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:109
 msgid "Audio Streams"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:122
 msgid "Subtitle Streams"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:126
 msgid "Copy to clipboard"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:137
 msgid "FILE SELECTION"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:139 ../../vdms_dialogs/mediainfo.py:142
-#: ../../vdms_dialogs/mediainfo.py:145 ../../vdms_dialogs/mediainfo.py:148
-#: ../../vdms_main/main_frame.py:1318
 msgid "Properties"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:140 ../../vdms_dialogs/mediainfo.py:143
-#: ../../vdms_dialogs/mediainfo.py:146 ../../vdms_dialogs/mediainfo.py:149
 msgid "Values"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:152
 msgid "Streams Properties"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:244
 msgid "Unable to open the clipboard on Format tab"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:263
 msgid "Unable to open the clipboard on Video Streams tab"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:283
 msgid "Unable to open the clipboard on Audio Streams tab"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:303
 msgid "Unable to open the clipboard on Subtitle Streams tab"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:90
 msgid "Where do you prefer to save your transcodes?"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:101 ../../vdms_dialogs/preferences.py:128
-#: ../../vdms_dialogs/preferences.py:149 ../../vdms_dialogs/preferences.py:161
-#: ../../vdms_dialogs/preferences.py:173 ../../vdms_panels/filedrop.py:284
 msgid "Change"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:103
-#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:602
-#: ../../vdms_panels/presets_manager.py:1050
 msgid "Same destination paths as source files"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:108
 msgid "Assign optional suffix to destination file names:"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:114
 msgid "File removal preferences"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:118
 msgid "Trash the source files after successful encoding"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:131
 msgid "File Preferences"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:138
 msgid "Location of executables"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:140
 msgid ""
 "FFmpeg can be built by enabling/disabling its options and this depends on your needs.\n"
 "For some use cases it is possible to provide a custom build of FFmpeg where you can specify\n"
 "it in this preferences tab."
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:147
 msgid "Enable a custom location to run FFmpeg"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:159
 msgid "Enable a custom location to run FFprobe"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:171
 msgid "Enable a custom location to run FFplay"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:183
 msgid "FFmpeg"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:189
 msgid "Look and Feel (requires application restart)"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:194
 msgid "Icon themes"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:208
 msgid "At the top of window (default)"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:209
 msgid "At the bottom of window"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:210
 msgid "At the right of window"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:211
 msgid "At the left of window"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:213
 msgid "Place the toolbar"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:222
 msgid "Toolbar's icons size:"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:236
 msgid "Application Language (requires application restart)"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:248
 msgid "Look and Language"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:254
 msgid "Upon exiting the application"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:259
 msgid "Always ask me to confirm"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:261
 msgid "Clean the log files"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:264
 msgid "Remove cached files"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:268
 msgid "On operations completion"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:271
 msgid "These settings will remain active until the application is closed, If necessary, remember to reactivate them."
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:276
 msgid "Exit the application"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:279
 msgid "Shutdown the system"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:283
 msgid "SUDO password:"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:292
 msgid "Exit and Shutdown"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:298
 msgid "Specify the character encoding format"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:301
 msgid ""
 "Although UTF-8 is the default and most widely used standard encoding format, it is not the only encoding format available.\n"
 "Some file metadata may still contain non-UTF-8 character encodings resulting in the error \"'utf-8' codec can't decode bytes...\".\n"
 "If you know the encoding format the file was written in, you can try specifying it here, e.g. ISO 8859-1, ISO 8859-16, etc."
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:311
 msgid "Character encoding:"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:320
 msgid "Default application directories"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:324
 msgid "Configuration directory"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:337
 msgid "Cache directory"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:349
 msgid "Log directory"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:363
 msgid "Advanced"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:369
 msgid ""
 "The following settings affect output messages and the log messages during transcoding processes.\n"
 "Be careful, by changing these settings some functions of the application may not work correctly,\n"
 "change only if you know what you are doing.\n"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:376
 msgid "Set logging level flags used by FFmpeg"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:383
 msgid "Set logging level flags used by FFplay"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:391
 msgid "FFmpeg logging levels"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:437
 msgid "By assigning an additional suffix you could avoid overwriting files"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:440
 msgid "Type sudo password here, only for Unix-like operating systems, not for MS Windows"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:443
 msgid "Preferences"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:596 ../../vdms_dialogs/preferences.py:676
-#: ../../vdms_main/main_frame.py:879 ../../vdms_main/main_frame.py:1060
 msgid "Choose Destination"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:627
 msgid "Enter only alphanumeric characters. You can also use the hyphen (\"-\") and the underscore (\"_\"). Spaces are not allowed."
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:642
-#: ../../vdms_dialogs/setting_profiles.py:257
-#: ../../vdms_dialogs/setting_profiles.py:264
-#: ../../vdms_dialogs/setting_profiles.py:286
-#: ../../vdms_dialogs/setting_profiles.py:309 ../../vdms_main/main_frame.py:399
-#: ../../vdms_main/main_frame.py:421 ../../vdms_panels/av_conversions.py:605
-#: ../../vdms_panels/av_conversions.py:612
-#: ../../vdms_panels/sequence_to_video.py:352
-#: ../../vdms_panels/video_to_sequence.py:399
 msgid "Videomass - Warning!"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:731 ../../vdms_dialogs/preferences.py:771
-#: ../../vdms_dialogs/preferences.py:811 ../../vdms_dialogs/wizard_dlg.py:365
-#: ../../vdms_dialogs/wizard_dlg.py:384 ../../vdms_dialogs/wizard_dlg.py:403
 #, python-brace-format
 msgid "{} location"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:36
-#: ../../vdms_dialogs/setting_profiles.py:38
 msgid "One-Pass, Do not start with `ffmpeg -i filename`; do not end with `output-filename`"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:40
-#: ../../vdms_dialogs/setting_profiles.py:42
 msgid "Two-Pass (optional), Do not start with `ffmpeg -i filename`; do not end with `output-filename`"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:59
 msgid "Videomass - Edit the selected item in the queue"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:71
-#: ../../vdms_dialogs/setting_profiles.py:92
 msgid "Pre-input arguments for One-Pass (optional)"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:82
-#: ../../vdms_dialogs/setting_profiles.py:151
-#: ../../vdms_panels/presets_manager.py:255
 msgid "FFmpeg arguments for one-pass encoding"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:88
-#: ../../vdms_dialogs/setting_profiles.py:158
-#: ../../vdms_panels/presets_manager.py:259
 msgid "Any optional arguments to add before input file on the one-pass encoding, e.g required names of some hardware accelerations like -hwaccel to use with CUDA."
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:102
-#: ../../vdms_dialogs/setting_profiles.py:98
 msgid "Pre-input arguments for Two-Pass (optional)"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:113
-#: ../../vdms_dialogs/setting_profiles.py:152
-#: ../../vdms_panels/presets_manager.py:257
 msgid "FFmpeg arguments for two-pass encoding"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:120
-#: ../../vdms_dialogs/setting_profiles.py:162
-#: ../../vdms_panels/presets_manager.py:263
 msgid "Any optional arguments to add before input file on the two-pass encoding, e.g required names of some hardware accelerations like -hwaccel to use with CUDA."
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:65 ../../vdms_main/main_frame.py:508
-#: ../../vdms_panels/presets_manager.py:189
-#: ../../vdms_panels/video_to_sequence.py:171
 msgid "Edit"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:68
 msgid "Remove"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:71
 msgid "Remove all"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:74
 msgid ""
 "Export\n"
 "queue file"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:77
 msgid ""
 "Import\n"
 "queue file"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:85 ../../vdms_panels/filedrop.py:273
 msgid "Destination file name"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:137
 msgid "Remove all items in the queue"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:151
 msgid "Videomass - Queue"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:228
 msgid "Export queue file"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:296 ../../vdms_panels/av_conversions.py:1192
-#: ../../vdms_panels/presets_manager.py:1044
-#: ../../vdms_panels/video_to_sequence.py:600
 msgid "Same as source"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:301
 msgid ""
 "Source\n"
 "File destination\n"
@@ -1265,186 +885,129 @@ msgid ""
 "Clip duration"
 msgstr ""
 
-#: ../../vdms_dialogs/renamer.py:76
 msgid "# will be replaced by ascending numbers starting with:"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:87
 msgid "Font Size"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:111
 msgid "Font Color"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:121
 msgid "Shadow Color"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:132
 msgid "Show text box"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:136
 msgid "Box Color"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:156
 msgid "The timestamp size does not auto-adjust to the video size, you have to set the size here"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:160 ../../vdms_main/main_frame.py:559
 msgid "Timestamp settings"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:46
 msgid "Supported Formats list (optional). Do not include the `.`"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:47
 msgid "Output Format. Empty to copy format and codec. Do not include the `.`"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:70
 msgid "Profile Name"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:74
-#: ../../vdms_panels/presets_manager.py:404
 msgid "Description"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:149
 msgid "A short profile name"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:150
 msgid "A long description of the profile"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:153
 msgid "One or more comma-separated format names compatible with this profile"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:155
 msgid "Output format extension. Leave empty to copy codec and format"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:256
 msgid "Incomplete profile assignments"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:263
 msgid "Formats must be comma-separated"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:279
-#: ../../vdms_utils/queue_utils.py:80
 #, python-brace-format
 msgid ""
 "ERROR: Keys mismatched for requested data.\n"
 "Invalid file: «{0}»"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:285
-#: ../../vdms_dialogs/setting_profiles.py:308
 msgid "Profile already stored with same name"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:293
 msgid "Profile stored successfully!"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:311
 msgid "Profile change successful!"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:80
 msgid "Log file list"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:82 ../../vdms_dialogs/showlogs.py:116
 msgid "Log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:105
 msgid "Refresh log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:107
 msgid "Clear log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:160
 msgid "Select a log file"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:167
 msgid "Are you sure you want to clear the selected log file?"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:168 ../../vdms_dialogs/wizard_dlg.py:251
-#: ../../vdms_io/checkup.py:68 ../../vdms_main/main_frame.py:205
-#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1685
-#: ../../vdms_panels/presets_manager.py:349
-#: ../../vdms_panels/presets_manager.py:550
-#: ../../vdms_panels/presets_manager.py:590
-#: ../../vdms_panels/presets_manager.py:649
-#: ../../vdms_panels/presets_manager.py:684
-#: ../../vdms_panels/presets_manager.py:749
-#: ../../vdms_panels/presets_manager.py:775
-#: ../../vdms_panels/presets_manager.py:874
-#: ../../vdms_panels/presets_manager.py:904
 msgid "Please confirm"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:83
 msgid "File name"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:84
 msgid "Max volume dBFS"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:85
 msgid "Mean volume dBFS"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:86
 msgid "Offset dBFS"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:87
 msgid "Result dBFS"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:92
 msgid "Post-normalization references:"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:102
 msgid "=  Clipped peaks"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:111
 msgid "=  No changes"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:121
 msgid "=  Below max peak"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:166
-#: ../../vdms_panels/audio_encoders/acodecs.py:841
 msgid "RMS-based volume statistics"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:191
-#: ../../vdms_panels/audio_encoders/acodecs.py:839
 msgid "PEAK-based volume statistics"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:216
 msgid ""
 "...It means the resulting audio will be clipped,\n"
 "because its volume is higher than the maximum 0 db\n"
@@ -1452,34 +1015,28 @@ msgid ""
 "sound distorted."
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:242
 msgid ""
 "...It means the resulting audio will not change,\n"
 "because it's equal to the source."
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:266
 msgid ""
 "...It means an audio signal will be produced with\n"
 "a lower volume than the source."
 msgstr ""
 
-#: ../../vdms_dialogs/videomass_check_version.py:63
 msgid "Get Latest Version"
 msgstr ""
 
-#: ../../vdms_dialogs/videomass_check_version.py:67
 msgid "Checking for newer version"
 msgstr ""
 
-#: ../../vdms_dialogs/videomass_check_version.py:95
 msgid ""
 "\n"
 "\n"
 "New releases fix bugs and offer new features."
 msgstr ""
 
-#: ../../vdms_dialogs/videomass_check_version.py:96
 #, python-brace-format
 msgid ""
 "\n"
@@ -1488,7 +1045,6 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../../vdms_dialogs/while_playing.py:37
 msgid ""
 "q, ESC\n"
 "f\n"
@@ -1511,115 +1067,89 @@ msgid ""
 "left mouse double-click"
 msgstr ""
 
-#: ../../vdms_dialogs/while_playing.py:92
 msgid "Shortcut keys while playing with FFplay"
 msgstr ""
 
-#: ../../vdms_dialogs/widget_utils.py:120 ../../vdms_main/main_frame.py:1326
 msgid "Stop"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:63
 msgid "Please take a moment to set up the application"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:64
 msgid "Click the \"Next\" button to get started"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:79
 msgid "Welcome to the Videomass Wizard!"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:123
 msgid "Videomass is an application based on FFmpeg\n"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:125
 msgid "If FFmpeg is not on your computer, this application will be unusable"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:128
 msgid ""
 "If you have already installed FFmpeg on your operating system,\n"
 "click the \"Auto-detection\" button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:131
 msgid ""
 "If you want to use a version of FFmpeg located on your filesystem\n"
 "but not installed on your operating system,\n"
 "click the \"Locate\" button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:162
 msgid "Auto-detection"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:164
 msgid "Locate"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:214
 msgid "Click the \"Next\" button"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:235
 #, python-brace-format
 msgid "'{}' is not installed on your computer. Install it or indicate another location by clicking the 'Locate' button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:249
 msgid ""
 "Videomass already seems to include FFmpeg.\n"
 "\n"
 "Do you want to use that?"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:275
 msgid "Locating FFmpeg executables\n"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:277
 msgid ""
 "\"ffmpeg\", \"ffprobe\" and \"ffplay\" are required. Complete all\n"
 "the text boxes below by clicking on the respective buttons."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:437
 msgid "Wizard completed successfully!\n"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:438
 msgid "Remember that you can always change these settings later, through the Preferences dialog."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:440
 msgid "Thank You!"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:441
 msgid "To exit click the \"Finish\" button"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:527
 msgid "< Previous"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:530 ../../vdms_dialogs/wizard_dlg.py:613
 msgid "Next >"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:535
 msgid "Videomass Wizard"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:563 ../../vdms_dialogs/wizard_dlg.py:586
-#: ../../vdms_dialogs/wizard_dlg.py:591
 msgid "Finish"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:44 ../../vdms_io/checkup.py:92
 #, python-brace-format
 msgid ""
 "Output folder does not exist:\n"
@@ -1627,432 +1157,326 @@ msgid ""
 "\"{}\"\n"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:65
 msgid "Files already exist, do you want to overwrite them?"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:67
 msgid "Already exist"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:81
 msgid "Not found"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:82 ../../vdms_panels/filedrop.py:196
 msgid "Error list"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:83
 msgid "File(s) not found"
 msgstr ""
 
-#: ../../vdms_io/io_tools.py:56
 #, python-format
 msgid "File does not exist or is invalid:  %s"
 msgstr ""
 
-#: ../../vdms_io/io_tools.py:74
 msgid ""
 "Wait....\n"
 "Audio peak analysis."
 msgstr ""
 
-#: ../../vdms_io/io_tools.py:179
 msgid "Videomass - Downloading..."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1409
-#: ../../vdms_main/main_frame.py:1441
 msgid "Ready"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:203
 msgid ""
 "Not all items in the queue were completed.\n"
 "\n"
 "Would you like to keep them in the queue?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:224
 #, python-brace-format
 msgid "Queue ({0})"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:229 ../../vdms_main/main_frame.py:1334
 msgid "Queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:396 ../../vdms_main/main_frame.py:418
 msgid "There are still active windows with running processes, make sure you finish your work before exit."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:403
 msgid "Are you sure you want to exit the application?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:405
 msgid "Exit"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:463
 msgid "Import files\tCtrl+O"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:466
 msgid "Open destination folder of encodings\tCtrl+D"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:469
 msgid "Load queue file"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:470
 msgid "Load a previously exported queue file"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:473
 msgid "Open trash"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:474
 msgid "Open the Videomass trash folder"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:476
 msgid "Empty trash"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:477
 msgid "Delete all files in the Videomass trash folder"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:480
 msgid "Exit\tCtrl+Q"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:481
 msgid "Completely exit the application"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:482
 msgid "File"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:486 ../../vdms_panels/filedrop.py:340
-#: ../../vdms_panels/filedrop.py:381
 msgid "Rename selected file\tCtrl+R"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:487
 msgid "Rename the destination of the selected file"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:490 ../../vdms_panels/filedrop.py:341
-#: ../../vdms_panels/filedrop.py:384
 msgid "Batch rename files\tCtrl+B"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:491
 msgid "Numerically renames the destination of all items in the list"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:496 ../../vdms_panels/filedrop.py:343
-#: ../../vdms_panels/filedrop.py:388
 msgid "Remove selected entry\tDEL"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:497
 msgid "Remove the selected file from the list"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:500 ../../vdms_panels/filedrop.py:344
-#: ../../vdms_panels/filedrop.py:391
 msgid "Clear list\tShift+DEL"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:501
 msgid "Clear the file list"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:506
 msgid "Preferences\tCtrl+P"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:507
 msgid "Application preferences"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:512
 msgid "Find FFmpeg topics"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:513
 msgid "A useful tool to search for FFmpeg help topics and options"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:518
 msgid "Check for preset updates"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:519
 #, python-brace-format
 msgid "Check for new presets updates from {0}"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:521
 msgid "Get latest presets"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:522
 #, python-brace-format
 msgid "Get the latest presets from {0}"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:525
 msgid "Work notes\tCtrl+N"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:526
 msgid "Read and write useful notes and reminders."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:528
 msgid "Tools"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:535
 msgid "Show FFmpeg's built-in configuration capabilities"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:539
 msgid "Muxers and demuxers available on your version of FFmpeg"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:543
 msgid "Encoders available on your version of FFmpeg"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:546
 msgid "Decoders available on your version of FFmpeg"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:550
 msgid "Enable timestamps on playback"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:551
 msgid "Displays timestamp when playing media with FFplay"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:554
 msgid "Auto-exit after playback"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:555
 msgid "If checked, the FFplay window will auto-close when playback is complete"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:559
 msgid "Customize the timestamp style"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:562
 msgid "While playing..."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:563
 msgid "Show useful shortcut keys when playing or previewing using FFplay"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:567
 msgid "Show timeline editor\tCtrl+T"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:568
 msgid "Set duration or trim slices of time to remove unwanted parts from your files"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:572
 msgid "View"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:579
 msgid "Home panel\tCtrl+Shift+H"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:580
 msgid "Go to the «Home» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:583
 msgid "Presets Manager\tCtrl+Shift+P"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:584
 msgid "Go to the «Presets Manager» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:586
 msgid "A/V Conversions\tCtrl+Shift+V"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:587
 msgid "Go to the «A/V Conversions» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:589
 msgid "Concatenate Demuxer\tCtrl+Shift+D"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:590
 msgid "Go to the «Concatenate Demuxer» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:593
 msgid "Still Image Maker\tCtrl+Shift+I"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:594
 msgid "Go to the «Still Image Maker» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:596
 msgid "From Movie to Pictures\tCtrl+Shift+S"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:597
 msgid "Go to the «From Movie to Pictures» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:600
 msgid "Output monitor\tCtrl+Shift+O"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:601
 msgid "Keeps track of the output for debugging errors"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:603
 msgid "Go"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:607
 msgid "User guide"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:611
 msgid "System version"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:612
 msgid "Get version about your operating system, version of Python and wxPython."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:616
 msgid "Show log files\tCtrl+L"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:617
 msgid "Viewing log messages"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:620
 msgid "Issue tracker"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:624
 msgid "Contribute to the project"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:627
 msgid "Sponsor this project"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:628
 msgid "Become a developer supporter"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:629
 msgid "Donate"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:630
 msgid "Donate to the app developer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:634
 msgid "Other projects by the developer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:650
 msgid "About Videomass"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:651
 msgid "Check for newer version"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:652
 msgid "Check for the latest Videomass version"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:654
 msgid "Help"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:729
 msgid "Import files"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:752
 msgid "No default folder has been set for the destination of the encodings. The current setting is \"Same destination paths as source files\"."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:784 ../../vdms_main/main_frame.py:809
 #, python-brace-format
 msgid ""
 "'{}':\n"
 "No such file or directory"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:797
 msgid "Are you sure to empty trash folder?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:805
 #, python-brace-format
 msgid ""
 "'{}':\n"
 "There are no files to delete."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:862
 #, python-brace-format
 msgid "Installed release v{0}. A new presets release is available {1}"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:866
 #, python-brace-format
 msgid "Installed release v{0}. No new updates found."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:896
 msgid ""
 "Wait....\n"
 "The archive is being downloaded"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:908
 #, python-brace-format
 msgid "Successfully downloaded to \"{0}\""
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1120
 msgid "Some changes require restarting the application."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1126
 #, python-brace-format
 msgid ""
 "{0}\n"
@@ -2060,214 +1484,159 @@ msgid ""
 "Do you want to restart the application now?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1128
 msgid "Restart Videomass?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1207
 #, python-brace-format
 msgid "A new release is available - v.{0}\n"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1210
 msgid "You are using a development version that has not yet been released!\n"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1213
 msgid "Congratulation! You are already using the latest version.\n"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1301
 msgid "Previous panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1302
 msgid "Back"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1305
 msgid "Next panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1306
 msgid "Next"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1309
 msgid "Home panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1310
 msgid "Home"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1313
 msgid "Play the selected imput file"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1314
 msgid "Play"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1317
 msgid "Get informative data about imported media streams"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1321
 msgid "Start batch processing"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1325
 msgid "Stops current process"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1329
 msgid "Add an item to Queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1330
 msgid "Add to Queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1333
 msgid "Show queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1408 ../../vdms_panels/presets_manager.py:569
 msgid "Videomass"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1442
 msgid "Videomass - File List"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1459
 msgid "Videomass - AV Conversions"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1488
 msgid "Videomass - Presets Manager"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1518
 msgid "Videomass - Concatenate Demuxer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1547
 msgid "Videomass - From Movie to Pictures"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1576
 msgid "Videomass - Still Image Maker"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1660 ../../vdms_panels/av_conversions.py:577
-#: ../../vdms_panels/filedrop.py:500 ../../vdms_panels/filedrop.py:616
-#: ../../vdms_panels/sequence_to_video.py:322
-#: ../../vdms_panels/video_to_sequence.py:369
-#: ../../vdms_panels/video_to_sequence.py:501
 msgid "Have to select an item in the file list first"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1682
 msgid ""
 "An item with the same destination file already exists.\n"
 "\n"
 "Do you want to replace it by adding the new item to the queue?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1703
 msgid "Videomass - FFmpeg Message Monitoring"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1828
 #, python-brace-format
 msgid "The system will turn off in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1829
 msgid "Videomass - Shutdown!"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1836
 msgid "Error while shutting down. Please see file log for details."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1848
 #, python-brace-format
 msgid "Exiting the application in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1849
 msgid "Videomass - Exiting!"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:46
 msgid "Start point adjustment"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:48
 msgid "End point adjustment"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:105
 msgid "Hours"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:106
 msgid "Minutes"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:107
 msgid "Seconds"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:108
 msgid "Milliseconds"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:189 ../../vdms_miniframes/timeline.py:312
 msgid "No source duration:"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:208 ../../vdms_miniframes/timeline.py:298
-#: ../../vdms_miniframes/timeline.py:333 ../../vdms_miniframes/timeline.py:338
-#: ../../vdms_miniframes/timeline.py:441
 #, python-brace-format
 msgid "{0} {1}  |  Segment Duration: {2}"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:260 ../../vdms_miniframes/timeline.py:277
 msgid "End adjustment"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:261 ../../vdms_miniframes/timeline.py:279
 msgid "Start adjustment"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:320
 msgid "Source duration:"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:387
 msgid "WARNING: Invalid selection, out of range."
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:461
 msgid ""
 "Start by dragging the bottom left handle,\n"
 "or right-click for options."
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:497
 msgid "Start"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:498
 msgid "End"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:548
 msgid ""
 "The timeline editor is a tool that allows you to trim slices of time on selected imported media (see File List panel).\n"
 "\n"
@@ -2280,39 +1649,30 @@ msgid ""
 "The \"Start\"/\"End\" duration values always refer to the initial position of the timeline: 00:00:00.000. For other informations as the segment duration and warnings, please refer to the status bar messages."
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:565
 msgid "Timeline Editor Usage"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:153
 msgid "Media:"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:169
 msgid "Container:"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:180
 msgid "Save profile"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:183
 msgid "Target"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:316
 msgid "Miscellaneous"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:323
 msgid "Save as a new profile of the Presets Manager."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:325
 msgid "Available video encoders. \"Copy\" means that the video stream will not be re-encoded and will allow you (depending on the encoder) to change the container, audio codec and a few other parameters."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:330
 msgid ""
 "Container format. It is usually represented by the file extension (output format).\n"
 "\n"
@@ -2321,73 +1681,53 @@ msgid ""
 "If the media target is set to \"Audio\", you can extract only the audio streams from videos, or simply convert audio source files."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:338
 msgid ""
 "Set output files target: \"Video\" to save output files as video files; \"Audio\" to save files using an audio encoder and format.\n"
 "\n"
 "Note that by using \"Audio\" as the target, you will still be able to work on the video source files but you will only be able to extract the audio streams, convert them and apply audio filters such as normalization."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:346
 msgid "Preview video filters"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:347
 msgid "Disable active filters"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:348
-#: ../../vdms_panels/sequence_to_video.py:156
-#: ../../vdms_panels/video_to_sequence.py:113
 msgid "Resize"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:349
 msgid "Crop"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:350
 msgid "Transpose"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:352
 msgid "Denoise"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:353
 msgid "Stabilize"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:354
 msgid "Equalize"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:517
 msgid "Unable to preview Video Stabilizer filter"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:602
 msgid ""
 "Unsupported file:\n"
 "Missing decoder or library? Check FFmpeg configuration."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:611
-#: ../../vdms_panels/sequence_to_video.py:351
-#: ../../vdms_panels/video_to_sequence.py:398
 msgid "The file is not a frame or a video file"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:434
-#: ../../vdms_panels/av_conversions.py:861
 msgid "Undetected volume values! Click the \"Volume detect\" button to analyze audio volume data."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1186
 msgid "Off"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1203
 msgid ""
 "Batch processing items\n"
 "Destination\n"
@@ -2402,109 +1742,81 @@ msgid ""
 "Clip duration"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1246
-#: ../../vdms_panels/presets_manager.py:814
 #, python-brace-format
 msgid "Write profile on «{0}»"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1266
-#: ../../vdms_panels/presets_manager.py:513
 msgid "Enter name for new preset"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1276
-#: ../../vdms_panels/presets_manager.py:524
 msgid "Invalid file name, make sure to provide a valid name including the «.json» extension"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1284
 #, python-brace-format
 msgid "Cannot save current data in file «{}»."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1289
 msgid "Open Videomass preset"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1307
 msgid "Videomass - Save new profile"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1308
 msgid "Where do you want to save this profile?"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1309
 msgid "Save the profile to a new preset"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1310
 msgid "Save the profile to an existing preset"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:69
 msgid "Welcome to Videomass"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:71
 #, python-brace-format
 msgid "Version {}"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:82
 msgid "Presets Manager"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:85
 msgid "AV-Conversions"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:88
 msgid "Concatenate media files"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:91
 msgid "Still Image Maker"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:94
 msgid "From Movie to Pictures"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:123
 msgid "Create, edit and use quickly your favorite FFmpeg presets and profiles with full formats support and codecs."
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:127
 msgid "A set of useful tools for audio and video conversions. Save your profiles and reuse them with Presets Manager."
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:131
 msgid "Concatenate multiple media files based on import order without re-encoding"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:134
 msgid "Create video from a sequence of images, based on import order, with the ability to add an audio file."
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:137
 msgid "Extract images (frames) from your movies in JPG, PNG, BMP, GIF formats."
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:47
 msgid "At least two files are required to perform concatenation."
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:63
 msgid "Invalid data found"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:68
 msgid "The files do not have the same \"codec_types\", same \"sample_rate\" or same \"width\" or \"height\". Unable to proceed."
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:84
 msgid ""
 "\n"
 "- The concatenation function is performed only with Audio files or only with Video files.\n"
@@ -2520,17 +1832,12 @@ msgid ""
 "- Audio files must have exactly the same formats, same codecs with equal sample rate."
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:125
 msgid "Videomass Documentation:"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:136
-#: ../../vdms_panels/sequence_to_video.py:212
-#: ../../vdms_panels/video_to_sequence.py:181
 msgid "Official FFmpeg documentation:"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:253
 msgid ""
 "Items to concatenate\n"
 "File destination\n"
@@ -2539,250 +1846,188 @@ msgid ""
 "Duration"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:45
 msgid "File has illegal characters like:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:46
 msgid "Invalid character found in path name: (\")"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:47
 msgid "Directories are not allowed, just add files, please."
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:48
 msgid "File without format extension: please give an appropriate extension to the file name, example '.mkv', '.avi', '.mp3', etc."
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:84
 #, python-brace-format
 msgid "Name has illegal characters like: {0}"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:85
 msgid "Name already in use:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:185
 msgid "Duplicate file, it has already been added to the list."
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:197
 msgid "Rejected files"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:269
 msgid "Source file"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:270
 msgid "Duration"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:271
 msgid "Media type"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:272
 msgid "Size"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:405
 msgid "Drag one or more files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:282
 msgid "Save to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:306
 msgid "Set a new destination folder for encodings"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:308
 msgid "Encodings destination folder"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:394
 msgid "Play file"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:408
 msgid "Drag two or more Audio/Video files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:412
 msgid "Drag one or more Image files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:415
 msgid "Drag one or more Video files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:623
 msgid "Rename the file destination"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:624
 msgid "Rename the selected file to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:638 ../../vdms_panels/filedrop.py:648
-#: ../../vdms_panels/filedrop.py:679
 msgid "Add Files"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:655
 msgid "Rename in batch"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:656
 #, python-brace-format
 msgid "Rename the {0} items to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:658
 msgid "New Name #"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:114
 msgid "Sorry, all task failed !"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:115
 msgid "The process was stopped due to a fatal error."
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:116
 msgid "Interrupted Process !"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:117
 msgid "Successfully completed !"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:118
 msgid "Not everything was successful."
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:148
 msgid "Encoding Status"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:152
 msgid "Current Log"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:354
 msgid "Fatal Error !"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:363
 msgid "Get your files at the destination you specified"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:377
 msgid "For more details please read the Current Log."
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:380
 msgid "...Finished"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:399
 msgid "Please wait... interruption in progress"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:402
 msgid "...Interrupted"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:166
 msgid "Presets"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:180
 msgid "Write"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:184
 msgid "Delete"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:194
 msgid "Duplicate"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:199
 msgid "Profiles"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:206
 msgid "One-Pass Encoding"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:218
 msgid "Two-Pass Encoding"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:232
 msgid "Choose a preset and view its profiles"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:233
 msgid "Write a new profile and save it in the selected preset"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:235
 msgid "Delete the selected profile"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:236
 msgid "Edit the selected profile"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:237
 msgid "Duplicate the selected profile"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:238
 msgid "Create new preset"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:240
 msgid "Remove selected preset"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:242
 msgid "Backup selected preset"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:244
 msgid "Backup the presets folder"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:246
 msgid "Restore a preset"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:248
 msgid "Restore a presets folder"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:250
 msgid "Resets the selected preset to default values"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:252
 msgid "Reset all presets to default values"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:254
 msgid "Refresh the presets list"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:338
 #, python-brace-format
 msgid ""
 "Outdated presets version found: v{1}\n"
@@ -2796,28 +2041,22 @@ msgid ""
 "Do you want to perform this update now?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:403
 msgid "Name"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:405
 msgid "Output Format"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:406
 msgid "Supported Format List"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:531
 #, python-brace-format
 msgid "Cannot save current data in file '{}'."
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:535
 msgid "You just successfully created a new preset!"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:547
 #, python-brace-format
 msgid ""
 "Are you sure you want to remove \"{}\" preset?\n"
@@ -2825,7 +2064,6 @@ msgid ""
 " It will be moved to the \"Removals\" subfolder inside the presets folder."
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:558
 #, python-brace-format
 msgid ""
 "{}\n"
@@ -2833,72 +2071,55 @@ msgid ""
 "Sorry, removal failed, cannot continue.."
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:568
 #, python-brace-format
 msgid "The preset \"{0}\" was successfully removed"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:583
-#: ../../vdms_panels/presets_manager.py:612
 msgid "Open a destination folder"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:588
 msgid "A file with this name already exists, do you want to overwrite it?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:602
-#: ../../vdms_panels/presets_manager.py:622
 msgid "Backup completed successfully"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:631
 msgid "Open the preset you want to restore"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:645
 msgid ""
 "This preset already exists and is about to be updated. Don't worry, it will keep all your saved profiles.\n"
 "\n"
 "Do you want to continue?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:663
 msgid "Restore successful"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:681
 msgid ""
 "This will update the presets database. Don't worry, it will keep all your saved profiles.\n"
 "\n"
 "Do you want to continue?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:689
 msgid "Open the presets folder to restore"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:725
 msgid "The presets database has been successfully updated"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:740
 msgid "The selected preset is not part of Videomass's default presets."
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:745
 msgid ""
 "Be careful! The selected preset will be overwritten with the default one. Your profiles may be deleted!\n"
 "\n"
 "Do you want to continue?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:760
-#: ../../vdms_panels/presets_manager.py:794
 msgid "Successful recovery"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:769
 msgid ""
 "Be careful! This action will restore all presets to default ones. Your profiles may be deleted!\n"
 "\n"
@@ -2907,30 +2128,24 @@ msgid ""
 "Do you want to continue?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:833
 #, python-brace-format
 msgid "Edit profile on «{0}»"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:872
 msgid "Are you sure you want to delete the selected profile? It will no longer be possible to recover it."
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:891
 msgid "First select a profile in the list"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:899
 msgid ""
 "The selected profile command has been changed manually.\n"
 "Do you want to apply it during the conversion process?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:909
 msgid "Don't show this dialog again"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:1054
 msgid ""
 "Batch processing items\n"
 "Destination\n"
@@ -2942,11 +2157,9 @@ msgid ""
 "Clip duration"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:54
 msgid "Images need to be resized, please use Resize function."
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:73
 msgid ""
 "\n"
 "1. Import one or more image files such as JPG, PNG and BMP formats, then select one.\n"
@@ -2964,38 +2177,29 @@ msgid ""
 "will be saved in a folder named 'Still_Images' with a progressive digit, in the path you specify."
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:129
 msgid "Enable a single still image"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:162
 msgid ""
 "Force original aspect ratio using\n"
 "padding rather than stretching"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:170
 msgid "Include audio file"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:173
 msgid "Play the video until audio track finishes"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:180
-#: ../../vdms_panels/sequence_to_video.py:439
 msgid "Open audio file"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:199
 msgid "Additional arguments"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:454
 msgid "Open Audio File"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:466
 #, python-brace-format
 msgid ""
 "Invalid file: '{}'\n"
@@ -3003,7 +2207,6 @@ msgid ""
 "{}"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:471
 #, python-brace-format
 msgid ""
 "Invalid file: '{}'\n"
@@ -3011,21 +2214,14 @@ msgid ""
 "It doesn't appear to be an audio file."
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:560
-#: ../../vdms_panels/sequence_to_video.py:587
-#: ../../vdms_panels/video_to_sequence.py:511
 #, python-brace-format
 msgid "Invalid file: '{}'"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:570
-#: ../../vdms_panels/sequence_to_video.py:595
 #, python-brace-format
 msgid "Unsupported format '{}'"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:576
-#: ../../vdms_panels/sequence_to_video.py:600
 #, python-brace-format
 msgid ""
 "File does not exist:\n"
@@ -3033,15 +2229,9 @@ msgid ""
 "\"{}\"\n"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:577
 msgid "ERROR"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:707
-msgid "Shortest"
-msgstr ""
-
-#: ../../vdms_panels/sequence_to_video.py:715
 msgid ""
 "Items to concatenate\n"
 "Output filename\n"
@@ -3057,7 +2247,6 @@ msgid ""
 "Overall video duration"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:50
 msgid ""
 "\n"
 "1. Import one or more video files, then select one.\n"
@@ -3074,51 +2263,39 @@ msgid ""
 "with a progressive digit, in the path you specify."
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:86
 msgid "Create thumbnails"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:87
 msgid "Create tiled mosaics"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:88
 msgid "Create animated GIF"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:90
 msgid "Options"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:119
 msgid "Output format:"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:131
 msgid "Rows:"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:141
 msgid "Columns:"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:205
 msgid "Other unofficial resources:"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:229
 msgid "Set FPS control from 0.1 to 30.0 fps. The higher this value, the more images will be extracted."
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:232
 msgid "Spaces around the mosaic tiles. From 0 to 32 pixels"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:234
 msgid "Spaces around the mosaic borders. From 0 to 32 pixels"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:626
 msgid ""
 "Selected File\n"
 "Output Format\n"
@@ -3134,58 +2311,45 @@ msgid ""
 "Duration"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:118
 msgid "Audio encoder settings, mapping and filters"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:128
 msgid "Audio Encoder"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:137
 msgid "Settings"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:148
 msgid "Index Selection:"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:157
 msgid "Map:"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:180
 msgid "Normalization"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:191
 msgid "Volume detect"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:195
 msgid "Volume Statistics"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:199
 msgid "Target level:"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:264
 msgid "Gets maximum volume and average volume data in dBFS, then calculates the offset amount for audio normalization."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:267
 msgid "Limiter for the maximum peak level or the mean level (when switch to RMS) in dBFS. From -99.0 to +0.0; default for PEAK level is -1.0; default for RMS is -20.0"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:271
 msgid ""
 "Normally on a video with correctly indexed streams and having one or more audio streams, the first audio stream should be indexed at \"1\", the second at \"2\" and so on (the video stream on the other hand is always indexed at \"0\"). In this case it is recommended to select the desired stream by setting a specific index, e.g \"1\" for for the first available audio stream.\n"
 "\n"
 "Set this control to \"Auto\" if the source file is simply an audio track."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:280
 msgid ""
 "\"Auto\" keeps all audio streams and processes only the one selected by the \"Index Selection\" control.\n"
 "\n"
@@ -3194,70 +2358,55 @@ msgid ""
 "\"Index Only\" processes only the audio stream selected by the \"Index Selection\" control and removes all others from the video"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:288
 msgid "Integrated Loudness Target in LUFS. From -70.0 to -5.0, default is -16.0"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:291
 msgid "Maximum True Peak in dBTP. From -1.5 to +0.0, default is -2.0"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:294
 msgid "Loudness Range Target in LUFS. From +1.0 to +20.0, default is +11.0"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:297
 msgid "Play the audio stream selected in the \"Index Selection\" control. Using this function you can test the result of audio normalization."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:503
 msgid "Selected index does not exist or does not contain any audio streams"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:508
 #, python-brace-format
 msgid ""
 "ERROR: Missing audio stream:\n"
 "\"{}\""
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:726
 msgid "PEAK level normalization, which will produce a maximum peak level equal to the set target level."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:729
 msgid "RMS-based normalization, which according to mean volume calculates the amount of gain to reach same average power signal."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:733
 msgid ""
 "Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements the EBU R128 algorithm.\n"
 "Ideal for live normalization. It produces worse results than the High-quality two-pass Loudnorm normalization, but is faster."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:740
 msgid ""
 "High-quality two-pass Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements\n"
 "the EBU R128 algorithm. Ideal for postprocessing."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:789
 msgid "You need to import at least one file"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:63
 msgid "Subtitle Mapping:"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:77
 msgid "Copy Chapters"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:79
 msgid "Copy Metadata"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:85
 msgid ""
 "Select \"All\" to include any source file subtitles in the output video.\n"
 "\n"
@@ -3266,147 +2415,63 @@ msgid ""
 "This option is automatically ignored for output audio files."
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:90
 msgid "Copy the chapter markers as is from source file. This option is automatically ignored for output audio files."
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:93
 msgid "Copy all incoming metadata from source file, such as audio/video tags, titles, unique marks, and so on."
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:108
 msgid "Additional options"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:89
-#: ../../vdms_panels/video_encoders/av1_svt.py:120
-#: ../../vdms_panels/video_encoders/avc_x264.py:90
-#: ../../vdms_panels/video_encoders/hevc_x265.py:98
-#: ../../vdms_panels/video_encoders/mpeg4.py:71
-#: ../../vdms_panels/video_encoders/vp9_webm.py:131
 msgid "Reload"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:101
-#: ../../vdms_panels/video_encoders/av1_svt.py:129
-#: ../../vdms_panels/video_encoders/avc_x264.py:101
-#: ../../vdms_panels/video_encoders/hevc_x265.py:109
-#: ../../vdms_panels/video_encoders/mpeg4.py:82
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:97
-#: ../../vdms_panels/video_encoders/vp9_webm.py:141
 msgid "Optimize for Web"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:247
-#: ../../vdms_panels/video_encoders/av1_svt.py:313
-#: ../../vdms_panels/video_encoders/avc_x264.py:242
-#: ../../vdms_panels/video_encoders/hevc_x265.py:250
-#: ../../vdms_panels/video_encoders/mpeg4.py:198
-#: ../../vdms_panels/video_encoders/vp9_webm.py:288
 msgid "Reloads the selected video encoder settings. Changes will be discarded."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:250
-#: ../../vdms_panels/video_encoders/avc_x264.py:273
-#: ../../vdms_panels/video_encoders/hevc_x265.py:277
-#: ../../vdms_panels/video_encoders/vp9_webm.py:291
 msgid "Constant rate factor. Lower values correspond to higher quality and greater file size. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:254
-#: ../../vdms_panels/video_encoders/av1_svt.py:357
-#: ../../vdms_panels/video_encoders/vp9_webm.py:295
 msgid "Number of tile rows to use, default changes per resolution"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:256
-#: ../../vdms_panels/video_encoders/av1_svt.py:359
-#: ../../vdms_panels/video_encoders/vp9_webm.py:297
 msgid "Number of tile columns to use, default changes per resolution"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:259
-#: ../../vdms_panels/video_encoders/av1_svt.py:368
-#: ../../vdms_panels/video_encoders/avc_x264.py:253
-#: ../../vdms_panels/video_encoders/hevc_x265.py:261
-#: ../../vdms_panels/video_encoders/mpeg4.py:201
-#: ../../vdms_panels/video_encoders/vp9_webm.py:300
 msgid "Set the Group Of Picture (GOP). Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:262
-#: ../../vdms_panels/video_encoders/av1_svt.py:371
-#: ../../vdms_panels/video_encoders/avc_x264.py:256
-#: ../../vdms_panels/video_encoders/hevc_x265.py:264
-#: ../../vdms_panels/video_encoders/mpeg4.py:204
-#: ../../vdms_panels/video_encoders/vp9_webm.py:303
 msgid "It can reduce the file size, but takes longer."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:264
-#: ../../vdms_panels/video_encoders/av1_svt.py:373
-#: ../../vdms_panels/video_encoders/avc_x264.py:258
-#: ../../vdms_panels/video_encoders/hevc_x265.py:266
-#: ../../vdms_panels/video_encoders/mpeg4.py:206
-#: ../../vdms_panels/video_encoders/vp9_webm.py:305
 msgid "Set minimum bitrate tolerance. Most useful in setting up a CBR encode. It is of little use otherwise. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:268
-#: ../../vdms_panels/video_encoders/av1_svt.py:377
-#: ../../vdms_panels/video_encoders/avc_x264.py:262
-#: ../../vdms_panels/video_encoders/hevc_x265.py:270
-#: ../../vdms_panels/video_encoders/mpeg4.py:210
-#: ../../vdms_panels/video_encoders/vp9_webm.py:309
 msgid "Specifies a maximum tolerance. Requires bufsize to be set. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:271
-#: ../../vdms_panels/video_encoders/av1_svt.py:380
-#: ../../vdms_panels/video_encoders/avc_x264.py:265
-#: ../../vdms_panels/video_encoders/hevc_x265.py:273
-#: ../../vdms_panels/video_encoders/mpeg4.py:213
-#: ../../vdms_panels/video_encoders/vp9_webm.py:312
 msgid "Set ratecontrol buffer size, which determines the variability of the output bitrate. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:275
-#: ../../vdms_panels/video_encoders/av1_svt.py:384
-#: ../../vdms_panels/video_encoders/avc_x264.py:277
-#: ../../vdms_panels/video_encoders/hevc_x265.py:281
-#: ../../vdms_panels/video_encoders/mpeg4.py:231
-#: ../../vdms_panels/video_encoders/vp9_webm.py:316
 msgid "Specifies the target (average) bit rate for the encoder to use. Higher value = higher quality. Set -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:279
-#: ../../vdms_panels/video_encoders/av1_svt.py:388
-#: ../../vdms_panels/video_encoders/avc_x264.py:281
-#: ../../vdms_panels/video_encoders/hevc_x265.py:285
-#: ../../vdms_panels/video_encoders/mpeg4.py:235
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:131
-#: ../../vdms_panels/video_encoders/vp9_webm.py:320
 msgid "Video width and video height ratio."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:281
-#: ../../vdms_panels/video_encoders/av1_svt.py:390
-#: ../../vdms_panels/video_encoders/avc_x264.py:283
-#: ../../vdms_panels/video_encoders/hevc_x265.py:287
-#: ../../vdms_panels/video_encoders/mpeg4.py:237
-#: ../../vdms_panels/video_encoders/vp9_webm.py:322
 msgid "Frame rate (frames per second). Frames repeat a given number of times per second. In some countries this is 30 for NTSC, other countries (like Italy) use 25 for PAL"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:285
 msgid "Quality/Speed ratio modifier. CPU Used sets how efficient the compression will be. Lower values mean slower encoding with better quality, and vice-versa. Valid values are from 0 to 8 inclusive."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:290
 msgid "Quality and compression efficiency vs speed trade-off. \"good\" is the default and recommended for most applications; \"realtime\" is recommended for live/fast encoding (live streaming, video conferencing, etc); \"allintra\" for All Intra encoding."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:297
 msgid ""
 "Row Multi-Threading enables row-based multi-threading which maximizes CPU usage.\n"
 "\n"
@@ -3415,7 +2480,6 @@ msgid ""
 "Enabling Row Multi-Threading is only faster when the CPU has more threads than the number of encoded tiles."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:316
 msgid ""
 "presets 1-3 represent extremely high efficiency, for use when encode time is not important and quality/size of the resulting video file is critical.\n"
 "\n"
@@ -3426,7 +2490,6 @@ msgid ""
 "Preset 13 is even faster but not intended for direct human consumption--it can be used, for example, as a per-scene quality metric in VOD applications. One should use the lowest preset that is tolerable."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:327
 msgid ""
 "Constant rate factor. This parameter governs the quality/size trade-off.\n"
 "\n"
@@ -3437,7 +2500,6 @@ msgid ""
 "Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:334
 msgid ""
 "The \"Film Grain\" parameter allows SVT-AV1 to detect and delete film grain from the source video, and replace it with synthetic grain of the same character, resulting in significant bitrate savings.\n"
 "\n"
@@ -3450,80 +2512,57 @@ msgid ""
 "If the source video does not have natural grain, this parameter can be set to -1 to disable it or at least 0."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:346
 msgid ""
 "If enabled, the \"Film Grain Denoiser\" option can mitigate the detail removal caused by high \"Film Grain\" values required to preserve the look of very grainy films\n"
 "\n"
 "By default, the denoised frames are passed to be encoded as the final pictures, enabling this feature will lead to the original frames to be used instead. "
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:353
 msgid "Enables encoder optimization to produce faster (less CPU intensive) bit streams to decode, similar to the fastdecode tuning in x264 and x265."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:362
-#: ../../vdms_panels/video_encoders/avc_x264.py:247
-#: ../../vdms_panels/video_encoders/hevc_x265.py:255
 msgid "Set profile restrictions"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:364
-#: ../../vdms_panels/video_encoders/avc_x264.py:249
-#: ../../vdms_panels/video_encoders/hevc_x265.py:257
 msgid "Specify level for a selected profile"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:366
-#: ../../vdms_panels/video_encoders/avc_x264.py:251
-#: ../../vdms_panels/video_encoders/hevc_x265.py:259
 msgid "Tune the encoding params"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/avc_x264.py:245
-#: ../../vdms_panels/video_encoders/hevc_x265.py:253
 msgid "Set the encoding preset (default \"medium\")"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/avc_x264.py:269
 msgid "specifies the target (average) bit rate for the encoder to use. Higher value = higher quality. Set -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:217
 msgid "Variable Bit Rate. From 0-30, with 1 being highest quality/largest filesize and 30 being the lowest quality/smallest filesize. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:222
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:133
 msgid "Frames repeat a given number of times per second. In some countries this is 30 for NTSC, other countries (like Italy) use 25 for PAL"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:226
 msgid "The default FourCC stored in an MPEG-4-coded file will be FMP4. If you want a different FourCC, set this option to xvid to force the FourCC xvid to be stored as the video FourCC rather than the default."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:162
 msgid "Copy Video Codec"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:163
 msgid ""
 "This will just copy the video track as is, without any video re-encoding.\n"
 "You will only be able to change output format, select other audio encoders and\n"
 "a few other options."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_no_enc.py:74
 msgid "Video export disabled"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_no_enc.py:75
 msgid ""
 "The Media target you just selected will only allow you to export files as audio tracks.\n"
 "You can then process audio source files only or extract indexed audio streams on\n"
 "video files."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:326
 msgid ""
 "Speed sets how efficient the compression will be.\n"
 "\n"
@@ -3536,7 +2575,6 @@ msgid ""
 "When the Quality is set to realtime, the available values for Speed are 0 to 8."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:335
 msgid ""
 "Time to spend encoding.\n"
 "\n"
@@ -3547,35 +2585,30 @@ msgid ""
 "\"realtime\" is recommended for live / fast encoding."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:341
-msgid "If enabled, adds support for row based multithreading which greatly enhances the number of threads the encoder can utilise. This improves encoding speed significantly on systems that are otherwise underutilised when encoding VP9. Since the amount of additional threads depends on the number of \"tiles\", which itself depends on the video resolution, encoding higher resolution videos will see a larger performance improvement."
+msgid ""
+"If enabled, adds support for row based multithreading which greatly enhances the number of threads the encoder can utilise. This improves encoding speed significantly on systems that are otherwise underutilised when encoding VP9. Since the amount of additional threads depends on the number of \"tiles\", which itself depends on the video resolution, encoding higher resolution videos will see a "
+"larger performance improvement."
 msgstr ""
 
-#: ../../vdms_utils/presets_manager_utils.py:46
 #, python-brace-format
 msgid "Supports ({0}) formats only, not ({1})"
 msgstr ""
 
-#: ../../vdms_utils/presets_manager_utils.py:49
 msgid "File formats not supported by the selected profile"
 msgstr ""
 
-#: ../../vdms_utils/presets_manager_utils.py:52
 msgid "Warning"
 msgstr ""
 
-#: ../../vdms_utils/presets_manager_utils.py:90
 msgid ""
 "No presets found.\n"
 "\n"
 "Possible solution: open the Presets Manager panel, go to the presets column and try to click the \"Restore all...\" button"
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:54
 msgid "Import queue file"
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:89
 #, python-brace-format
 msgid ""
 "ERROR: invalid data found loading queue file.\n"
@@ -3584,25 +2617,20 @@ msgid ""
 "Cannot contain multiple occurrences in `destination` keys value."
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:118
 msgid "Videomass - Add Items to Queue"
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:119
 msgid ""
 "Multiple items with identical names and destination paths cannot coexist.\n"
 "Please choose one of the following actions:"
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:123
 msgid "Replace occurrences with items from the imported queue."
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:124
 msgid "Add only the currently missing items to the queue."
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:125
 msgid "Remove the current queue and replace it with the imported one."
 msgstr ""
 
@@ -3613,5 +2641,8 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "Subtitle Mapping"
+#~ msgstr ""
+
+#~ msgid "Shortest"
 #~ msgstr ""
 

--- a/videomass/data/locale/es_CU/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/es_CU/LC_MESSAGES/videomass.po
@@ -1,13 +1,13 @@
-# Spanish translation for Videomass.
-# Copyleft -  2024 Gianluca Pernigotto
-# This file is distributed under the same license as the Videomass package
-# FIRST AUTHOR Gianluca Pernigotto <jeanlucperni@gmail.com>, 2021
+# Spanish (Cuba) translations for Videomass.
+# Copyright (C) 2025 ORGANIZATION
+# This file is distributed under the same license as the Videomass project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Videomass 5.0.18\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-26 15:04+0200\n"
+"POT-Creation-Date: 2025-07-30 11:02+0200\n"
 "PO-Revision-Date: 2024-08-26 17:29-0600\n"
 "Last-Translator: José Alberto Valle Cid j.alberto.vc@gmail.com\n"
 "Language: es_CU\n"
@@ -18,7 +18,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
-#: ../../gui_app.py:196
 #, python-brace-format
 msgid ""
 "Unexpected error while deleting file contents:\n"
@@ -29,162 +28,111 @@ msgstr ""
 "\n"
 "{0}"
 
-#: ../../vdms_dialogs/about_dialog.py:52
 msgid "Cross-platform graphical user interface for FFmpeg\n"
 msgstr ""
 
-#: ../../vdms_dialogs/audioproperties.py:224
 msgid "Videomass supports mono and stereo audio channels. If you are not sure set to \"Auto\" and source values will be copied."
 msgstr "Videomass soporta canales de audio mono y estéreo. Si no esta seguro elija \"Auto\" y se copiaran los valores de la fuente."
 
-#: ../../vdms_dialogs/audioproperties.py:228
 msgid "The audio Rate (or sample-rate) is the sound sampling frequency and is measured in Hertz. The higher the frequency, the more true it will be to the sound source and the more the file will increase in size. For audio CD playback, set a sampling frequency of 44100 kHz. If you are not sure, set to \"Auto\" and source values will be copied."
 msgstr "La Frecuencia de audio (o frecuencia de muestreo) es la frecuencia de toma de muestras del audio y se mide en Hertz. A mayor frecuencia, la fuente de sonido tendrá mayor fidelidad y se incrementara el tamaño del archivo. Para calidad CD , elija una frecuencia de muestreo de 44100 kHz. Si no esta seguro elija \"Auto\" y se copiaran los valores de la fuente."
 
-#: ../../vdms_dialogs/audioproperties.py:237
 msgid "The audio bitrate affects the file compression and thus the quality of listening. The higher the value, the higher the quality."
 msgstr "La frecuencia de bits (bitrate) del audio afecta la compresión y la calidad de audio. Los valores mas altos implican mejor calidad."
 
-#: ../../vdms_dialogs/audioproperties.py:241
 msgid "Bit depth is the number of bits of information in each sample, and it directly corresponds to the resolution of each sample. Bit depth is only meaningful in reference to a PCM digital signal. Non-PCM formats, such as lossy compression formats, do not have associated bit depths."
 msgstr "La profundidad de bites el numero de bits de información en cada muestra, y se corresponde directamente a al resolución de cada muestra. La profundidad de bit solo es relevante para señales digitales PCM. Los formatos No-PCM, como los formatos compresos/con perdidas, no tienen asociados una profundidad de bits."
 
-#: ../../vdms_dialogs/epilogue.py:74 ../../vdms_dialogs/queuedlg.py:120
 msgid "When finished, once the operations have been completed successfully:"
 msgstr "Al finalizar las operaciones con éxito:"
 
-#: ../../vdms_dialogs/epilogue.py:80 ../../vdms_dialogs/queuedlg.py:126
 msgid "Trash the source files"
 msgstr "Desechar archivos fuente"
 
-#: ../../vdms_dialogs/epilogue.py:84 ../../vdms_dialogs/queuedlg.py:130
 msgid "Clear the File List"
 msgstr "Limpia la Lista de Archivos"
 
-#: ../../vdms_dialogs/epilogue.py:91 ../../vdms_dialogs/queuedlg.py:142
-#: ../../vdms_main/main_frame.py:1322
 msgid "Run"
 msgstr "Ejecutar"
 
-#: ../../vdms_dialogs/epilogue.py:97
 msgid "Videomass - Batch Mode"
 msgstr "Videomass - Proceso por lotes"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:47
 msgid "FFmpeg encoders"
 msgstr "Codificadores FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:48
 msgid "supported encoders"
 msgstr "codificadores soportados"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:50
 msgid "FFmpeg decoders"
 msgstr "Decodificadores FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:51
 msgid "supported decoders"
 msgstr "decodificadores soportados"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:77
-#: ../../vdms_panels/av_conversions.py:293
 msgid "Video"
 msgstr "Video"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:87
-#: ../../vdms_panels/av_conversions.py:305
 msgid "Audio"
 msgstr "Audio"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:97
 msgid "Subtitle"
 msgstr "Subtitulo"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:114
-#: ../../vdms_dialogs/ffmpeg_codecs.py:123
-#: ../../vdms_dialogs/ffmpeg_codecs.py:132
-#: ../../vdms_dialogs/ffmpeg_formats.py:112
-#: ../../vdms_dialogs/ffmpeg_formats.py:115
-#: ../../vdms_dialogs/ffmpeg_formats.py:118
 msgid "description"
 msgstr "descripción"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:72
 msgid "Informations"
 msgstr "Informaciones"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:83
 msgid "Flags settings"
 msgstr "Configurar banderas"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:93
 msgid "Flags enabled"
 msgstr "Banderas activas"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:103
 msgid "Flags disabled"
 msgstr "Deshabilitar banderas"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:116
 msgid "FFmpeg configuration"
 msgstr "Configuración de FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:124
 msgid "flags"
 msgstr "banderas"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:125 ../../vdms_dialogs/ffmpeg_conf.py:129
-#: ../../vdms_dialogs/ffmpeg_conf.py:133
 msgid "options"
 msgstr "opciones"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:128 ../../vdms_dialogs/ffmpeg_conf.py:132
 msgid "status"
 msgstr "estado"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:167
 msgid "FFprobe   ...not found !"
 msgstr "¡No se encontró FFprobe !"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:175
 msgid "FFplay   ...not found !"
 msgstr "¡No se encontró FFplay !"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:205
-#: ../../vdms_panels/sequence_to_video.py:706
-#: ../../vdms_panels/video_to_sequence.py:606
 msgid "Enabled"
 msgstr "Habilitado"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:216
-#: ../../vdms_panels/sequence_to_video.py:706
-#: ../../vdms_panels/video_to_sequence.py:610
 msgid "Disabled"
 msgstr "Deshabilitado"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:71
 msgid "Demuxing only"
 msgstr "Solo Desmezclar"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:82
 msgid "Muxing only"
 msgstr "Solo Mezclar"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:93
 msgid "Demuxing/Muxing support"
 msgstr "Soporte Desmezclar/Mezclar"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:104
 msgid "FFmpeg file formats"
 msgstr "Formatos de archivos FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:111
-#: ../../vdms_dialogs/ffmpeg_formats.py:114
-#: ../../vdms_dialogs/ffmpeg_formats.py:117
 msgid "supported formats"
 msgstr "formatos soportados"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:46
 msgid ""
 "Contextual help based on the argument entered in the additional text field.\n"
 "Each argument consists of the type and a type-specific name.\n"
@@ -210,117 +158,84 @@ msgstr ""
 "\n"
 "Algunos ejemplos:"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:68 ../../vdms_dialogs/ffmpeg_help.py:301
-#: ../../vdms_dialogs/ffmpeg_help.py:315
 msgid "Help topic"
 msgstr "Temas de ayuda"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:69
 msgid "List basic options"
 msgstr "Mostrar opciones básicas"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:70
 msgid "List more options"
 msgstr "Mostrar más opciones"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:71
 msgid "List all options (very long)"
 msgstr "Mostrar todas las opciones (muy largo)"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:72
 msgid "Show available devices"
 msgstr "Ver dispositivos disponibles"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:73
 msgid "Show available bit stream filters"
 msgstr "Ver filtros disponibles para flujo de bits"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:74
 msgid "Show available protocols"
 msgstr "Ver protocolos disponibles"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:75
 msgid "Show available filters"
 msgstr "Ver filtros disponibles"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:76
 msgid "Show available pixel formats"
 msgstr "Ver formatos de pixel disponibles"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:77
 msgid "Show available audio sample formats"
 msgstr "Ver formatos disponibles para muestreo de audio"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:78
 msgid "Show available color names"
 msgstr "Ver nombres de color disponibles"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:79
 msgid "List sources of the input device"
 msgstr "Lista fuentes del dispositivo de entrada"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:80
 msgid "List sinks of the output device"
 msgstr "Lista receptores del dispositivo de salida"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:81
 msgid "Show available HW acceleration methods"
 msgstr "Ver métodos de aceleración por HW"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:82
 msgid "Show license"
 msgstr "Mostrar licensia"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:117 ../../vdms_dialogs/filter_scale.py:76
-#: ../../vdms_dialogs/shownormlist.py:98 ../../vdms_dialogs/shownormlist.py:107
-#: ../../vdms_dialogs/shownormlist.py:116 ../../vdms_miniframes/timeline.py:263
-#: ../../vdms_miniframes/timeline.py:283 ../../vdms_panels/concatenate.py:117
-#: ../../vdms_panels/sequence_to_video.py:117
-#: ../../vdms_panels/video_to_sequence.py:81
 msgid "Read me"
 msgstr "Leame"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:123 ../../vdms_main/main_frame.py:534
 msgid "Show configuration"
 msgstr "Mostrar configuración"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:127 ../../vdms_main/main_frame.py:542
 msgid "Encoders"
 msgstr "Codificadores"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:131 ../../vdms_main/main_frame.py:545
 msgid "Decoders"
 msgstr "Decodificadores"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:135 ../../vdms_main/main_frame.py:538
 msgid "Muxers and Demuxers"
 msgstr "Mezcladores y Dezmezcladores"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:165
 msgid "help topic list"
 msgstr "lista de temas de ayuda"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:184
 msgid "Type the argument here and confirm with the enter key on your keyboard"
 msgstr "Teclee aquí el argumento y presione la tecla enter de su teclado"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:192
 msgid "The search function allows you to find entries in the current topic"
 msgstr "La función de búsqueda le permite encontrar entradas del tema actual"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:195
 msgid "Ignore case"
 msgstr "Ignorar mayúsculas"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:196
 msgid "Ignore case distinctions: characters with different case will match."
 msgstr "Ignorar mayúsculas: las letras mayúsculas y minúsculas serán iguales."
 
-#: ../../vdms_dialogs/ffmpeg_help.py:206
 msgid "FFmpeg help topics"
 msgstr "Temas de ayuda de FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:254
 msgid ""
 "This is a multifunctional search tool useful for local help searches\n"
 "on multiple FFmpeg topics and options. The search control, to\n"
@@ -342,8 +257,6 @@ msgstr ""
 "es seguro que su versión de FFmpeg es muy antigua o no tenga configuradas\n"
 "esas características."
 
-#: ../../vdms_dialogs/ffmpeg_help.py:320 ../../vdms_dialogs/ffmpeg_help.py:345
-#: ../../vdms_dialogs/ffmpeg_help.py:371
 msgid ""
 "\n"
 "  ..Nothing available"
@@ -351,7 +264,6 @@ msgstr ""
 "\n"
 "  ..Nada disponible"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:391
 msgid ""
 "\n"
 "  ..Not found"
@@ -359,217 +271,121 @@ msgstr ""
 "\n"
 "...No encontrado"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:91
 msgid "Before"
 msgstr "Antes"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:97
 msgid "After"
 msgstr "Despues"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:103
-#: ../../vdms_dialogs/filter_crop.py:239
 msgid "Search for a specific frame"
 msgstr "Buscar un cuadro especifico"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:117
-#: ../../vdms_dialogs/filter_crop.py:253
 msgid "Load"
 msgstr "Cargar"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:120
 msgid "Color EQ"
 msgstr "Color EQ"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:126
 msgid "Contrast:"
 msgstr "Contraste:"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:134
-#: ../../vdms_dialogs/filter_colorcorrection.py:148
 msgid "-100 to +100, default value 0"
 msgstr "-100 a +100, valor por defecto 0"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:139
 msgid "Brightness:"
 msgstr "Brillo:"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:158
 msgid "Saturation:"
 msgstr "Saturación:"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:166
 msgid "0 to 300, default value 100"
 msgstr "0 a 300, valor por defecto 100"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:170
 msgid "Gamma:"
 msgstr "Gamma:"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:179
 msgid "0 to 100, default value 10"
 msgstr "0 a 100, valor por defecto 10"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:187
-#: ../../vdms_dialogs/filter_crop.py:306
-#: ../../vdms_dialogs/filter_deinterlace.py:209
-#: ../../vdms_dialogs/filter_denoisers.py:110
-#: ../../vdms_dialogs/filter_scale.py:210 ../../vdms_dialogs/filter_stab.py:316
-#: ../../vdms_dialogs/filter_transpose.py:105
-#: ../../vdms_miniframes/timeline.py:262 ../../vdms_miniframes/timeline.py:281
 msgid "Reset"
 msgstr "Reiniciar"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:207
 msgid "Color Correction EQ Tool"
 msgstr "Corrección de EQ Color"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:343
-#: ../../vdms_dialogs/filter_colorcorrection.py:383
-#: ../../vdms_dialogs/filter_colorcorrection.py:390
-#: ../../vdms_dialogs/filter_crop.py:417 ../../vdms_dialogs/filter_scale.py:287
-#: ../../vdms_dialogs/filter_scale.py:394 ../../vdms_dialogs/filter_stab.py:473
-#: ../../vdms_dialogs/filter_stab.py:483 ../../vdms_dialogs/filter_stab.py:494
-#: ../../vdms_dialogs/filter_transpose.py:182
-#: ../../vdms_dialogs/mediainfo.py:245 ../../vdms_dialogs/mediainfo.py:265
-#: ../../vdms_dialogs/mediainfo.py:285 ../../vdms_dialogs/mediainfo.py:305
-#: ../../vdms_dialogs/setting_profiles.py:281
-#: ../../vdms_dialogs/setting_profiles.py:289 ../../vdms_io/checkup.py:45
-#: ../../vdms_io/checkup.py:93 ../../vdms_io/io_tools.py:144
-#: ../../vdms_main/main_frame.py:904 ../../vdms_main/main_frame.py:939
-#: ../../vdms_main/main_frame.py:961 ../../vdms_main/main_frame.py:979
-#: ../../vdms_main/main_frame.py:999
-#: ../../vdms_panels/audio_encoders/acodecs.py:510
-#: ../../vdms_panels/audio_encoders/acodecs.py:800
-#: ../../vdms_panels/concatenate.py:186
-#: ../../vdms_panels/long_processing_task.py:60
-#: ../../vdms_panels/presets_manager.py:426
-#: ../../vdms_panels/presets_manager.py:490
-#: ../../vdms_panels/presets_manager.py:560
-#: ../../vdms_panels/presets_manager.py:599
-#: ../../vdms_panels/presets_manager.py:619
-#: ../../vdms_panels/presets_manager.py:657
-#: ../../vdms_panels/presets_manager.py:701
-#: ../../vdms_panels/presets_manager.py:714
-#: ../../vdms_panels/presets_manager.py:721
-#: ../../vdms_panels/presets_manager.py:756
-#: ../../vdms_panels/presets_manager.py:785
-#: ../../vdms_panels/presets_manager.py:791
-#: ../../vdms_panels/sequence_to_video.py:467
-#: ../../vdms_panels/sequence_to_video.py:473
-#: ../../vdms_panels/sequence_to_video.py:561
-#: ../../vdms_panels/sequence_to_video.py:571
-#: ../../vdms_panels/sequence_to_video.py:588
-#: ../../vdms_panels/sequence_to_video.py:596
-#: ../../vdms_panels/sequence_to_video.py:602
-#: ../../vdms_panels/sequence_to_video.py:643
-#: ../../vdms_panels/sequence_to_video.py:689
-#: ../../vdms_panels/video_to_sequence.py:512
-#: ../../vdms_panels/video_to_sequence.py:583
-#: ../../vdms_threads/ffplay_file.py:43
-#: ../../vdms_utils/presets_manager_utils.py:86
-#: ../../vdms_utils/presets_manager_utils.py:95
-#: ../../vdms_utils/queue_utils.py:68 ../../vdms_utils/queue_utils.py:82
-#: ../../vdms_utils/queue_utils.py:95
 msgid "Videomass - Error!"
 msgstr "Videomass - ¡Error!"
 
-#: ../../vdms_dialogs/filter_crop.py:228 ../../vdms_dialogs/filter_scale.py:109
 #, python-brace-format
 msgid "Source size: {0} x {1} pixels"
 msgstr "Tamaño de la fuente: {0} x {1} pixeles"
 
-#: ../../vdms_dialogs/filter_crop.py:236
 msgid "Crop color"
 msgstr "Color de Recorte"
 
-#: ../../vdms_dialogs/filter_crop.py:256
 msgid "Cropping area selection "
 msgstr "Recortar area seleccionada "
 
-#: ../../vdms_dialogs/filter_crop.py:261 ../../vdms_dialogs/filter_scale.py:121
 msgid "Height"
 msgstr "Altura"
 
-#: ../../vdms_dialogs/filter_crop.py:281
 msgid "Center"
 msgstr "Centro"
 
-#: ../../vdms_dialogs/filter_crop.py:292 ../../vdms_dialogs/filter_scale.py:121
 msgid "Width"
 msgstr "Ancho"
 
-#: ../../vdms_dialogs/filter_crop.py:334
 msgid "Crop Tool"
 msgstr "Herramienta de Recorte"
 
-#: ../../vdms_dialogs/filter_crop.py:335
 msgid "Choose the color to draw the cropping area"
 msgstr "Seleccione el color para dibujar el área de recorte"
 
-#: ../../vdms_dialogs/filter_crop.py:337
 msgid "Crop to width"
 msgstr "Recortar ancho"
 
-#: ../../vdms_dialogs/filter_crop.py:338
 msgid "Move vertically (set to -1 to center the vertical axis)"
 msgstr "Mover verticalmente ( -1 para centrar el eje vertical)"
 
-#: ../../vdms_dialogs/filter_crop.py:340
 msgid "Move horizontally (set to -1 to center the horizontal axis)"
 msgstr "Mover horizontalmente (-1 para centrar el eje horizontal)"
 
-#: ../../vdms_dialogs/filter_crop.py:342
 msgid "Crop to height"
 msgstr "Recortar altura"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:56
 msgid "Advanced Options"
 msgstr "Opciones Avanzadas"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:57
-#: ../../vdms_panels/av_conversions.py:351
 msgid "Deinterlace"
 msgstr "Desentrelazado"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:59
 msgid "Interlace"
 msgstr "Entrelazado"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:63
 msgid "Deinterlaces with w3fdif filter"
 msgstr "Desentrelazar con el filtro w3fdif"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:77
 msgid "Deinterlaces with yadif filter"
 msgstr "Desentrelazar con el filtro yadif"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:101
 msgid "Interlaces with interlace filter"
 msgstr "Entrelazar con el filtro entrelazar"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:118
 msgid "Deinterlacing and Interlacing"
 msgstr "Desenetrelazar y entrelazar"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:144
 msgid "Deinterlace the input video with `w3fdif` filter"
 msgstr "Desentrelazar el video de entrada con el filtro `w3fdif`"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:146
 msgid "Set the interlacing filter coefficients."
 msgstr "Fijar los coeficientes del filtro de entrelazado."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:148
-#: ../../vdms_dialogs/filter_deinterlace.py:158
 msgid "Specify which frames to deinterlace."
 msgstr "Especificar los cuadros a desentrelazar."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:150
 msgid "Deinterlace the input video with `yadif` filter. Using FFmpeg, this is the best and fastest choice"
 msgstr "Desentrelazar el video de entrada con el filtro `yadif` . Utilizar FFmpeg, es la mejor opción y la más rápida"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:153
 msgid ""
 "mode\n"
 "The interlacing mode to adopt."
@@ -577,7 +393,6 @@ msgstr ""
 "modo\n"
 "El modo de entrelazado."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:155
 msgid ""
 "parity\n"
 "The picture field parity assumed for the input interlaced video."
@@ -585,11 +400,9 @@ msgstr ""
 "paridad\n"
 "La paridad del campo imagen asumida por el video entrelazado de entrada."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:160
 msgid "Simple interlacing filter from progressive contents."
 msgstr "Filtro de entrelazado simple proveniente de contenidos progresivos."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:162
 msgid ""
 "scan:\n"
 "determines whether the interlaced frame is taken from the even (tff - default) or odd (bff) lines of the progressive frame."
@@ -597,7 +410,6 @@ msgstr ""
 "scan:\n"
 "determina si el cuadro entrelazado proviene de las lineas pares (tff - predeterminado) o impares (bff) del cuadro progresivo."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:166
 msgid ""
 "lowpass:\n"
 "Enable (default) or disable the vertical lowpass filter to avoid twitter interlacing and reduce moire patterns.\n"
@@ -607,31 +419,24 @@ msgstr ""
 "Habilita (predeterminado) o deshabilita el filtro vertical pasabajos para evitar el entrelazado twitter y reducir  el efecto Moiré.\n"
 "No esta configurado valor predeterminado."
 
-#: ../../vdms_dialogs/filter_denoisers.py:56
 msgid "Denoiser Filters"
 msgstr "Filtros ReduceRuido"
 
-#: ../../vdms_dialogs/filter_denoisers.py:60
 msgid "Enable nlmeans denoiser"
 msgstr "Habilita filtro nlmeans"
 
-#: ../../vdms_dialogs/filter_denoisers.py:73
 msgid "nlmeans options"
 msgstr "opciones de nlmeans"
 
-#: ../../vdms_dialogs/filter_denoisers.py:82
 msgid "Enable hqdn3d denoiser"
 msgstr "Habilitar filtro hqdn3d"
 
-#: ../../vdms_dialogs/filter_denoisers.py:91
 msgid "hqdn3d options"
 msgstr "opciones de hqdn3d"
 
-#: ../../vdms_dialogs/filter_denoisers.py:116
 msgid "Denoiser Tool"
 msgstr "Reduce Ruido"
 
-#: ../../vdms_dialogs/filter_denoisers.py:117
 msgid ""
 "nlmeans:\n"
 "Denoise frames using Non-Local Means algorithm is capable of restoring video sequences, even with strong noise. It is ideal for enhancing the quality of old VHS tapes."
@@ -639,7 +444,6 @@ msgstr ""
 "nlmeans:\n"
 "Mejora los cuadros usando el algoritmo  Medios No-Locales, es capaz de restaurar incluso secuencias de video con fuerte ruido. Es ideal para mejorar la calidad de las antiguas cintas VHS."
 
-#: ../../vdms_dialogs/filter_denoisers.py:122
 msgid ""
 "hqdn3d:\n"
 "This is a high precision/quality 3d denoise filter. It aims to reduce image noise, producing smooth images and making still images really still. It should enhance compressibility."
@@ -647,65 +451,48 @@ msgstr ""
 "hqdn3d:\n"
 "Estes es un filtro reductor de alta precisión/calidad 3d . Su objetivo es reducir el ruido de la imagen, produciendo imágenes suaves y hacer que las imágenes fijas sean realmente fijas. Debe mejorar la compresibilidad."
 
-#: ../../vdms_dialogs/filter_scale.py:81
 msgid "View result"
 msgstr "Ver resultado"
 
-#: ../../vdms_dialogs/filter_scale.py:85
 msgid "New size in pixels"
 msgstr "Nuevo tamaño en pixeles"
 
-#: ../../vdms_dialogs/filter_scale.py:89
 msgid "Width:"
 msgstr "Ancho:"
 
-#: ../../vdms_dialogs/filter_scale.py:99
 msgid "Height:"
 msgstr "Alto:"
 
-#: ../../vdms_dialogs/filter_scale.py:115
 msgid "Constrain proportions (keep aspect ratio)"
 msgstr "Restringir proporciones (mantener relación de aspecto)"
 
-#: ../../vdms_dialogs/filter_scale.py:120
 msgid "Which dimension to adjust?"
 msgstr "¿Que dimensión se ajustara?"
 
-#: ../../vdms_dialogs/filter_scale.py:129
 msgid "Aspect Ratio"
 msgstr "Relación de Aspecto"
 
-#: ../../vdms_dialogs/filter_scale.py:132
 msgid "Setdar filter (display aspect ratio) example 16/9, 4/3 "
 msgstr "Filtro Setdar  (relación de aspecto de pantalla) ejemplo 16/9, 4/3 "
 
-#: ../../vdms_dialogs/filter_scale.py:137
-#: ../../vdms_dialogs/filter_scale.py:171
 msgid "Numerator"
 msgstr "Numerador"
 
-#: ../../vdms_dialogs/filter_scale.py:162
-#: ../../vdms_dialogs/filter_scale.py:196
 msgid "Denominator"
 msgstr "Denominador"
 
-#: ../../vdms_dialogs/filter_scale.py:166
 msgid "Setsar filter (sample aspect ratio) example 1/1"
 msgstr "Filtro Setsar  (relación de aspecto de la muestra) ejemplo 1/1"
 
-#: ../../vdms_dialogs/filter_scale.py:217
 msgid "Resize Tool"
 msgstr "Redimensionar"
 
-#: ../../vdms_dialogs/filter_scale.py:218
 msgid "Scale filter, set to 0 to disable"
 msgstr "Filtro Escala, poner a 0 para deshabilitar"
 
-#: ../../vdms_dialogs/filter_scale.py:221
 msgid "Display Aspect Ratio. Set to 0 to disable"
 msgstr "Relación de Aspecto de Pantalla. Poner a 0 para deshabilitar"
 
-#: ../../vdms_dialogs/filter_scale.py:224
 msgid ""
 "Sample (aka Pixel) Aspect Ratio.\n"
 "Set to 0 to disable"
@@ -713,7 +500,6 @@ msgstr ""
 "Relación de Aspecto de Muestra (Pixel) .\n"
 "Poner a 0 para deshabilitar"
 
-#: ../../vdms_dialogs/filter_scale.py:366
 msgid ""
 "If you want to keep the aspect ratio, select \"Constrain proportions\" below and\n"
 "specify only one dimension, either width or height, and set the other dimension\n"
@@ -723,156 +509,121 @@ msgstr ""
 "especifique sólo una dimensión, ya sea la anchura o la altura, y fije la otra dimensión\n"
 "a -1 o -2 (algunos códecs requieren -2, por lo que deberá hacer algunas pruebas primero)."
 
-#: ../../vdms_dialogs/filter_stab.py:81
 msgid "Enable stabilizer"
 msgstr "Habilitar estabilizador"
 
-#: ../../vdms_dialogs/filter_stab.py:83
 msgid "Create a side-by-side comparison video"
 msgstr "Crear un video de comparación lado a lado"
 
-#: ../../vdms_dialogs/filter_stab.py:88
 msgid "Create a snapshot"
 msgstr "Crear nueva instantanea"
 
-#: ../../vdms_dialogs/filter_stab.py:106
-#: ../../vdms_panels/audio_encoders/acodecs.py:167
 msgid "Preview"
 msgstr "Previsualizar"
 
-#: ../../vdms_dialogs/filter_stab.py:109
 msgid "Duration seconds:"
 msgstr "Duración en segundos:"
 
-#: ../../vdms_dialogs/filter_stab.py:118
 msgid "Video Detect"
 msgstr "Detectar Video"
 
-#: ../../vdms_dialogs/filter_stab.py:176
 msgid "[TRIPOD] Enable tripod mode if checked"
 msgstr "[TRIPOD] Al marcar se habilita el modo tripie"
 
-#: ../../vdms_dialogs/filter_stab.py:183
 msgid "Video transform"
 msgstr "Transformación de video"
 
-#: ../../vdms_dialogs/filter_stab.py:202
 msgid "[OPTALGO] optimization algorithm"
 msgstr "[OPTALGO] algoritmo de optimización"
 
-#: ../../vdms_dialogs/filter_stab.py:224
 msgid "[CROP] Specify how to deal with borders at movement compensation"
 msgstr "[CROP] Especifica como lidiar con los bordes al compensar el movimiento"
 
-#: ../../vdms_dialogs/filter_stab.py:231
 msgid "[INVERT] Invert transforms if checked"
 msgstr "[INVERT] Al marcar, invierte las transformaciones"
 
-#: ../../vdms_dialogs/filter_stab.py:234
 msgid "[RELATIVE] Consider transforms as relative to previous frame if checked, absolute if unchecked"
 msgstr "[RELATIVE] Marcado considera las transformaciones como relativas al cuadro previo, desmarcado como absolutas"
 
-#: ../../vdms_dialogs/filter_stab.py:279
 msgid "Specify type of interpolation"
 msgstr "Especificar tipo de interpolación"
 
-#: ../../vdms_dialogs/filter_stab.py:287
 msgid "[TRIPOD2] virtual tripod mode, equivalent to relative=unchecked:smoothing=0"
 msgstr "[TRIPOD2] modo de tripie virtual, equivalente a relative=desmarcado:smoothing=0"
 
-#: ../../vdms_dialogs/filter_stab.py:294
 msgid "Unsharp filter:"
 msgstr "Filtro desenfoque:"
 
-#: ../../vdms_dialogs/filter_stab.py:323
 msgid "Seek to a position on the video."
 msgstr "Ir a una posición del video."
 
-#: ../../vdms_dialogs/filter_stab.py:325
 msgid "Make a snapshot of the video with the settings made."
 msgstr "Hacer instantánea del video con las configuraciones usadas."
 
-#: ../../vdms_dialogs/filter_stab.py:327
 msgid "Set the snapshot duration from 3 to 15 seconds from the seek position, default is 5 seconds."
 msgstr "Fijar duración de instantánea  de 3 a 15 segundos,  5 es lo predeterminado."
 
-#: ../../vdms_dialogs/filter_stab.py:331
 msgid "Set how shaky the video is and how quick the camera is. A value of 1 means little shakiness, a value of 10 means strong shakiness. Default value is 5."
 msgstr "Fija el grado de temblor del vídeo y la rapidez de la cámara. Un valor de 1 significa poca vibración, un valor de 10 significa mucha vibración. El valor predeterminado es 5."
 
-#: ../../vdms_dialogs/filter_stab.py:335
 msgid "Set the accuracy of the detection process. A value of 1 means low accuracy, a value of 15 means high accuracy. Default value is 15."
 msgstr "Fija la precisión del proceso de detección. Un valor de 1 significa poca precisión, un valor de 15(predeterminado) significa alta precisión."
 
-#: ../../vdms_dialogs/filter_stab.py:339
 msgid "Set stepsize of the search process. The region around minimum is scanned with 1 pixel resolution. Default value is 6."
 msgstr "Fija el paso del proceso de búsqueda. La resolución mínima de la región es de 1 pixel. Valor predeterminado 6."
 
-#: ../../vdms_dialogs/filter_stab.py:343
 msgid "Set minimum contrast. Below this value a local measurement field is discarded. The range is 0-1. Default value is 0.25."
 msgstr "Fija el contraste mínimo. Bajo este valor la medida del campo local es descartada. El rango es 0-1. Valor predeterminado 0.25."
 
-#: ../../vdms_dialogs/filter_stab.py:346
 msgid "Set reference frame number for tripod mode. If enabled, the motion of the frames is compared to a reference frame in the filtered stream, identified by the specified number. The idea is to compensate all movements in a more-or-less static scene and keep the camera view absolutely still. The frames are counted starting from 1."
 msgstr "Fija el numero de cuadro de referencia para el modo tripod. Si se habilita, el movimiento de los cuadros se compara con un cuadro de referencia en el flujo filtrado, identificado por el numero especificado. The idea is to compensate all movements in a more-or-less static scene and keep the camera view absolutely still. The frames are counted starting from 1."
 
-#: ../../vdms_dialogs/filter_stab.py:355
-msgid "Set the number of frames (value*2 + 1) used for lowpass filtering the camera movements. Default value is 15. For example a number of 10 means that 21 frames are used (10 in the past and 10 in the future) to smoothen the motion in the video. A larger value leads to a smoother video, but limits the acceleration of the camera (pan/tilt movements). 0 is a special case where a static camera is simulated."
-msgstr "Fijar el numero de cuadros (valor*2 + 1) usados por pasabajos para filtrar movimientos de cámara. Valor predeterminado 15. Por ejemplo un valor de 10 significa que  se utilizan 21 cuadros (10 en el pasado 10 en el futuro) para suavizar el movimiento en el video. Un valor mayor produce un vídeo más suave, pero limita la aceleración de la cámara (movimientos de giro/inclinación). 0 es un caso especial en el que se simula una cámara estática."
+msgid ""
+"Set the number of frames (value*2 + 1) used for lowpass filtering the camera movements. Default value is 15. For example a number of 10 means that 21 frames are used (10 in the past and 10 in the future) to smoothen the motion in the video. A larger value leads to a smoother video, but limits the acceleration of the camera (pan/tilt movements). 0 is a special case where a static camera is "
+"simulated."
+msgstr ""
+"Fijar el numero de cuadros (valor*2 + 1) usados por pasabajos para filtrar movimientos de cámara. Valor predeterminado 15. Por ejemplo un valor de 10 significa que  se utilizan 21 cuadros (10 en el pasado 10 en el futuro) para suavizar el movimiento en el video. Un valor mayor produce un vídeo más suave, pero limita la aceleración de la cámara (movimientos de giro/inclinación). 0 es un caso "
+"especial en el que se simula una cámara estática."
 
-#: ../../vdms_dialogs/filter_stab.py:363
 msgid "Set the camera path optimization algorithm. Values are: `gauss`: gaussian kernel low-pass filter on camera motion (default), and `avg`: averaging on transformations"
 msgstr "Fija el algoritmo de optimización para la trayectoria de camera. Valores: `gauss`: filtro pasabajos núcleo gaussiano para el movimiento de cámara (predeterminado), y `avg`: promedio de transformaciones"
 
-#: ../../vdms_dialogs/filter_stab.py:367
 msgid "Set maximal angle in radians (degree*PI/180) to rotate frames. Default value is -1, meaning no limit."
 msgstr "Fija angulo máximo en radianes (grados*PI/180) para rotar los cuadros. Valor predeterminado -1, significa sin limites."
 
-#: ../../vdms_dialogs/filter_stab.py:370
 msgid "Specify how to deal with borders that may be visible due to movement compensation. Values are: `keep` keep image information from previous frame (default), `black` fill the border black"
 msgstr "Especifica como lidiar con los bordes visibles al compensar el movimiento. Valores: `mantener` mantener la información de la imagen del cuadro previo (predeterminado), `negro` rellenar lo negro en el borde"
 
-#: ../../vdms_dialogs/filter_stab.py:375
 msgid "Invert transforms if checked. Default is unchecked."
 msgstr "Si se marca Invierte transformaciones. Desmarcado es lo predeterminado."
 
-#: ../../vdms_dialogs/filter_stab.py:377
 msgid "Consider transforms as relative to previous frame if checked, absolute if unchecked. Default is checked."
 msgstr "Marcado considera las transformaciones como relativas al cuadro previo, desmarcado como absolutas. Desmarcado es lo predeterminado."
 
-#: ../../vdms_dialogs/filter_stab.py:380
 msgid "Set percentage to zoom. A positive value will result in a zoom-in effect, a negative value in a zoom-out effect. Default value is 0 (no zoom)."
 msgstr "Fija el porcentaje de aumento. Un valor positivo produce efecto de acercamiento, un valor negativo de alejamiento. Valor predeterminado 0 (sin aumento)."
 
-#: ../../vdms_dialogs/filter_stab.py:384
 msgid "Set optimal zooming to avoid borders. Accepted values are: `0` disabled, `1` optimal static zoom value is determined (only very strong movements will lead to visible borders) (default), `2` optimal adaptive zoom value is determined (no borders will be visible), see zoomspeed. Note that the value given at zoom is added to the one calculated here."
 msgstr "Fija el aumento optimo para evitar bordes. Valores aceptados: `0` desactivado, `1` se determina el nivel de aumento optimo (solo los movimientos muy fuertes producen bordes visibles) (predeterminado), `2` se determina el nivel de aumento optimo adaptativo (no habrá bordes visibles), vea zoomspeed. Note que el valor dado en aumento se añade al calculado aquí."
 
-#: ../../vdms_dialogs/filter_stab.py:391
 msgid "Set percent to zoom maximally each frame (enabled when optzoom is set to 2). Range is from 0 to 5, default value is 0.25."
 msgstr "Fija el porcentaje de aumento máximo en cada cuadro (habilitado cuando optzoom se fija a 2). Rango de 0 to 5, valor predeterminado 0.25."
 
-#: ../../vdms_dialogs/filter_stab.py:395
 msgid "Specify type of interpolation. Available values are: `no` no interpolation, `linear` linear only horizontal, `bilinear` linear in both directions (default), `bicubic` cubic in both directions (slow)"
 msgstr "Especifica tipo de interpolación. Valores disponibles: `no` = sin interpolación, `linear` lineal solo horizontal, `bilinear` lineal en ambas direcciones (predeterminado), `bicubic’`cubica en ambas direcciones (lenta)"
 
-#: ../../vdms_dialogs/filter_stab.py:400
 msgid "Enable virtual tripod mode if checked, which is equivalent to relative=0:smoothing=0. Default is unchecked. Use also tripod option of vidstabdetect."
 msgstr "Habilita el modo de tripie virtual, equivalente a relative=0:smoothing=0. Desmarcado por omisión. Use junto a la opción tripod de vidstabdetect."
 
-#: ../../vdms_dialogs/filter_stab.py:405
 msgid "Sharpen or blur the input video. Note the use of the unsharp filter which is always recommended."
 msgstr "Enfoca o desenfoca el vídeo de entrada.. Se recomienda siempre usar el filtro de desenfoque."
 
-#: ../../vdms_dialogs/filter_stab.py:409
 msgid "Video Stabilizer Tool"
 msgstr "Herramienta Estabilizador de video"
 
-#: ../../vdms_dialogs/filter_stab.py:541 ../../vdms_io/io_tools.py:73
 msgid "Videomass - Loading..."
 msgstr "Videomass - Cargando..."
 
-#: ../../vdms_dialogs/filter_stab.py:542
 msgid ""
 "Please wait,\n"
 "This process will take a few seconds."
@@ -880,135 +631,96 @@ msgstr ""
 "Por favor espere,\n"
 "Este proceso tomar unos segundos."
 
-#: ../../vdms_dialogs/filter_transpose.py:80
-#: ../../vdms_dialogs/filter_transpose.py:293
 msgid "Default position"
 msgstr "Posición predeterminada"
 
-#: ../../vdms_dialogs/filter_transpose.py:86
 msgid "Rotation setting"
 msgstr "Rotación"
 
-#: ../../vdms_dialogs/filter_transpose.py:94
 msgid "90° (left)"
 msgstr "90° (izq)"
 
-#: ../../vdms_dialogs/filter_transpose.py:96
 msgid "90° (right)"
 msgstr "90° (der)"
 
-#: ../../vdms_dialogs/filter_transpose.py:100
 msgid "180°"
 msgstr "180°"
 
-#: ../../vdms_dialogs/filter_transpose.py:115
 msgid "Transpose Tool"
 msgstr "Herramienta Transposición"
 
-#: ../../vdms_dialogs/filter_transpose.py:229
 msgid "Rotate 90 degrees right"
 msgstr "Rotar 90 grados a la derecha"
 
-#: ../../vdms_dialogs/filter_transpose.py:251
 msgid "Rotate 180 degrees"
 msgstr "Rotar 180 grados"
 
-#: ../../vdms_dialogs/filter_transpose.py:272
 msgid "Rotate 90 degrees left"
 msgstr "Rotar 90 grados a la izquierda"
 
-#: ../../vdms_dialogs/mediainfo.py:82
 msgid "Format"
 msgstr "Formato"
 
-#: ../../vdms_dialogs/mediainfo.py:96
 msgid "Video Stream"
 msgstr "Flujo de Video"
 
-#: ../../vdms_dialogs/mediainfo.py:109
 msgid "Audio Streams"
 msgstr "Flujos de Audio"
 
-#: ../../vdms_dialogs/mediainfo.py:122
 msgid "Subtitle Streams"
 msgstr "Flujos de Subtítulos"
 
-#: ../../vdms_dialogs/mediainfo.py:126
 msgid "Copy to clipboard"
 msgstr "Copiar al portapapeles"
 
-#: ../../vdms_dialogs/mediainfo.py:137
 msgid "FILE SELECTION"
 msgstr "SELECCIÓN DE ARCHIVO"
 
-#: ../../vdms_dialogs/mediainfo.py:139 ../../vdms_dialogs/mediainfo.py:142
-#: ../../vdms_dialogs/mediainfo.py:145 ../../vdms_dialogs/mediainfo.py:148
-#: ../../vdms_main/main_frame.py:1318
 msgid "Properties"
 msgstr "Propiedades"
 
-#: ../../vdms_dialogs/mediainfo.py:140 ../../vdms_dialogs/mediainfo.py:143
-#: ../../vdms_dialogs/mediainfo.py:146 ../../vdms_dialogs/mediainfo.py:149
 msgid "Values"
 msgstr "Valores"
 
-#: ../../vdms_dialogs/mediainfo.py:152
 msgid "Streams Properties"
 msgstr "Propiedades de los Flujos"
 
-#: ../../vdms_dialogs/mediainfo.py:244
 msgid "Unable to open the clipboard on Format tab"
 msgstr "Np se puede abrir el portapapeles en la pestaña Formato"
 
-#: ../../vdms_dialogs/mediainfo.py:263
 msgid "Unable to open the clipboard on Video Streams tab"
 msgstr "Np se puede abrir el portapapeles en la pestaña Flujos de Video"
 
-#: ../../vdms_dialogs/mediainfo.py:283
 msgid "Unable to open the clipboard on Audio Streams tab"
 msgstr "Np se puede abrir el portapapeles en la pestaña Flujos de Audio"
 
-#: ../../vdms_dialogs/mediainfo.py:303
 msgid "Unable to open the clipboard on Subtitle Streams tab"
 msgstr "Np se puede abrir el portapapeles en la pestaña Flujos de Subtitulos"
 
-#: ../../vdms_dialogs/preferences.py:90
 msgid "Where do you prefer to save your transcodes?"
 msgstr "¿Donde prefiere guardar sus resultados?"
 
-#: ../../vdms_dialogs/preferences.py:101 ../../vdms_dialogs/preferences.py:128
-#: ../../vdms_dialogs/preferences.py:149 ../../vdms_dialogs/preferences.py:161
-#: ../../vdms_dialogs/preferences.py:173 ../../vdms_panels/filedrop.py:284
 msgid "Change"
 msgstr "Cambiar"
 
-#: ../../vdms_dialogs/preferences.py:103
-#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:602
-#: ../../vdms_panels/presets_manager.py:1050
 msgid "Same destination paths as source files"
 msgstr "Misma carpeta destino que archivos fuente"
 
-#: ../../vdms_dialogs/preferences.py:108
 msgid "Assign optional suffix to destination file names:"
 msgstr "Asignar un sufijo opcional a los archivos de salida:"
 
-#: ../../vdms_dialogs/preferences.py:114
 msgid "File removal preferences"
 msgstr "Preferencias de borrado de archivo"
 
-#: ../../vdms_dialogs/preferences.py:118
 msgid "Trash the source files after successful encoding"
 msgstr "Desechar archivos fuente después de codificación exitosa"
 
-#: ../../vdms_dialogs/preferences.py:131
 msgid "File Preferences"
 msgstr "Preferencias de Archivo"
 
-#: ../../vdms_dialogs/preferences.py:138
 msgid "Location of executables"
 msgstr "Trayectoria de ejecutables"
 
-#: ../../vdms_dialogs/preferences.py:140
 msgid ""
 "FFmpeg can be built by enabling/disabling its options and this depends on your needs.\n"
 "For some use cases it is possible to provide a custom build of FFmpeg where you can specify\n"
@@ -1018,107 +730,81 @@ msgstr ""
 "En algunos caso es posible proporcionar una compilación personalizada de  FFmpeg, la cual puede\n"
 "especificar en esta pestaña."
 
-#: ../../vdms_dialogs/preferences.py:147
 msgid "Enable a custom location to run FFmpeg"
 msgstr "Habilitar FFmpeg en otra trayectoria"
 
-#: ../../vdms_dialogs/preferences.py:159
 msgid "Enable a custom location to run FFprobe"
 msgstr "Habilitar FFprobe en otra trayectoria"
 
-#: ../../vdms_dialogs/preferences.py:171
 msgid "Enable a custom location to run FFplay"
 msgstr "Habilitar FFplay en otra trayectoria"
 
-#: ../../vdms_dialogs/preferences.py:183
 msgid "FFmpeg"
 msgstr "FFmpeg"
 
-#: ../../vdms_dialogs/preferences.py:189
 msgid "Look and Feel (requires application restart)"
 msgstr "Apariencia de la aplicación (requiere reiniciar la aplicación)"
 
-#: ../../vdms_dialogs/preferences.py:194
 msgid "Icon themes"
 msgstr "Temas de iconos"
 
-#: ../../vdms_dialogs/preferences.py:208
 msgid "At the top of window (default)"
 msgstr "Parte superior de la ventana (predeterminado)"
 
-#: ../../vdms_dialogs/preferences.py:209
 msgid "At the bottom of window"
 msgstr "Parte inferior de la ventana"
 
-#: ../../vdms_dialogs/preferences.py:210
 msgid "At the right of window"
 msgstr "A la derecha de la ventana"
 
-#: ../../vdms_dialogs/preferences.py:211
 msgid "At the left of window"
 msgstr "A la izquierda de la ventana"
 
-#: ../../vdms_dialogs/preferences.py:213
 msgid "Place the toolbar"
 msgstr "Situar la barra de herramientas"
 
-#: ../../vdms_dialogs/preferences.py:222
 msgid "Toolbar's icons size:"
 msgstr "Tamaño de iconos:"
 
-#: ../../vdms_dialogs/preferences.py:236
 msgid "Application Language (requires application restart)"
 msgstr "Idioma de la aplicación (requiere reiniciar la aplicación)"
 
-#: ../../vdms_dialogs/preferences.py:248
 msgid "Look and Language"
 msgstr "Apariencia e Idioma"
 
-#: ../../vdms_dialogs/preferences.py:254
 msgid "Upon exiting the application"
 msgstr "Al salir de la aplicación"
 
-#: ../../vdms_dialogs/preferences.py:259
 msgid "Always ask me to confirm"
 msgstr "Siempre pedir confirmación"
 
-#: ../../vdms_dialogs/preferences.py:261
 msgid "Clean the log files"
 msgstr "Limpiar los archivos de registro"
 
-#: ../../vdms_dialogs/preferences.py:264
 msgid "Remove cached files"
 msgstr "Eliminar archivos cache"
 
-#: ../../vdms_dialogs/preferences.py:268
 msgid "On operations completion"
 msgstr "Al completar operación"
 
-#: ../../vdms_dialogs/preferences.py:271
 msgid "These settings will remain active until the application is closed, If necessary, remember to reactivate them."
 msgstr "Estas configuraciones permanecen activas hasta que se cierre la aplicación, De ser necesario recuerde reactivarlas."
 
-#: ../../vdms_dialogs/preferences.py:276
 msgid "Exit the application"
 msgstr "Salir de la aplicación"
 
-#: ../../vdms_dialogs/preferences.py:279
 msgid "Shutdown the system"
 msgstr "Apagar el sistema"
 
-#: ../../vdms_dialogs/preferences.py:283
 msgid "SUDO password:"
 msgstr "contraseña para sudo:"
 
-#: ../../vdms_dialogs/preferences.py:292
 msgid "Exit and Shutdown"
 msgstr "Salir y Apagar"
 
-#: ../../vdms_dialogs/preferences.py:298
 msgid "Specify the character encoding format"
 msgstr "Especificar formato de caracteres"
 
-#: ../../vdms_dialogs/preferences.py:301
 msgid ""
 "Although UTF-8 is the default and most widely used standard encoding format, it is not the only encoding format available.\n"
 "Some file metadata may still contain non-UTF-8 character encodings resulting in the error \"'utf-8' codec can't decode bytes...\".\n"
@@ -1128,31 +814,24 @@ msgstr ""
 "Algunos metadatos aun pueden contener caracteres distintos a los de UTF-8, produciendo el error \"'utf-8' codec can't decode bytes...\".\n"
 "Si sabe el formato de caracteres usado por el archivo, puede intentar especificarlo aquí, ej. ISO 8859-1, ISO 8859-16, etc."
 
-#: ../../vdms_dialogs/preferences.py:311
 msgid "Character encoding:"
 msgstr "Formato de caracteres:"
 
-#: ../../vdms_dialogs/preferences.py:320
 msgid "Default application directories"
 msgstr "Carpetas predeterminadas de la aplicación"
 
-#: ../../vdms_dialogs/preferences.py:324
 msgid "Configuration directory"
 msgstr "Configuración de carpeta"
 
-#: ../../vdms_dialogs/preferences.py:337
 msgid "Cache directory"
 msgstr "Carpeta para Cache"
 
-#: ../../vdms_dialogs/preferences.py:349
 msgid "Log directory"
 msgstr "Carpeta de registros"
 
-#: ../../vdms_dialogs/preferences.py:363
 msgid "Advanced"
 msgstr "Avanzadas"
 
-#: ../../vdms_dialogs/preferences.py:369
 msgid ""
 "The following settings affect output messages and the log messages during transcoding processes.\n"
 "Be careful, by changing these settings some functions of the application may not work correctly,\n"
@@ -1162,121 +841,73 @@ msgstr ""
 "Sea cauteloso, cambiar las configuraciones de algunas funciones de la aplicación puede no funcionar,\n"
 "cámbielas solo si sabe lo que esta haciendo.\n"
 
-#: ../../vdms_dialogs/preferences.py:376
 msgid "Set logging level flags used by FFmpeg"
 msgstr "Fijar opciones de nivel de registro de FFmpeg"
 
-#: ../../vdms_dialogs/preferences.py:383
 msgid "Set logging level flags used by FFplay"
 msgstr "Fijar opciones de nivel de registro de FFplay"
 
-#: ../../vdms_dialogs/preferences.py:391
 msgid "FFmpeg logging levels"
 msgstr "Nivel de registro de FFmpeg"
 
-#: ../../vdms_dialogs/preferences.py:437
 msgid "By assigning an additional suffix you could avoid overwriting files"
 msgstr "Asignar un sufijo adicional evita la reescritura de archivos"
 
-#: ../../vdms_dialogs/preferences.py:440
 msgid "Type sudo password here, only for Unix-like operating systems, not for MS Windows"
 msgstr "Teclee contraseña para sudo, solo para sistemas tipo Unix, no para MS Windows"
 
-#: ../../vdms_dialogs/preferences.py:443
 msgid "Preferences"
 msgstr "Preferencias"
 
-#: ../../vdms_dialogs/preferences.py:596 ../../vdms_dialogs/preferences.py:676
-#: ../../vdms_main/main_frame.py:879 ../../vdms_main/main_frame.py:1060
 msgid "Choose Destination"
 msgstr "Elija Destino"
 
-#: ../../vdms_dialogs/preferences.py:627
 msgid "Enter only alphanumeric characters. You can also use the hyphen (\"-\") and the underscore (\"_\"). Spaces are not allowed."
 msgstr "Teclee solo caracteres alfanuméricos. Puede utilizar el guion (\"-\") y el guion bajo (\"_\"). No se permiten espacios."
 
-#: ../../vdms_dialogs/preferences.py:642
-#: ../../vdms_dialogs/setting_profiles.py:257
-#: ../../vdms_dialogs/setting_profiles.py:264
-#: ../../vdms_dialogs/setting_profiles.py:286
-#: ../../vdms_dialogs/setting_profiles.py:309 ../../vdms_main/main_frame.py:399
-#: ../../vdms_main/main_frame.py:421 ../../vdms_panels/av_conversions.py:605
-#: ../../vdms_panels/av_conversions.py:612
-#: ../../vdms_panels/sequence_to_video.py:352
-#: ../../vdms_panels/video_to_sequence.py:399
 msgid "Videomass - Warning!"
 msgstr "Videomass - ¡Advertencia!"
 
-#: ../../vdms_dialogs/preferences.py:731 ../../vdms_dialogs/preferences.py:771
-#: ../../vdms_dialogs/preferences.py:811 ../../vdms_dialogs/wizard_dlg.py:365
-#: ../../vdms_dialogs/wizard_dlg.py:384 ../../vdms_dialogs/wizard_dlg.py:403
 #, python-brace-format
 msgid "{} location"
 msgstr "Trayectoria de {}"
 
-#: ../../vdms_dialogs/queue_edit.py:36
-#: ../../vdms_dialogs/setting_profiles.py:38
 msgid "One-Pass, Do not start with `ffmpeg -i filename`; do not end with `output-filename`"
 msgstr "Un-Paso, No inicie con `ffmpeg -i archivo`; no termine con `archivo-destino`"
 
-#: ../../vdms_dialogs/queue_edit.py:40
-#: ../../vdms_dialogs/setting_profiles.py:42
 msgid "Two-Pass (optional), Do not start with `ffmpeg -i filename`; do not end with `output-filename`"
 msgstr "Dos-Pasos (opcional), No inicie con `ffmpeg -i archivo`; no termine con `archivo-destino`"
 
-#: ../../vdms_dialogs/queue_edit.py:59
 msgid "Videomass - Edit the selected item in the queue"
 msgstr "Videomass - Editar entrada seleccionada en la lista"
 
-#: ../../vdms_dialogs/queue_edit.py:71
-#: ../../vdms_dialogs/setting_profiles.py:92
 msgid "Pre-input arguments for One-Pass (optional)"
 msgstr "Argumentos Pre-input para Un-paso (opcional)"
 
-#: ../../vdms_dialogs/queue_edit.py:82
-#: ../../vdms_dialogs/setting_profiles.py:151
-#: ../../vdms_panels/presets_manager.py:255
 msgid "FFmpeg arguments for one-pass encoding"
 msgstr "Argumentos de FFmpeg para codificación en un-paso"
 
-#: ../../vdms_dialogs/queue_edit.py:88
-#: ../../vdms_dialogs/setting_profiles.py:158
-#: ../../vdms_panels/presets_manager.py:259
 msgid "Any optional arguments to add before input file on the one-pass encoding, e.g required names of some hardware accelerations like -hwaccel to use with CUDA."
 msgstr "Cualquier argumento adicional previo al archivo de entrada para la codificación un-paso, ej. nombres de aceleradores de hardware como -hwaccel para usar con CUDA."
 
-#: ../../vdms_dialogs/queue_edit.py:102
-#: ../../vdms_dialogs/setting_profiles.py:98
 msgid "Pre-input arguments for Two-Pass (optional)"
 msgstr "Argumentos Pre-input para Dos-pasos (opcional)"
 
-#: ../../vdms_dialogs/queue_edit.py:113
-#: ../../vdms_dialogs/setting_profiles.py:152
-#: ../../vdms_panels/presets_manager.py:257
 msgid "FFmpeg arguments for two-pass encoding"
 msgstr "Argumentos de FFmpeg para codificación en dos-pasoa"
 
-#: ../../vdms_dialogs/queue_edit.py:120
-#: ../../vdms_dialogs/setting_profiles.py:162
-#: ../../vdms_panels/presets_manager.py:263
 msgid "Any optional arguments to add before input file on the two-pass encoding, e.g required names of some hardware accelerations like -hwaccel to use with CUDA."
 msgstr "Cualquier argumento adicional previo al archivo de entrada para la codificación dos-pasos, ej. nombres de aceleradores de hardware como -hwaccel para usar con CUDA."
 
-#: ../../vdms_dialogs/queuedlg.py:65 ../../vdms_main/main_frame.py:508
-#: ../../vdms_panels/presets_manager.py:189
-#: ../../vdms_panels/video_to_sequence.py:171
 msgid "Edit"
 msgstr "Editar"
 
-#: ../../vdms_dialogs/queuedlg.py:68
 msgid "Remove"
 msgstr "Eliminar"
 
-#: ../../vdms_dialogs/queuedlg.py:71
 msgid "Remove all"
 msgstr "Eliminar todo"
 
-#: ../../vdms_dialogs/queuedlg.py:74
 msgid ""
 "Export\n"
 "queue file"
@@ -1284,7 +915,6 @@ msgstr ""
 "Exportar\n"
 "lista de archivos"
 
-#: ../../vdms_dialogs/queuedlg.py:77
 msgid ""
 "Import\n"
 "queue file"
@@ -1292,30 +922,22 @@ msgstr ""
 "Importar\n"
 "archivo de lista"
 
-#: ../../vdms_dialogs/queuedlg.py:85 ../../vdms_panels/filedrop.py:273
 #, fuzzy
 msgid "Destination file name"
 msgstr "Archivo de Salida"
 
-#: ../../vdms_dialogs/queuedlg.py:137
 msgid "Remove all items in the queue"
 msgstr "Eliminar todas las entradas de la lista"
 
-#: ../../vdms_dialogs/queuedlg.py:151
 msgid "Videomass - Queue"
 msgstr "Videomass - Lista"
 
-#: ../../vdms_dialogs/queuedlg.py:228
 msgid "Export queue file"
 msgstr "Exportar archivo de lista"
 
-#: ../../vdms_dialogs/queuedlg.py:296 ../../vdms_panels/av_conversions.py:1192
-#: ../../vdms_panels/presets_manager.py:1044
-#: ../../vdms_panels/video_to_sequence.py:600
 msgid "Same as source"
 msgstr "Igual que la fuente"
 
-#: ../../vdms_dialogs/queuedlg.py:301
 msgid ""
 "Source\n"
 "File destination\n"
@@ -1333,81 +955,60 @@ msgstr ""
 "Segmento de Inicio\n"
 "Duración de Clip"
 
-#: ../../vdms_dialogs/renamer.py:76
 msgid "# will be replaced by ascending numbers starting with:"
 msgstr "# Se reemplazara con números incrementales desde:"
 
-#: ../../vdms_dialogs/set_timestamp.py:87
 msgid "Font Size"
 msgstr "Tamaño de Letra"
 
-#: ../../vdms_dialogs/set_timestamp.py:111
 msgid "Font Color"
 msgstr "Color de Letra"
 
-#: ../../vdms_dialogs/set_timestamp.py:121
 msgid "Shadow Color"
 msgstr "Color de Sombra"
 
-#: ../../vdms_dialogs/set_timestamp.py:132
 msgid "Show text box"
 msgstr "Mostrar caja de texto"
 
-#: ../../vdms_dialogs/set_timestamp.py:136
 msgid "Box Color"
 msgstr "Color de la Caja"
 
-#: ../../vdms_dialogs/set_timestamp.py:156
 msgid "The timestamp size does not auto-adjust to the video size, you have to set the size here"
 msgstr "El tamaño de la estampa de tiempo no se auto ajusta al tamaño de video, configure aquí el tamaño"
 
-#: ../../vdms_dialogs/set_timestamp.py:160 ../../vdms_main/main_frame.py:559
 msgid "Timestamp settings"
 msgstr "Configurar Estampa de tiempo"
 
-#: ../../vdms_dialogs/setting_profiles.py:46
 msgid "Supported Formats list (optional). Do not include the `.`"
 msgstr "Lista de formatos soportados (opcional). No incluya el `.`"
 
-#: ../../vdms_dialogs/setting_profiles.py:47
 msgid "Output Format. Empty to copy format and codec. Do not include the `.`"
 msgstr "Formato de Salida. Vacio, copia el formato y codec. No incluya el `.`"
 
-#: ../../vdms_dialogs/setting_profiles.py:70
 msgid "Profile Name"
 msgstr "Nombre de Perfil"
 
-#: ../../vdms_dialogs/setting_profiles.py:74
-#: ../../vdms_panels/presets_manager.py:404
 msgid "Description"
 msgstr "Descripción"
 
-#: ../../vdms_dialogs/setting_profiles.py:149
 msgid "A short profile name"
 msgstr "Un nombre corto de perfil"
 
-#: ../../vdms_dialogs/setting_profiles.py:150
 msgid "A long description of the profile"
 msgstr "Una descripción amplia del perfil"
 
-#: ../../vdms_dialogs/setting_profiles.py:153
 msgid "One or more comma-separated format names compatible with this profile"
 msgstr "Uno o más nombres de formato compatibles con este perfil, separados por comas"
 
-#: ../../vdms_dialogs/setting_profiles.py:155
 msgid "Output format extension. Leave empty to copy codec and format"
 msgstr "Extensión del formato de salida. Deje vació para copiar codec y formato"
 
-#: ../../vdms_dialogs/setting_profiles.py:256
 msgid "Incomplete profile assignments"
 msgstr "Asignaciones de perfil incompletas"
 
-#: ../../vdms_dialogs/setting_profiles.py:263
 msgid "Formats must be comma-separated"
 msgstr "Debe separar con coma los formatos"
 
-#: ../../vdms_dialogs/setting_profiles.py:279
-#: ../../vdms_utils/queue_utils.py:80
 #, python-brace-format
 msgid ""
 "ERROR: Keys mismatched for requested data.\n"
@@ -1416,105 +1017,69 @@ msgstr ""
 "ERROR: No coinciden llaves para datos requeridos.\n"
 "Archivo invalido: «{0}»"
 
-#: ../../vdms_dialogs/setting_profiles.py:285
-#: ../../vdms_dialogs/setting_profiles.py:308
 msgid "Profile already stored with same name"
 msgstr "Ya existe perfil con ese nombre"
 
-#: ../../vdms_dialogs/setting_profiles.py:293
 msgid "Profile stored successfully!"
 msgstr "¡Perfil guardado exitosamente!"
 
-#: ../../vdms_dialogs/setting_profiles.py:311
 msgid "Profile change successful!"
 msgstr "¡Cambio de Perfil exitosol!"
 
-#: ../../vdms_dialogs/showlogs.py:80
 msgid "Log file list"
 msgstr "Lista de archivos de registro"
 
-#: ../../vdms_dialogs/showlogs.py:82 ../../vdms_dialogs/showlogs.py:116
 msgid "Log messages"
 msgstr "Registro de mensajes"
 
-#: ../../vdms_dialogs/showlogs.py:105
 msgid "Refresh log messages"
 msgstr "Refrescar mensajes de registro"
 
-#: ../../vdms_dialogs/showlogs.py:107
 msgid "Clear log messages"
 msgstr "Limpiar mensajes de registro"
 
-#: ../../vdms_dialogs/showlogs.py:160
 msgid "Select a log file"
 msgstr "Seleccionar archivo de registro"
 
-#: ../../vdms_dialogs/showlogs.py:167
 msgid "Are you sure you want to clear the selected log file?"
 msgstr "¿Seguro desea limpiar el archivo de registro?"
 
-#: ../../vdms_dialogs/showlogs.py:168 ../../vdms_dialogs/wizard_dlg.py:251
-#: ../../vdms_io/checkup.py:68 ../../vdms_main/main_frame.py:205
-#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1685
-#: ../../vdms_panels/presets_manager.py:349
-#: ../../vdms_panels/presets_manager.py:550
-#: ../../vdms_panels/presets_manager.py:590
-#: ../../vdms_panels/presets_manager.py:649
-#: ../../vdms_panels/presets_manager.py:684
-#: ../../vdms_panels/presets_manager.py:749
-#: ../../vdms_panels/presets_manager.py:775
-#: ../../vdms_panels/presets_manager.py:874
-#: ../../vdms_panels/presets_manager.py:904
 msgid "Please confirm"
 msgstr "Por favor Confirme"
 
-#: ../../vdms_dialogs/shownormlist.py:83
 msgid "File name"
 msgstr "Nombre de archivo"
 
-#: ../../vdms_dialogs/shownormlist.py:84
 msgid "Max volume dBFS"
 msgstr "Volumen máximo dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:85
 msgid "Mean volume dBFS"
 msgstr "Volumen promedio dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:86
 msgid "Offset dBFS"
 msgstr "Desplazamiento dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:87
 msgid "Result dBFS"
 msgstr "Resultado dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:92
 msgid "Post-normalization references:"
 msgstr "Referencias post-normalización:"
 
-#: ../../vdms_dialogs/shownormlist.py:102
 msgid "=  Clipped peaks"
 msgstr "=  Picos recortados"
 
-#: ../../vdms_dialogs/shownormlist.py:111
 msgid "=  No changes"
 msgstr "=  Sin cambios"
 
-#: ../../vdms_dialogs/shownormlist.py:121
 msgid "=  Below max peak"
 msgstr "=  Pico inferior máximo"
 
-#: ../../vdms_dialogs/shownormlist.py:166
-#: ../../vdms_panels/audio_encoders/acodecs.py:841
 msgid "RMS-based volume statistics"
 msgstr "Estadísticas de volumen basadas en RMS"
 
-#: ../../vdms_dialogs/shownormlist.py:191
-#: ../../vdms_panels/audio_encoders/acodecs.py:839
 msgid "PEAK-based volume statistics"
 msgstr "Estadísticas de volumen basadas en Picos"
 
-#: ../../vdms_dialogs/shownormlist.py:216
 msgid ""
 "...It means the resulting audio will be clipped,\n"
 "because its volume is higher than the maximum 0 db\n"
@@ -1526,7 +1091,6 @@ msgstr ""
 "de 0 db. Esto provoca perdida de datos y el audio \n"
 "podría sonar distorsionado."
 
-#: ../../vdms_dialogs/shownormlist.py:242
 msgid ""
 "...It means the resulting audio will not change,\n"
 "because it's equal to the source."
@@ -1534,7 +1098,6 @@ msgstr ""
 "...Significa que el audio resultante no tendrá\n"
 "cambios y sera igual al de la fuente."
 
-#: ../../vdms_dialogs/shownormlist.py:266
 msgid ""
 "...It means an audio signal will be produced with\n"
 "a lower volume than the source."
@@ -1542,15 +1105,12 @@ msgstr ""
 "...Significa que la señal de audio se producirá\n"
 "con un volumen menor al original."
 
-#: ../../vdms_dialogs/videomass_check_version.py:63
 msgid "Get Latest Version"
 msgstr "Obtenga la Ultima Version"
 
-#: ../../vdms_dialogs/videomass_check_version.py:67
 msgid "Checking for newer version"
 msgstr "Comprobando versión más reciente"
 
-#: ../../vdms_dialogs/videomass_check_version.py:95
 msgid ""
 "\n"
 "\n"
@@ -1560,7 +1120,6 @@ msgstr ""
 "\n"
 "Las nuevas versiones corrigen fallos y añaden características."
 
-#: ../../vdms_dialogs/videomass_check_version.py:96
 #, python-brace-format
 msgid ""
 "\n"
@@ -1573,7 +1132,6 @@ msgstr ""
 "Videomass versión. {0}\n"
 "\n"
 
-#: ../../vdms_dialogs/while_playing.py:37
 msgid ""
 "q, ESC\n"
 "f\n"
@@ -1615,65 +1173,51 @@ msgstr ""
 "click botón derecho\n"
 "doble click botón izquierdo"
 
-#: ../../vdms_dialogs/while_playing.py:92
 msgid "Shortcut keys while playing with FFplay"
 msgstr "Atajos del teclado al reproducir con FFplay"
 
-#: ../../vdms_dialogs/widget_utils.py:120 ../../vdms_main/main_frame.py:1326
 msgid "Stop"
 msgstr "Parar"
 
-#: ../../vdms_dialogs/wizard_dlg.py:63
 msgid "Please take a moment to set up the application"
 msgstr "Por favor configure la aplicación"
 
-#: ../../vdms_dialogs/wizard_dlg.py:64
 msgid "Click the \"Next\" button to get started"
 msgstr "Presione el botón \"Siguiente\" para iniciar"
 
-#: ../../vdms_dialogs/wizard_dlg.py:79
 msgid "Welcome to the Videomass Wizard!"
 msgstr "¡Bienvenido al asistente de Videomass!"
 
-#: ../../vdms_dialogs/wizard_dlg.py:123
 msgid "Videomass is an application based on FFmpeg\n"
 msgstr "Videomass es una aplicación basada en FFmpeg\n"
 
-#: ../../vdms_dialogs/wizard_dlg.py:125
 msgid "If FFmpeg is not on your computer, this application will be unusable"
 msgstr "Si FFmpeg no esta en su equipo, esta aplicación es inútil"
 
-#: ../../vdms_dialogs/wizard_dlg.py:128
 msgid ""
 "If you have already installed FFmpeg on your operating system,\n"
 "click the \"Auto-detection\" button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:131
 msgid ""
 "If you want to use a version of FFmpeg located on your filesystem\n"
 "but not installed on your operating system,\n"
 "click the \"Locate\" button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:162
 msgid "Auto-detection"
 msgstr "Auto-detectar"
 
-#: ../../vdms_dialogs/wizard_dlg.py:164
 msgid "Locate"
 msgstr "Localizar"
 
-#: ../../vdms_dialogs/wizard_dlg.py:214
 msgid "Click the \"Next\" button"
 msgstr "Presione el botón \"Siguiente\""
 
-#: ../../vdms_dialogs/wizard_dlg.py:235
 #, python-brace-format
 msgid "'{}' is not installed on your computer. Install it or indicate another location by clicking the 'Locate' button."
 msgstr "'{}' no esta instalado en su equipo. Instalelo o indique su ubicación presionando el botón 'Localizar'."
 
-#: ../../vdms_dialogs/wizard_dlg.py:249
 msgid ""
 "Videomass already seems to include FFmpeg.\n"
 "\n"
@@ -1683,11 +1227,9 @@ msgstr ""
 "\n"
 "¿Desea utilizarlo?"
 
-#: ../../vdms_dialogs/wizard_dlg.py:275
 msgid "Locating FFmpeg executables\n"
 msgstr "Localizando ejecutables de FFmpeg\n"
 
-#: ../../vdms_dialogs/wizard_dlg.py:277
 msgid ""
 "\"ffmpeg\", \"ffprobe\" and \"ffplay\" are required. Complete all\n"
 "the text boxes below by clicking on the respective buttons."
@@ -1695,40 +1237,30 @@ msgstr ""
 "Se requiere \"ffmpeg\", \"ffprobe\" y \"ffplay\". Complete todas\n"
 "las cajas de texto presionando en los botones respectivos."
 
-#: ../../vdms_dialogs/wizard_dlg.py:437
 msgid "Wizard completed successfully!\n"
 msgstr "¡Asistente completado con éxito!\n"
 
-#: ../../vdms_dialogs/wizard_dlg.py:438
 msgid "Remember that you can always change these settings later, through the Preferences dialog."
 msgstr "Recuerde que puede cambiar estas configuraciones posteriormente, mediante el dialogo Preferencias."
 
-#: ../../vdms_dialogs/wizard_dlg.py:440
 msgid "Thank You!"
 msgstr "¡Gracias!"
 
-#: ../../vdms_dialogs/wizard_dlg.py:441
 msgid "To exit click the \"Finish\" button"
 msgstr "Para salir presione el botón \"Finalizar\""
 
-#: ../../vdms_dialogs/wizard_dlg.py:527
 msgid "< Previous"
 msgstr "< Anterior"
 
-#: ../../vdms_dialogs/wizard_dlg.py:530 ../../vdms_dialogs/wizard_dlg.py:613
 msgid "Next >"
 msgstr "Siguiente >"
 
-#: ../../vdms_dialogs/wizard_dlg.py:535
 msgid "Videomass Wizard"
 msgstr "Asistente de Videomass"
 
-#: ../../vdms_dialogs/wizard_dlg.py:563 ../../vdms_dialogs/wizard_dlg.py:586
-#: ../../vdms_dialogs/wizard_dlg.py:591
 msgid "Finish"
 msgstr "Finalizar"
 
-#: ../../vdms_io/checkup.py:44 ../../vdms_io/checkup.py:92
 #, python-brace-format
 msgid ""
 "Output folder does not exist:\n"
@@ -1739,32 +1271,25 @@ msgstr ""
 "\n"
 "\"{}\"\n"
 
-#: ../../vdms_io/checkup.py:65
 msgid "Files already exist, do you want to overwrite them?"
 msgstr "Ya existe archivo, ¿quiere sobreecribirlo?"
 
-#: ../../vdms_io/checkup.py:67
 msgid "Already exist"
 msgstr "Ya existe"
 
-#: ../../vdms_io/checkup.py:81
 msgid "Not found"
 msgstr "No encontrado"
 
-#: ../../vdms_io/checkup.py:82 ../../vdms_panels/filedrop.py:196
 msgid "Error list"
 msgstr "Lista de Error"
 
-#: ../../vdms_io/checkup.py:83
 msgid "File(s) not found"
 msgstr "Archivo(s) no encontrado(s)"
 
-#: ../../vdms_io/io_tools.py:56
 #, python-format
 msgid "File does not exist or is invalid:  %s"
 msgstr "Archivo no existe o invalido:  %s"
 
-#: ../../vdms_io/io_tools.py:74
 msgid ""
 "Wait....\n"
 "Audio peak analysis."
@@ -1772,16 +1297,12 @@ msgstr ""
 "Espere....\n"
 "Analizando Picos de Audio."
 
-#: ../../vdms_io/io_tools.py:179
 msgid "Videomass - Downloading..."
 msgstr "Videomass - Descargando..."
 
-#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1409
-#: ../../vdms_main/main_frame.py:1441
 msgid "Ready"
 msgstr "Listo"
 
-#: ../../vdms_main/main_frame.py:203
 msgid ""
 "Not all items in the queue were completed.\n"
 "\n"
@@ -1791,343 +1312,256 @@ msgstr ""
 "\n"
 "¿Desea mantenerlas en la lista?"
 
-#: ../../vdms_main/main_frame.py:224
 #, python-brace-format
 msgid "Queue ({0})"
 msgstr "Lista ({0})"
 
-#: ../../vdms_main/main_frame.py:229 ../../vdms_main/main_frame.py:1334
 msgid "Queue"
 msgstr "Lista"
 
-#: ../../vdms_main/main_frame.py:396 ../../vdms_main/main_frame.py:418
 msgid "There are still active windows with running processes, make sure you finish your work before exit."
 msgstr "Aun hay ventanas activas con procesos ejecutándose, asegúrese de finalizar su trabajo antes de salir."
 
-#: ../../vdms_main/main_frame.py:403
 msgid "Are you sure you want to exit the application?"
 msgstr "¿Seguro que desea salir?"
 
-#: ../../vdms_main/main_frame.py:405
 msgid "Exit"
 msgstr "Salir"
 
-#: ../../vdms_main/main_frame.py:463
 msgid "Import files\tCtrl+O"
 msgstr "Importar archivos\tCtrl+O"
 
-#: ../../vdms_main/main_frame.py:466
 msgid "Open destination folder of encodings\tCtrl+D"
 msgstr "Carpeta destino para codificaciones\tCtrl+D"
 
-#: ../../vdms_main/main_frame.py:469
 msgid "Load queue file"
 msgstr "Cargar archivo de Lista"
 
-#: ../../vdms_main/main_frame.py:470
 msgid "Load a previously exported queue file"
 msgstr "Cargar archivo de Lista previamente exportado"
 
-#: ../../vdms_main/main_frame.py:473
 msgid "Open trash"
 msgstr "Abrir Papelera"
 
-#: ../../vdms_main/main_frame.py:474
 msgid "Open the Videomass trash folder"
 msgstr "Abre carpeta de la papelera de Videomass"
 
-#: ../../vdms_main/main_frame.py:476
 msgid "Empty trash"
 msgstr "Vaciar papelera"
 
-#: ../../vdms_main/main_frame.py:477
 msgid "Delete all files in the Videomass trash folder"
 msgstr "Borrar todo de la papelera de Videomass"
 
-#: ../../vdms_main/main_frame.py:480
 msgid "Exit\tCtrl+Q"
 msgstr "Salir\tCtrl+Q"
 
-#: ../../vdms_main/main_frame.py:481
 msgid "Completely exit the application"
 msgstr "Salir de la aplicación"
 
-#: ../../vdms_main/main_frame.py:482
 msgid "File"
 msgstr "Archivo"
 
-#: ../../vdms_main/main_frame.py:486 ../../vdms_panels/filedrop.py:340
-#: ../../vdms_panels/filedrop.py:381
 msgid "Rename selected file\tCtrl+R"
 msgstr "Renombrar archivo seleccionado\tCtrl+R"
 
-#: ../../vdms_main/main_frame.py:487
 msgid "Rename the destination of the selected file"
 msgstr "Renombra destino de archivo seleccionado"
 
-#: ../../vdms_main/main_frame.py:490 ../../vdms_panels/filedrop.py:341
-#: ../../vdms_panels/filedrop.py:384
 #, fuzzy
 msgid "Batch rename files\tCtrl+B"
 msgstr "Renombrado en lote\tCtrl+B"
 
-#: ../../vdms_main/main_frame.py:491
 msgid "Numerically renames the destination of all items in the list"
 msgstr "Ennumerar el destino de todas las entradas de la lista"
 
-#: ../../vdms_main/main_frame.py:496 ../../vdms_panels/filedrop.py:343
-#: ../../vdms_panels/filedrop.py:388
 msgid "Remove selected entry\tDEL"
 msgstr "Quitar entrada seleccionada\tDEL"
 
-#: ../../vdms_main/main_frame.py:497
 msgid "Remove the selected file from the list"
 msgstr "Eliminar archivo seleccionado de la lista"
 
-#: ../../vdms_main/main_frame.py:500 ../../vdms_panels/filedrop.py:344
-#: ../../vdms_panels/filedrop.py:391
 msgid "Clear list\tShift+DEL"
 msgstr "Vaciar lista\tShift+DEL"
 
-#: ../../vdms_main/main_frame.py:501
 msgid "Clear the file list"
 msgstr "Limpiar la lista de archivos"
 
-#: ../../vdms_main/main_frame.py:506
 msgid "Preferences\tCtrl+P"
 msgstr "Preferencias\tCtrl+P"
 
-#: ../../vdms_main/main_frame.py:507
 msgid "Application preferences"
 msgstr "Preferencias de la aplicación"
 
-#: ../../vdms_main/main_frame.py:512
 msgid "Find FFmpeg topics"
 msgstr "Encontrar temas sobre FFmpeg"
 
-#: ../../vdms_main/main_frame.py:513
 msgid "A useful tool to search for FFmpeg help topics and options"
 msgstr "Una herramienta util para buscar temas de la ayuda de FFmpeg"
 
-#: ../../vdms_main/main_frame.py:518
 msgid "Check for preset updates"
 msgstr "Buscar nuevos presets"
 
-#: ../../vdms_main/main_frame.py:519
 #, python-brace-format
 msgid "Check for new presets updates from {0}"
 msgstr "Buscar nuevos presets en {0}"
 
-#: ../../vdms_main/main_frame.py:521
 msgid "Get latest presets"
 msgstr "Obtener los últimos preset"
 
-#: ../../vdms_main/main_frame.py:522
 #, python-brace-format
 msgid "Get the latest presets from {0}"
 msgstr "Obtener los últimos preset desde {0}"
 
-#: ../../vdms_main/main_frame.py:525
 msgid "Work notes\tCtrl+N"
 msgstr "Notas de trabajo\tCtrl+N"
 
-#: ../../vdms_main/main_frame.py:526
 msgid "Read and write useful notes and reminders."
 msgstr "Lea y escriba recordatorios y notas."
 
-#: ../../vdms_main/main_frame.py:528
 msgid "Tools"
 msgstr "Herramientas"
 
-#: ../../vdms_main/main_frame.py:535
 msgid "Show FFmpeg's built-in configuration capabilities"
 msgstr "Mostrar capacidades de  configuración integradas en FFmpeg"
 
-#: ../../vdms_main/main_frame.py:539
 msgid "Muxers and demuxers available on your version of FFmpeg"
 msgstr "Mezcladores y Desmezcladores disponibles en el FFmpeg utilizado"
 
-#: ../../vdms_main/main_frame.py:543
 msgid "Encoders available on your version of FFmpeg"
 msgstr "Muestra los codificadores disponibles en FFmpeg"
 
-#: ../../vdms_main/main_frame.py:546
 msgid "Decoders available on your version of FFmpeg"
 msgstr "Muestra los decodificadores disponibles en FFmpeg"
 
-#: ../../vdms_main/main_frame.py:550
 msgid "Enable timestamps on playback"
 msgstr "Mostrar marcas de tiempo al reproducir"
 
-#: ../../vdms_main/main_frame.py:551
 msgid "Displays timestamp when playing media with FFplay"
 msgstr "Mostrar marcas de tiempo al reproducir con FFplay"
 
-#: ../../vdms_main/main_frame.py:554
 msgid "Auto-exit after playback"
 msgstr "Salir al terminar reproducción"
 
-#: ../../vdms_main/main_frame.py:555
 msgid "If checked, the FFplay window will auto-close when playback is complete"
 msgstr "Al activar, la ventana de FFplay se cerrara al finalizar la reproducción"
 
-#: ../../vdms_main/main_frame.py:559
 msgid "Customize the timestamp style"
 msgstr "Personalizar Estampa de tiempo"
 
-#: ../../vdms_main/main_frame.py:562
 msgid "While playing..."
 msgstr "Durante reproducción..."
 
-#: ../../vdms_main/main_frame.py:563
 msgid "Show useful shortcut keys when playing or previewing using FFplay"
 msgstr "Mostrar atajos de teclado al reproducir o previsualizar con FFplay"
 
-#: ../../vdms_main/main_frame.py:567
 msgid "Show timeline editor\tCtrl+T"
 msgstr "Editor de linea de tiempo\tCtrl+T"
 
-#: ../../vdms_main/main_frame.py:568
 msgid "Set duration or trim slices of time to remove unwanted parts from your files"
 msgstr "Fijar lduración o recortar pedazos de tiempo, eliminar partes no deseadas de archivos"
 
-#: ../../vdms_main/main_frame.py:572
 msgid "View"
 msgstr "Ver"
 
-#: ../../vdms_main/main_frame.py:579
 msgid "Home panel\tCtrl+Shift+H"
 msgstr "Panel principal\tCtrl+Shift+H"
 
-#: ../../vdms_main/main_frame.py:580
 msgid "Go to the «Home» panel"
 msgstr "Ir al panel «Principal»"
 
-#: ../../vdms_main/main_frame.py:583
 msgid "Presets Manager\tCtrl+Shift+P"
 msgstr "Administrador de Presets\tCtrl+Shift+P"
 
-#: ../../vdms_main/main_frame.py:584
 msgid "Go to the «Presets Manager» panel"
 msgstr "Ir al panel «Administrador de Presets»"
 
-#: ../../vdms_main/main_frame.py:586
 msgid "A/V Conversions\tCtrl+Shift+V"
 msgstr "Conversiones A/V \tCtrl+Shift+V"
 
-#: ../../vdms_main/main_frame.py:587
 msgid "Go to the «A/V Conversions» panel"
 msgstr "Ir al panel «Conversiones A/V»"
 
-#: ../../vdms_main/main_frame.py:589
 msgid "Concatenate Demuxer\tCtrl+Shift+D"
 msgstr "Encadenar Dezmezclador\tCtrl+Shift+D"
 
-#: ../../vdms_main/main_frame.py:590
 msgid "Go to the «Concatenate Demuxer» panel"
 msgstr "Ir al panel «Encadenar Desmezcladores»"
 
-#: ../../vdms_main/main_frame.py:593
 msgid "Still Image Maker\tCtrl+Shift+I"
 msgstr "Creador de Imágenes Fijas\tCtrl+Shift+I"
 
-#: ../../vdms_main/main_frame.py:594
 msgid "Go to the «Still Image Maker» panel"
 msgstr "Ir al panel «Productor de Imágenes Fijas»"
 
-#: ../../vdms_main/main_frame.py:596
 msgid "From Movie to Pictures\tCtrl+Shift+S"
 msgstr "De Película a Imágenes\tCtrl+Shift+S"
 
-#: ../../vdms_main/main_frame.py:597
 msgid "Go to the «From Movie to Pictures» panel"
 msgstr "Ir al panel «De Película a Imágenes»"
 
-#: ../../vdms_main/main_frame.py:600
 msgid "Output monitor\tCtrl+Shift+O"
 msgstr "Monitor de Salida\tCtrl+Shift+O"
 
-#: ../../vdms_main/main_frame.py:601
 msgid "Keeps track of the output for debugging errors"
 msgstr "Mantener rastro de la salida para depuración de errores"
 
-#: ../../vdms_main/main_frame.py:603
 msgid "Go"
 msgstr "Ir a"
 
-#: ../../vdms_main/main_frame.py:607
 msgid "User guide"
 msgstr "Guía de usuario"
 
-#: ../../vdms_main/main_frame.py:611
 msgid "System version"
 msgstr "Versión del Sistema"
 
-#: ../../vdms_main/main_frame.py:612
 msgid "Get version about your operating system, version of Python and wxPython."
 msgstr "Obteniendo versiones de su sistema, Python y wxPython."
 
-#: ../../vdms_main/main_frame.py:616
 msgid "Show log files\tCtrl+L"
 msgstr "Mostrar Registros\tCtrl+L"
 
-#: ../../vdms_main/main_frame.py:617
 msgid "Viewing log messages"
 msgstr "Ver mensajes de registro"
 
-#: ../../vdms_main/main_frame.py:620
 msgid "Issue tracker"
 msgstr "Seguimiento de fallos"
 
-#: ../../vdms_main/main_frame.py:624
 msgid "Contribute to the project"
 msgstr "Contribuir al proyecto"
 
-#: ../../vdms_main/main_frame.py:627
 msgid "Sponsor this project"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:628
 msgid "Become a developer supporter"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:629
 msgid "Donate"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:630
 msgid "Donate to the app developer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:634
 msgid "Other projects by the developer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:650
 msgid "About Videomass"
 msgstr "Sobre Videomass"
 
-#: ../../vdms_main/main_frame.py:651
 msgid "Check for newer version"
 msgstr "Comprobanr versión más reciente"
 
-#: ../../vdms_main/main_frame.py:652
 msgid "Check for the latest Videomass version"
 msgstr "Comprobar ultima versión de Videomass"
 
-#: ../../vdms_main/main_frame.py:654
 msgid "Help"
 msgstr "Ayuda"
 
-#: ../../vdms_main/main_frame.py:729
 msgid "Import files"
 msgstr "Importar archivos"
 
-#: ../../vdms_main/main_frame.py:752
 msgid "No default folder has been set for the destination of the encodings. The current setting is \"Same destination paths as source files\"."
 msgstr "No se fijo carpeta destino para las conversiones. La configuración actual es \"Misma carpeta que archivos fuente\"."
 
-#: ../../vdms_main/main_frame.py:784 ../../vdms_main/main_frame.py:809
 #, python-brace-format
 msgid ""
 "'{}':\n"
@@ -2136,11 +1570,9 @@ msgstr ""
 "'{}':\n"
 "No existe archivo o carpeta"
 
-#: ../../vdms_main/main_frame.py:797
 msgid "Are you sure to empty trash folder?"
 msgstr "¿Seguro que desea vaciar la papelera?"
 
-#: ../../vdms_main/main_frame.py:805
 #, python-brace-format
 msgid ""
 "'{}':\n"
@@ -2149,17 +1581,14 @@ msgstr ""
 "'{}':\n"
 "No hay archivos a borrar."
 
-#: ../../vdms_main/main_frame.py:862
 #, python-brace-format
 msgid "Installed release v{0}. A new presets release is available {1}"
 msgstr "Versión instalada v{0}. Nueva versión de presets disponible {1}"
 
-#: ../../vdms_main/main_frame.py:866
 #, python-brace-format
 msgid "Installed release v{0}. No new updates found."
 msgstr "Versión instalada v{0}. No se encontró actualizaciones."
 
-#: ../../vdms_main/main_frame.py:896
 msgid ""
 "Wait....\n"
 "The archive is being downloaded"
@@ -2167,16 +1596,13 @@ msgstr ""
 "Espere....\n"
 "El archivo esta siendo descargado"
 
-#: ../../vdms_main/main_frame.py:908
 #, python-brace-format
 msgid "Successfully downloaded to \"{0}\""
 msgstr "Descargado exitosamente en \"{0}\""
 
-#: ../../vdms_main/main_frame.py:1120
 msgid "Some changes require restarting the application."
 msgstr "Algunos cambios requieren reiniciar aplicación."
 
-#: ../../vdms_main/main_frame.py:1126
 #, python-brace-format
 msgid ""
 "{0}\n"
@@ -2187,116 +1613,85 @@ msgstr ""
 "\n"
 "¿Quiere reiniciar aplicación ahora?"
 
-#: ../../vdms_main/main_frame.py:1128
 msgid "Restart Videomass?"
 msgstr "¿Reiniciar Videomass?"
 
-#: ../../vdms_main/main_frame.py:1207
 #, python-brace-format
 msgid "A new release is available - v.{0}\n"
 msgstr "Una nueva versión esta disponible . {0}\n"
 
-#: ../../vdms_main/main_frame.py:1210
 msgid "You are using a development version that has not yet been released!\n"
 msgstr "¡Esta utilizando una versión de desarrollo!\n"
 
-#: ../../vdms_main/main_frame.py:1213
 msgid "Congratulation! You are already using the latest version.\n"
 msgstr "¡Felicitaciones! Ya esta utilizando la ultima versión versión.\n"
 
-#: ../../vdms_main/main_frame.py:1301
 msgid "Previous panel"
 msgstr "Panel anterior"
 
-#: ../../vdms_main/main_frame.py:1302
 msgid "Back"
 msgstr "Regresar"
 
-#: ../../vdms_main/main_frame.py:1305
 msgid "Next panel"
 msgstr "Siguiente panel"
 
-#: ../../vdms_main/main_frame.py:1306
 msgid "Next"
 msgstr "Siguiente"
 
-#: ../../vdms_main/main_frame.py:1309
 msgid "Home panel"
 msgstr "Panel Principal"
 
-#: ../../vdms_main/main_frame.py:1310
 msgid "Home"
 msgstr "Principal"
 
-#: ../../vdms_main/main_frame.py:1313
 msgid "Play the selected imput file"
 msgstr "Reproducir archivo de entrada seleccionado"
 
-#: ../../vdms_main/main_frame.py:1314
 msgid "Play"
 msgstr "Reproducir"
 
-#: ../../vdms_main/main_frame.py:1317
 msgid "Get informative data about imported media streams"
 msgstr "Obtiene información de flujos Multimedia importados"
 
-#: ../../vdms_main/main_frame.py:1321
 msgid "Start batch processing"
 msgstr "Comenzar proceso por lote"
 
-#: ../../vdms_main/main_frame.py:1325
 msgid "Stops current process"
 msgstr "Detener proceso actual"
 
-#: ../../vdms_main/main_frame.py:1329
 msgid "Add an item to Queue"
 msgstr "Añadir entrada a la Lista"
 
-#: ../../vdms_main/main_frame.py:1330
 msgid "Add to Queue"
 msgstr "Añadir a la Lista"
 
-#: ../../vdms_main/main_frame.py:1333
 msgid "Show queue"
 msgstr "Mostrar lista"
 
-#: ../../vdms_main/main_frame.py:1408 ../../vdms_panels/presets_manager.py:569
 msgid "Videomass"
 msgstr "Videomass"
 
-#: ../../vdms_main/main_frame.py:1442
 msgid "Videomass - File List"
 msgstr "Videomass - Lista de Archivos"
 
-#: ../../vdms_main/main_frame.py:1459
 msgid "Videomass - AV Conversions"
 msgstr "Videomass - Conversiones AV"
 
-#: ../../vdms_main/main_frame.py:1488
 msgid "Videomass - Presets Manager"
 msgstr "Videomass - Administrador de Presets"
 
-#: ../../vdms_main/main_frame.py:1518
 msgid "Videomass - Concatenate Demuxer"
 msgstr "Videomass - Encadenar Dezmezcladores"
 
-#: ../../vdms_main/main_frame.py:1547
 msgid "Videomass - From Movie to Pictures"
 msgstr "Videomass -De Película a Imágenes"
 
-#: ../../vdms_main/main_frame.py:1576
 msgid "Videomass - Still Image Maker"
 msgstr "Videomass -Productor de Imágenes Fijas"
 
-#: ../../vdms_main/main_frame.py:1660 ../../vdms_panels/av_conversions.py:577
-#: ../../vdms_panels/filedrop.py:500 ../../vdms_panels/filedrop.py:616
-#: ../../vdms_panels/sequence_to_video.py:322
-#: ../../vdms_panels/video_to_sequence.py:369
-#: ../../vdms_panels/video_to_sequence.py:501
 msgid "Have to select an item in the file list first"
 msgstr "Primero elija un archivo en la lista"
 
-#: ../../vdms_main/main_frame.py:1682
 msgid ""
 "An item with the same destination file already exists.\n"
 "\n"
@@ -2306,84 +1701,63 @@ msgstr ""
 "\n"
 "¿Desea reemplazarlo añadiendo la entrada a la lista?"
 
-#: ../../vdms_main/main_frame.py:1703
 msgid "Videomass - FFmpeg Message Monitoring"
 msgstr "Videomass - Monitor de mensajes de FFmpeg"
 
-#: ../../vdms_main/main_frame.py:1828
 #, python-brace-format
 msgid "The system will turn off in {0} seconds"
 msgstr "El sistema se apagara en {0} segundos"
 
-#: ../../vdms_main/main_frame.py:1829
 msgid "Videomass - Shutdown!"
 msgstr "Videomass - ¡Apagando!"
 
-#: ../../vdms_main/main_frame.py:1836
 msgid "Error while shutting down. Please see file log for details."
 msgstr "Error al apagar. Vea el archivo de registro para detalles."
 
-#: ../../vdms_main/main_frame.py:1848
 #, python-brace-format
 msgid "Exiting the application in {0} seconds"
 msgstr "La aplicación se cerrara en {0} segundos"
 
-#: ../../vdms_main/main_frame.py:1849
 msgid "Videomass - Exiting!"
 msgstr "Videomass - ¡Saliendo!"
 
-#: ../../vdms_miniframes/timeline.py:46
 msgid "Start point adjustment"
 msgstr "Punto de ajuste inicial"
 
-#: ../../vdms_miniframes/timeline.py:48
 msgid "End point adjustment"
 msgstr "Ajuste de punto final"
 
-#: ../../vdms_miniframes/timeline.py:105
 msgid "Hours"
 msgstr "Horas"
 
-#: ../../vdms_miniframes/timeline.py:106
 msgid "Minutes"
 msgstr "Minutos"
 
-#: ../../vdms_miniframes/timeline.py:107
 msgid "Seconds"
 msgstr "Segundos"
 
-#: ../../vdms_miniframes/timeline.py:108
 msgid "Milliseconds"
 msgstr "Milisegundos"
 
-#: ../../vdms_miniframes/timeline.py:189 ../../vdms_miniframes/timeline.py:312
 msgid "No source duration:"
 msgstr "Sin duraci´on de la fuente:"
 
-#: ../../vdms_miniframes/timeline.py:208 ../../vdms_miniframes/timeline.py:298
-#: ../../vdms_miniframes/timeline.py:333 ../../vdms_miniframes/timeline.py:338
-#: ../../vdms_miniframes/timeline.py:441
 #, python-brace-format
 msgid "{0} {1}  |  Segment Duration: {2}"
 msgstr "{0} {1}  |  Duración de Segmento: {2}"
 
-#: ../../vdms_miniframes/timeline.py:260 ../../vdms_miniframes/timeline.py:277
 msgid "End adjustment"
 msgstr "Ajuste de final"
 
-#: ../../vdms_miniframes/timeline.py:261 ../../vdms_miniframes/timeline.py:279
 msgid "Start adjustment"
 msgstr "Iniciar ajuste"
 
-#: ../../vdms_miniframes/timeline.py:320
 msgid "Source duration:"
 msgstr "Duración de fuente:"
 
-#: ../../vdms_miniframes/timeline.py:387
 msgid "WARNING: Invalid selection, out of range."
 msgstr "ADVERTENCIA: Selección invalida, fuera de rango."
 
-#: ../../vdms_miniframes/timeline.py:461
 msgid ""
 "Start by dragging the bottom left handle,\n"
 "or right-click for options."
@@ -2392,15 +1766,12 @@ msgstr ""
 "\n"
 "o presione con el botón derecho para ver las opciones."
 
-#: ../../vdms_miniframes/timeline.py:497
 msgid "Start"
 msgstr "Iniciar"
 
-#: ../../vdms_miniframes/timeline.py:498
 msgid "End"
 msgstr "Fin"
 
-#: ../../vdms_miniframes/timeline.py:548
 msgid ""
 "The timeline editor is a tool that allows you to trim slices of time on selected imported media (see File List panel).\n"
 "\n"
@@ -2422,39 +1793,30 @@ msgstr ""
 "\n"
 "Los valores \"Inicio\"/\"Fin\" siempre refieren al valor inicial de la linea de tiempo: 00:00:00.000. Para información sobre la duración del segmento y advertencias vea los mensajes en la barra de estado."
 
-#: ../../vdms_miniframes/timeline.py:565
 msgid "Timeline Editor Usage"
 msgstr "Uso del Editor de Linea de Tiempo"
 
-#: ../../vdms_panels/av_conversions.py:153
 msgid "Media:"
 msgstr "Medio:"
 
-#: ../../vdms_panels/av_conversions.py:169
 msgid "Container:"
 msgstr "Contenedor:"
 
-#: ../../vdms_panels/av_conversions.py:180
 msgid "Save profile"
 msgstr "Guardar perfil"
 
-#: ../../vdms_panels/av_conversions.py:183
 msgid "Target"
 msgstr "Destino"
 
-#: ../../vdms_panels/av_conversions.py:316
 msgid "Miscellaneous"
 msgstr "Misceláneos"
 
-#: ../../vdms_panels/av_conversions.py:323
 msgid "Save as a new profile of the Presets Manager."
 msgstr "Guardar nuevo perfil del Administrador de Presets."
 
-#: ../../vdms_panels/av_conversions.py:325
 msgid "Available video encoders. \"Copy\" means that the video stream will not be re-encoded and will allow you (depending on the encoder) to change the container, audio codec and a few other parameters."
 msgstr "Codificadores de video disponibles. \"Copiar\" indica que el flujo de video no sera recodificado y permite (según el codificador) cambiar el contenedor, codificador de audio y algunos otros parámetros."
 
-#: ../../vdms_panels/av_conversions.py:330
 msgid ""
 "Container format. It is usually represented by the file extension (output format).\n"
 "\n"
@@ -2468,7 +1830,6 @@ msgstr ""
 "\n"
 "If the media target is set to \"Audio\", you can extract only the audio streams from videos, or simply convert audio source files."
 
-#: ../../vdms_panels/av_conversions.py:338
 msgid ""
 "Set output files target: \"Video\" to save output files as video files; \"Audio\" to save files using an audio encoder and format.\n"
 "\n"
@@ -2478,46 +1839,34 @@ msgstr ""
 "\n"
 "Note que al usar \"Audio\" como destino, aun podrá trabajar sobre los archivos video originales pero solo podrá extraer los flujos de  audio, convertirlos y aplicarles filtros como el de normalización."
 
-#: ../../vdms_panels/av_conversions.py:346
 msgid "Preview video filters"
 msgstr "Previsualizar filtros de video"
 
-#: ../../vdms_panels/av_conversions.py:347
 msgid "Disable active filters"
 msgstr "Desactivar filtros activos"
 
-#: ../../vdms_panels/av_conversions.py:348
-#: ../../vdms_panels/sequence_to_video.py:156
-#: ../../vdms_panels/video_to_sequence.py:113
 msgid "Resize"
 msgstr "Redimencionar"
 
-#: ../../vdms_panels/av_conversions.py:349
 msgid "Crop"
 msgstr "Recortar"
 
-#: ../../vdms_panels/av_conversions.py:350
 msgid "Transpose"
 msgstr "Transponer"
 
-#: ../../vdms_panels/av_conversions.py:352
 #, fuzzy
 msgid "Denoise"
 msgstr "ReduceRuido"
 
-#: ../../vdms_panels/av_conversions.py:353
 msgid "Stabilize"
 msgstr "Estabilizar"
 
-#: ../../vdms_panels/av_conversions.py:354
 msgid "Equalize"
 msgstr "Equalizar"
 
-#: ../../vdms_panels/av_conversions.py:517
 msgid "Unable to preview Video Stabilizer filter"
 msgstr "No se puede previsualizar el filtro Estabilizador de Video"
 
-#: ../../vdms_panels/av_conversions.py:602
 msgid ""
 "Unsupported file:\n"
 "Missing decoder or library? Check FFmpeg configuration."
@@ -2525,22 +1874,15 @@ msgstr ""
 "Archivo no soportado:\n"
 "¿Falta decodificador o librería? Revise la configuración de FFmpeg."
 
-#: ../../vdms_panels/av_conversions.py:611
-#: ../../vdms_panels/sequence_to_video.py:351
-#: ../../vdms_panels/video_to_sequence.py:398
 msgid "The file is not a frame or a video file"
 msgstr "El archivo no es un cuadro o archivo de video"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:434
-#: ../../vdms_panels/av_conversions.py:861
 msgid "Undetected volume values! Click the \"Volume detect\" button to analyze audio volume data."
 msgstr "¡No se detectaron valores de volumen! Presione el botón \"Detectar Volumen\" para analizar los datos del audio."
 
-#: ../../vdms_panels/av_conversions.py:1186
 msgid "Off"
 msgstr "Apagado"
 
-#: ../../vdms_panels/av_conversions.py:1203
 msgid ""
 "Batch processing items\n"
 "Destination\n"
@@ -2566,109 +1908,81 @@ msgstr ""
 "Segmento inicial\n"
 "Duración de Clip"
 
-#: ../../vdms_panels/av_conversions.py:1246
-#: ../../vdms_panels/presets_manager.py:814
 #, python-brace-format
 msgid "Write profile on «{0}»"
 msgstr "Escribir perfil en «{0}»"
 
-#: ../../vdms_panels/av_conversions.py:1266
-#: ../../vdms_panels/presets_manager.py:513
 msgid "Enter name for new preset"
 msgstr "Intorduzca nombre del nuevo preset"
 
-#: ../../vdms_panels/av_conversions.py:1276
-#: ../../vdms_panels/presets_manager.py:524
 msgid "Invalid file name, make sure to provide a valid name including the «.json» extension"
 msgstr "Nombre de archivo invalido, asegúrese de proporcionar un nombre valido incluyendo la extensión «.json»"
 
-#: ../../vdms_panels/av_conversions.py:1284
 #, python-brace-format
 msgid "Cannot save current data in file «{}»."
 msgstr "No se puede guardar la información actual en '{}'."
 
-#: ../../vdms_panels/av_conversions.py:1289
 msgid "Open Videomass preset"
 msgstr "Abrir preset de Videomass"
 
-#: ../../vdms_panels/av_conversions.py:1307
 msgid "Videomass - Save new profile"
 msgstr "Videomass - Guardar nuevo perfil"
 
-#: ../../vdms_panels/av_conversions.py:1308
 msgid "Where do you want to save this profile?"
 msgstr "¿Desea guardar el perfil?"
 
-#: ../../vdms_panels/av_conversions.py:1309
 msgid "Save the profile to a new preset"
 msgstr "Guardar perfil en nuevo preset"
 
-#: ../../vdms_panels/av_conversions.py:1310
 msgid "Save the profile to an existing preset"
 msgstr "Guardar perfil en preset existente"
 
-#: ../../vdms_panels/choose_topic.py:69
 msgid "Welcome to Videomass"
 msgstr "Bienvenido a Videomass"
 
-#: ../../vdms_panels/choose_topic.py:71
 #, python-brace-format
 msgid "Version {}"
 msgstr "Versión {}"
 
-#: ../../vdms_panels/choose_topic.py:82
 msgid "Presets Manager"
 msgstr "Administrador de Presets"
 
-#: ../../vdms_panels/choose_topic.py:85
 msgid "AV-Conversions"
 msgstr "Conversiones-AV"
 
-#: ../../vdms_panels/choose_topic.py:88
 msgid "Concatenate media files"
 msgstr "Encadenar archivos de medios"
 
-#: ../../vdms_panels/choose_topic.py:91
 msgid "Still Image Maker"
 msgstr "Productor de Imágenes Fijas"
 
-#: ../../vdms_panels/choose_topic.py:94
 msgid "From Movie to Pictures"
 msgstr "De Película a Imágenes"
 
-#: ../../vdms_panels/choose_topic.py:123
 msgid "Create, edit and use quickly your favorite FFmpeg presets and profiles with full formats support and codecs."
 msgstr "Crear, editar y usar rápidamente sus presets y perfiles favoritos de FFmpeg con un completo soporte de formatos y codecs."
 
-#: ../../vdms_panels/choose_topic.py:127
 msgid "A set of useful tools for audio and video conversions. Save your profiles and reuse them with Presets Manager."
 msgstr "Un conjunto de herramientas útiles para conversiones de audio y video. Guarde sus perfiles y reutilicelos con el Administrador de Presets."
 
-#: ../../vdms_panels/choose_topic.py:131
 msgid "Concatenate multiple media files based on import order without re-encoding"
 msgstr "Encadenar múltiples archivos de medios en base a su orden de importación sin recodificar"
 
-#: ../../vdms_panels/choose_topic.py:134
 msgid "Create video from a sequence of images, based on import order, with the ability to add an audio file."
 msgstr "Crear video a partir de una secuencia de imágenes, ordenadas según se importan, con la posibilidad de añadir un archivo de audio file."
 
-#: ../../vdms_panels/choose_topic.py:137
 msgid "Extract images (frames) from your movies in JPG, PNG, BMP, GIF formats."
 msgstr "Extraer cuadros desde películas  a imágenes  en formatos JPG, PNG, BMP, GIF ."
 
-#: ../../vdms_panels/concatenate.py:47
 msgid "At least two files are required to perform concatenation."
 msgstr "Se requieren al menos dos archivos para realizar la encadenación."
 
-#: ../../vdms_panels/concatenate.py:63
 msgid "Invalid data found"
 msgstr "Información invalida"
 
-#: ../../vdms_panels/concatenate.py:68
 msgid "The files do not have the same \"codec_types\", same \"sample_rate\" or same \"width\" or \"height\". Unable to proceed."
 msgstr "Los archivos no tienen los mismos \"codec\", \"frec. muestreo\" o \"ancho\" o \"altura\". No se puede proceder."
 
-#: ../../vdms_panels/concatenate.py:84
 msgid ""
 "\n"
 "- The concatenation function is performed only with Audio files or only with Video files.\n"
@@ -2696,17 +2010,12 @@ msgstr ""
 "\n"
 "- Los archivo de Audio deben tener los mismos formatos, codecs y frecuencia de muestreo."
 
-#: ../../vdms_panels/concatenate.py:125
 msgid "Videomass Documentation:"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:136
-#: ../../vdms_panels/sequence_to_video.py:212
-#: ../../vdms_panels/video_to_sequence.py:181
 msgid "Official FFmpeg documentation:"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:253
 msgid ""
 "Items to concatenate\n"
 "File destination\n"
@@ -2720,254 +2029,192 @@ msgstr ""
 "Tipo de salida multimedia\n"
 "Duración"
 
-#: ../../vdms_panels/filedrop.py:45
 msgid "File has illegal characters like:"
 msgstr "Archivo con caracteres ilegales:"
 
-#: ../../vdms_panels/filedrop.py:46
 msgid "Invalid character found in path name: (\")"
 msgstr "Carácter invalido en la trayectoria: (\")"
 
-#: ../../vdms_panels/filedrop.py:47
 msgid "Directories are not allowed, just add files, please."
 msgstr "No se permiten Carpetas, por favor solo añada archivos."
 
-#: ../../vdms_panels/filedrop.py:48
 msgid "File without format extension: please give an appropriate extension to the file name, example '.mkv', '.avi', '.mp3', etc."
 msgstr "Archivo sin extensión de formato: ponga una extensión apropiada al archivo, ejemplo '.mkv', '.avi','.mp3', etc."
 
-#: ../../vdms_panels/filedrop.py:84
 #, python-brace-format
 msgid "Name has illegal characters like: {0}"
 msgstr "Nombre con caracteres invalidos: {0}"
 
-#: ../../vdms_panels/filedrop.py:85
 msgid "Name already in use:"
 msgstr "El nombre ya esta en uso:"
 
-#: ../../vdms_panels/filedrop.py:185
 msgid "Duplicate file, it has already been added to the list."
 msgstr "El archivo ya esta en la lista."
 
-#: ../../vdms_panels/filedrop.py:197
 msgid "Rejected files"
 msgstr "Archivos Rechazados"
 
-#: ../../vdms_panels/filedrop.py:269
 msgid "Source file"
 msgstr "Archivo fuente"
 
-#: ../../vdms_panels/filedrop.py:270
 msgid "Duration"
 msgstr "Duración"
 
-#: ../../vdms_panels/filedrop.py:271
 msgid "Media type"
 msgstr "Tipo de Medio"
 
-#: ../../vdms_panels/filedrop.py:272
 msgid "Size"
 msgstr "Tamaño"
 
-#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:405
 msgid "Drag one or more files below"
 msgstr "Arrastre uno o más archivos abajo"
 
-#: ../../vdms_panels/filedrop.py:282
 msgid "Save to:"
 msgstr "Guardar a:"
 
-#: ../../vdms_panels/filedrop.py:306
 msgid "Set a new destination folder for encodings"
 msgstr "Carpeta destino para codificaciones"
 
-#: ../../vdms_panels/filedrop.py:308
 msgid "Encodings destination folder"
 msgstr "Carpeta destino para codificaciones"
 
-#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:394
 msgid "Play file"
 msgstr "Reproducir archivo"
 
-#: ../../vdms_panels/filedrop.py:408
 msgid "Drag two or more Audio/Video files below"
 msgstr "Arrastre dos o más archivos Audio/Video abajo"
 
-#: ../../vdms_panels/filedrop.py:412
 #, fuzzy
 msgid "Drag one or more Image files below"
 msgstr "Arrastre uno o más archivos abajo"
 
-#: ../../vdms_panels/filedrop.py:415
 msgid "Drag one or more Video files below"
 msgstr "Arrastre uno o más archivos Video abajo"
 
-#: ../../vdms_panels/filedrop.py:623
 msgid "Rename the file destination"
 msgstr "Renombra archivo destino"
 
-#: ../../vdms_panels/filedrop.py:624
 msgid "Rename the selected file to:"
 msgstr "Renombrar archivo seleccionado a:"
 
-#: ../../vdms_panels/filedrop.py:638 ../../vdms_panels/filedrop.py:648
-#: ../../vdms_panels/filedrop.py:679
 msgid "Add Files"
 msgstr "Añadir Archivos"
 
-#: ../../vdms_panels/filedrop.py:655
 msgid "Rename in batch"
 msgstr "Renombrar por lote"
 
-#: ../../vdms_panels/filedrop.py:656
 #, python-brace-format
 msgid "Rename the {0} items to:"
 msgstr "Renombrar {0} objetos a:"
 
-#: ../../vdms_panels/filedrop.py:658
 msgid "New Name #"
 msgstr "Nombre Nuevo #"
 
-#: ../../vdms_panels/long_processing_task.py:114
 msgid "Sorry, all task failed !"
 msgstr "¡Ha fallado la tarea !"
 
-#: ../../vdms_panels/long_processing_task.py:115
 msgid "The process was stopped due to a fatal error."
 msgstr "Proceso detenido debido a error fatal."
 
-#: ../../vdms_panels/long_processing_task.py:116
 msgid "Interrupted Process !"
 msgstr "¡Proceso Interrumpido !"
 
-#: ../../vdms_panels/long_processing_task.py:117
 msgid "Successfully completed !"
 msgstr "¡Completado exitosamente !"
 
-#: ../../vdms_panels/long_processing_task.py:118
 msgid "Not everything was successful."
 msgstr "No todo fue exitoso."
 
-#: ../../vdms_panels/long_processing_task.py:148
 msgid "Encoding Status"
 msgstr "Estado de codificación"
 
-#: ../../vdms_panels/long_processing_task.py:152
 msgid "Current Log"
 msgstr "Registro"
 
-#: ../../vdms_panels/long_processing_task.py:354
 msgid "Fatal Error !"
 msgstr "¡Error Fatal !"
 
-#: ../../vdms_panels/long_processing_task.py:363
 msgid "Get your files at the destination you specified"
 msgstr "Guarde sus archivos en el destino especificado"
 
-#: ../../vdms_panels/long_processing_task.py:377
 msgid "For more details please read the Current Log."
 msgstr "Para mas detalles vea el Registro."
 
-#: ../../vdms_panels/long_processing_task.py:380
 msgid "...Finished"
 msgstr "...Completado"
 
-#: ../../vdms_panels/long_processing_task.py:399
 msgid "Please wait... interruption in progress"
 msgstr "Por favor espere.. Abortando"
 
-#: ../../vdms_panels/long_processing_task.py:402
 msgid "...Interrupted"
 msgstr "...Interrumpido"
 
-#: ../../vdms_panels/presets_manager.py:166
 msgid "Presets"
 msgstr "Presets"
 
-#: ../../vdms_panels/presets_manager.py:180
 msgid "Write"
 msgstr "Escribir"
 
-#: ../../vdms_panels/presets_manager.py:184
 msgid "Delete"
 msgstr "Borrar"
 
-#: ../../vdms_panels/presets_manager.py:194
 msgid "Duplicate"
 msgstr "Duplicado"
 
-#: ../../vdms_panels/presets_manager.py:199
 msgid "Profiles"
 msgstr "Perfiles"
 
-#: ../../vdms_panels/presets_manager.py:206
 msgid "One-Pass Encoding"
 msgstr "Codificación en Un-Paso"
 
-#: ../../vdms_panels/presets_manager.py:218
 msgid "Two-Pass Encoding"
 msgstr "Codificación en Dos-Pasos"
 
-#: ../../vdms_panels/presets_manager.py:232
 msgid "Choose a preset and view its profiles"
 msgstr "Elija un preset y vea sus perfiles"
 
-#: ../../vdms_panels/presets_manager.py:233
 #, fuzzy
 msgid "Write a new profile and save it in the selected preset"
 msgstr "Crear un nuevo perfil y guardarlo en el preset seleccionado"
 
-#: ../../vdms_panels/presets_manager.py:235
 msgid "Delete the selected profile"
 msgstr "Borrar perfil seleccionado"
 
-#: ../../vdms_panels/presets_manager.py:236
 msgid "Edit the selected profile"
 msgstr "Editar perfil seleccionado"
 
-#: ../../vdms_panels/presets_manager.py:237
 msgid "Duplicate the selected profile"
 msgstr "Duplicar perfil seleccionado"
 
-#: ../../vdms_panels/presets_manager.py:238
 #, fuzzy
 msgid "Create new preset"
 msgstr "Crear nuevo preset"
 
-#: ../../vdms_panels/presets_manager.py:240
 msgid "Remove selected preset"
 msgstr "Quitar preset seleccionado"
 
-#: ../../vdms_panels/presets_manager.py:242
 msgid "Backup selected preset"
 msgstr "Respaldar preset seleccionado"
 
-#: ../../vdms_panels/presets_manager.py:244
 msgid "Backup the presets folder"
 msgstr "Respaldar carpeta de presets"
 
-#: ../../vdms_panels/presets_manager.py:246
 msgid "Restore a preset"
 msgstr "Restablecer un preset"
 
-#: ../../vdms_panels/presets_manager.py:248
 msgid "Restore a presets folder"
 msgstr "Restablecer carpeta de presets"
 
-#: ../../vdms_panels/presets_manager.py:250
 msgid "Resets the selected preset to default values"
 msgstr "Restablecer preset seleccionado"
 
-#: ../../vdms_panels/presets_manager.py:252
 msgid "Reset all presets to default values"
 msgstr "Restablecer todos los presets"
 
-#: ../../vdms_panels/presets_manager.py:254
 #, fuzzy
 msgid "Refresh the presets list"
 msgstr "Actualizar lista de presets"
 
-#: ../../vdms_panels/presets_manager.py:338
 #, python-brace-format
 msgid ""
 "Outdated presets version found: v{1}\n"
@@ -2990,28 +2237,22 @@ msgstr ""
 "\n"
 "¿Desea actualizar?"
 
-#: ../../vdms_panels/presets_manager.py:403
 msgid "Name"
 msgstr "Nombre"
 
-#: ../../vdms_panels/presets_manager.py:405
 msgid "Output Format"
 msgstr "Formato de Salida"
 
-#: ../../vdms_panels/presets_manager.py:406
 msgid "Supported Format List"
 msgstr "Lista de formatos soportados"
 
-#: ../../vdms_panels/presets_manager.py:531
 #, python-brace-format
 msgid "Cannot save current data in file '{}'."
 msgstr "No se puede guardar la información actual en '{}'."
 
-#: ../../vdms_panels/presets_manager.py:535
 msgid "You just successfully created a new preset!"
 msgstr "¡Preset creado exitosamente!"
 
-#: ../../vdms_panels/presets_manager.py:547
 #, python-brace-format
 msgid ""
 "Are you sure you want to remove \"{}\" preset?\n"
@@ -3022,7 +2263,6 @@ msgstr ""
 "\n"
 "Se moverá a la carpeta \"Removals\" dentro de la carpeta de presets."
 
-#: ../../vdms_panels/presets_manager.py:558
 #, python-brace-format
 msgid ""
 "{}\n"
@@ -3033,30 +2273,22 @@ msgstr ""
 "\n"
 "Fallo al eliminar, no se puede continuar.."
 
-#: ../../vdms_panels/presets_manager.py:568
 #, python-brace-format
 msgid "The preset \"{0}\" was successfully removed"
 msgstr "El preset \"{0}\" se elimino con exito"
 
-#: ../../vdms_panels/presets_manager.py:583
-#: ../../vdms_panels/presets_manager.py:612
 msgid "Open a destination folder"
 msgstr "Abrir carpeta destino"
 
-#: ../../vdms_panels/presets_manager.py:588
 msgid "A file with this name already exists, do you want to overwrite it?"
 msgstr "Ya existe archivo con ese nombres, ¿quiere sobreecribirlo?"
 
-#: ../../vdms_panels/presets_manager.py:602
-#: ../../vdms_panels/presets_manager.py:622
 msgid "Backup completed successfully"
 msgstr "¡Respaldo completado con éxito!"
 
-#: ../../vdms_panels/presets_manager.py:631
 msgid "Open the preset you want to restore"
 msgstr "Abra el preset a restaurar"
 
-#: ../../vdms_panels/presets_manager.py:645
 msgid ""
 "This preset already exists and is about to be updated. Don't worry, it will keep all your saved profiles.\n"
 "\n"
@@ -3066,11 +2298,9 @@ msgstr ""
 "\n"
 "¿Desea continuar?"
 
-#: ../../vdms_panels/presets_manager.py:663
 msgid "Restore successful"
 msgstr "¡Restauración exitosa!"
 
-#: ../../vdms_panels/presets_manager.py:681
 msgid ""
 "This will update the presets database. Don't worry, it will keep all your saved profiles.\n"
 "\n"
@@ -3080,19 +2310,15 @@ msgstr ""
 "\n"
 "¿Desea continuar?"
 
-#: ../../vdms_panels/presets_manager.py:689
 msgid "Open the presets folder to restore"
 msgstr "Abrir carpeta de presets a restaurar"
 
-#: ../../vdms_panels/presets_manager.py:725
 msgid "The presets database has been successfully updated"
 msgstr "Base de datos de presets actualizada con exito"
 
-#: ../../vdms_panels/presets_manager.py:740
 msgid "The selected preset is not part of Videomass's default presets."
 msgstr "Preset seleccionado no es parte de Videomass."
 
-#: ../../vdms_panels/presets_manager.py:745
 msgid ""
 "Be careful! The selected preset will be overwritten with the default one. Your profiles may be deleted!\n"
 "\n"
@@ -3102,12 +2328,9 @@ msgstr ""
 "\n"
 "¿Desea continuar?"
 
-#: ../../vdms_panels/presets_manager.py:760
-#: ../../vdms_panels/presets_manager.py:794
 msgid "Successful recovery"
 msgstr "Recuperación exitosa"
 
-#: ../../vdms_panels/presets_manager.py:769
 msgid ""
 "Be careful! This action will restore all presets to default ones. Your profiles may be deleted!\n"
 "\n"
@@ -3121,20 +2344,16 @@ msgstr ""
 "\n"
 "¿Desea continuar?"
 
-#: ../../vdms_panels/presets_manager.py:833
 #, python-brace-format
 msgid "Edit profile on «{0}»"
 msgstr "Editar perfil en «{0}»"
 
-#: ../../vdms_panels/presets_manager.py:872
 msgid "Are you sure you want to delete the selected profile? It will no longer be possible to recover it."
 msgstr "¿Seguro que desea borrar el perfil seleccionado? No sera posible recuperarlo."
 
-#: ../../vdms_panels/presets_manager.py:891
 msgid "First select a profile in the list"
 msgstr "Primero elija un perfil en la lista"
 
-#: ../../vdms_panels/presets_manager.py:899
 msgid ""
 "The selected profile command has been changed manually.\n"
 "Do you want to apply it during the conversion process?"
@@ -3142,11 +2361,9 @@ msgstr ""
 "El comando del perfil seleccionado se cambio manualmente.\n"
 "¿Desea aplicarlo durante el proceso de conversión?"
 
-#: ../../vdms_panels/presets_manager.py:909
 msgid "Don't show this dialog again"
 msgstr "No mostrar nuevamente este dialogo"
 
-#: ../../vdms_panels/presets_manager.py:1054
 msgid ""
 "Batch processing items\n"
 "Destination\n"
@@ -3166,12 +2383,10 @@ msgstr ""
 "Inicio de segmento\n"
 "Duración de Clip"
 
-#: ../../vdms_panels/sequence_to_video.py:54
 #, fuzzy
 msgid "Images need to be resized, please use Resize function."
 msgstr "Las Imágenes deben redimencionarse, por favor use la función Redimensionar."
 
-#: ../../vdms_panels/sequence_to_video.py:73
 msgid ""
 "\n"
 "1. Import one or more image files such as JPG, PNG and BMP formats, then select one.\n"
@@ -3202,11 +2417,9 @@ msgstr ""
 "El video producido tendrá el nombre del archivo seleccionado en el panel 'Lista de Archivos' , \n"
 "y sera guardado en una carpeta llamada 'Still_Images' con un digito progresivo, en la trayectoria especificada."
 
-#: ../../vdms_panels/sequence_to_video.py:129
 msgid "Enable a single still image"
 msgstr "Habilitar solo una imagen fija"
 
-#: ../../vdms_panels/sequence_to_video.py:162
 msgid ""
 "Force original aspect ratio using\n"
 "padding rather than stretching"
@@ -3214,28 +2427,21 @@ msgstr ""
 "Forzar la relación de aspecto original usando\n"
 "rellenar en lugar de estirar"
 
-#: ../../vdms_panels/sequence_to_video.py:170
 msgid "Include audio file"
 msgstr "Incluir archivo de audio"
 
-#: ../../vdms_panels/sequence_to_video.py:173
 msgid "Play the video until audio track finishes"
 msgstr "Reproducir video hasta que la pista de audio finalice"
 
-#: ../../vdms_panels/sequence_to_video.py:180
-#: ../../vdms_panels/sequence_to_video.py:439
 msgid "Open audio file"
 msgstr "Abrir archivo de audio"
 
-#: ../../vdms_panels/sequence_to_video.py:199
 msgid "Additional arguments"
 msgstr "Argumentos Adicionales"
 
-#: ../../vdms_panels/sequence_to_video.py:454
 msgid "Open Audio File"
 msgstr "Abrir Archivo de Audio"
 
-#: ../../vdms_panels/sequence_to_video.py:466
 #, python-brace-format
 msgid ""
 "Invalid file: '{}'\n"
@@ -3246,7 +2452,6 @@ msgstr ""
 "\n"
 "{}"
 
-#: ../../vdms_panels/sequence_to_video.py:471
 #, python-brace-format
 msgid ""
 "Invalid file: '{}'\n"
@@ -3257,21 +2462,14 @@ msgstr ""
 "\n"
 "No parece un archivo de audio."
 
-#: ../../vdms_panels/sequence_to_video.py:560
-#: ../../vdms_panels/sequence_to_video.py:587
-#: ../../vdms_panels/video_to_sequence.py:511
 #, python-brace-format
 msgid "Invalid file: '{}'"
 msgstr "Archivo invalido: \"{}\""
 
-#: ../../vdms_panels/sequence_to_video.py:570
-#: ../../vdms_panels/sequence_to_video.py:595
 #, python-brace-format
 msgid "Unsupported format '{}'"
 msgstr "Formato no soportado '{}'"
 
-#: ../../vdms_panels/sequence_to_video.py:576
-#: ../../vdms_panels/sequence_to_video.py:600
 #, python-brace-format
 msgid ""
 "File does not exist:\n"
@@ -3282,15 +2480,9 @@ msgstr ""
 "\n"
 "\"{}\"\n"
 
-#: ../../vdms_panels/sequence_to_video.py:577
 msgid "ERROR"
 msgstr "ERROR"
 
-#: ../../vdms_panels/sequence_to_video.py:707
-msgid "Shortest"
-msgstr "MiniPrueba"
-
-#: ../../vdms_panels/sequence_to_video.py:715
 msgid ""
 "Items to concatenate\n"
 "Output filename\n"
@@ -3318,7 +2510,6 @@ msgstr ""
 "Duración de Imagen Fija\n"
 "Duración total de Video"
 
-#: ../../vdms_panels/video_to_sequence.py:50
 msgid ""
 "\n"
 "1. Import one or more video files, then select one.\n"
@@ -3348,51 +2539,39 @@ msgstr ""
 "Las imágenes producidas serán guardadas en una carpeta llamada 'Movie_to_Pictures'\n"
 "con un digito progresivo, en la trayectoria especificada."
 
-#: ../../vdms_panels/video_to_sequence.py:86
 msgid "Create thumbnails"
 msgstr "Crear miniaturas"
 
-#: ../../vdms_panels/video_to_sequence.py:87
 msgid "Create tiled mosaics"
 msgstr "Crear mosaicos"
 
-#: ../../vdms_panels/video_to_sequence.py:88
 msgid "Create animated GIF"
 msgstr "Crear GIF animado"
 
-#: ../../vdms_panels/video_to_sequence.py:90
 msgid "Options"
 msgstr "Opciones"
 
-#: ../../vdms_panels/video_to_sequence.py:119
 msgid "Output format:"
 msgstr "Formato de Salida:"
 
-#: ../../vdms_panels/video_to_sequence.py:131
 msgid "Rows:"
 msgstr "Renglones:"
 
-#: ../../vdms_panels/video_to_sequence.py:141
 msgid "Columns:"
 msgstr "Columnas:"
 
-#: ../../vdms_panels/video_to_sequence.py:205
 msgid "Other unofficial resources:"
 msgstr "Otros recursos no oficiales:"
 
-#: ../../vdms_panels/video_to_sequence.py:229
 msgid "Set FPS control from 0.1 to 30.0 fps. The higher this value, the more images will be extracted."
 msgstr "Fijar el control de FPS, desde 0.1 hasta 30.0 fps. Entre más alto el valor se extraen más imágenes."
 
-#: ../../vdms_panels/video_to_sequence.py:232
 msgid "Spaces around the mosaic tiles. From 0 to 32 pixels"
 msgstr "Espacio entre mosaicos. Desde 0 hasta 32 pixels"
 
-#: ../../vdms_panels/video_to_sequence.py:234
 msgid "Spaces around the mosaic borders. From 0 to 32 pixels"
 msgstr "Espacio entre bordes de mosaicos. Desde 0 hasta 32 pixels"
 
-#: ../../vdms_panels/video_to_sequence.py:626
 msgid ""
 "Selected File\n"
 "Output Format\n"
@@ -3420,51 +2599,39 @@ msgstr ""
 "Inicio de segmento\n"
 "Duración"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:118
 msgid "Audio encoder settings, mapping and filters"
 msgstr "Configuración de codificador de Audio, mapeo y filtros"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:128
 msgid "Audio Encoder"
 msgstr "Codificador de Audio"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:137
 msgid "Settings"
 msgstr "Configuraciones"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:148
 msgid "Index Selection:"
 msgstr "Selecciòn de Indice:"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:157
 msgid "Map:"
 msgstr "Mapear:"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:180
 msgid "Normalization"
 msgstr "Normalización"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:191
 msgid "Volume detect"
 msgstr "Detectar Volumen"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:195
 msgid "Volume Statistics"
 msgstr "Estadísticas de Volumen"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:199
 msgid "Target level:"
 msgstr "Nivel Objetivo:"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:264
 msgid "Gets maximum volume and average volume data in dBFS, then calculates the offset amount for audio normalization."
 msgstr "Obtiene el volumen máximo y promedio en dBFs, y calcula el desplazamiento para normalizar el audio."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:267
 msgid "Limiter for the maximum peak level or the mean level (when switch to RMS) in dBFS. From -99.0 to +0.0; default for PEAK level is -1.0; default for RMS is -20.0"
 msgstr "Limita por máximo nivel de pico o por nivel promedio (cuando se usa RMS) en dBFS. Desde -99 a +0.0; predeterminado para nivel de pico es -1.0; para RMS es 20.0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:271
 msgid ""
 "Normally on a video with correctly indexed streams and having one or more audio streams, the first audio stream should be indexed at \"1\", the second at \"2\" and so on (the video stream on the other hand is always indexed at \"0\"). In this case it is recommended to select the desired stream by setting a specific index, e.g \"1\" for for the first available audio stream.\n"
 "\n"
@@ -3474,7 +2641,6 @@ msgstr ""
 "\n"
 "Ponga este control en \"Auto\" si la fuente es una pista de audio ."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:280
 msgid ""
 "\"Auto\" keeps all audio streams and processes only the one selected by the \"Index Selection\" control.\n"
 "\n"
@@ -3488,28 +2654,22 @@ msgstr ""
 "\n"
 "\"Solo el Indice\" procesa solo el flujo de audio seleccionado en el control \"Selección de Indice\" y elimina el resto"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:288
 msgid "Integrated Loudness Target in LUFS. From -70.0 to -5.0, default is -16.0"
 msgstr "Intensidad Destino Integrada en LUFS. Desde -70.0 a -5.0, predeterminado -16.0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:291
 msgid "Maximum True Peak in dBTP. From -1.5 to +0.0, default is -2.0"
 msgstr "Pico Máximo Real en dBTP. Desde -9.0 a +0.0, predeterminado -2.0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:294
 #, fuzzy
 msgid "Loudness Range Target in LUFS. From +1.0 to +20.0, default is +11.0"
 msgstr "Rango de Intensidad Destino en LUFS. Desde +1.0 a +20.0, predeterminado +7.0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:297
 msgid "Play the audio stream selected in the \"Index Selection\" control. Using this function you can test the result of audio normalization."
 msgstr "Reproducir el flujo de audio seleccionado en la \"Selección de Indice\". Con esta función puede probar el resultado de normalizar el audio."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:503
 msgid "Selected index does not exist or does not contain any audio streams"
 msgstr "El indice seleccionado no existe o no contiene flujos de audio"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:508
 #, python-brace-format
 msgid ""
 "ERROR: Missing audio stream:\n"
@@ -3518,15 +2678,12 @@ msgstr ""
 "ERROR: Falta flujo de audio:\n"
 "\"{}\""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:726
 msgid "PEAK level normalization, which will produce a maximum peak level equal to the set target level."
 msgstr "Normalización de nivel de pico, produce un nivel de pico máximo igual al configurado."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:729
 msgid "RMS-based normalization, which according to mean volume calculates the amount of gain to reach same average power signal."
 msgstr "Normalización RMS, se calcula la ganancia de acuerdo al volumen medio para lograr la misma potencia promedio de señal."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:733
 msgid ""
 "Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements the EBU R128 algorithm.\n"
 "Ideal for live normalization. It produces worse results than the High-quality two-pass Loudnorm normalization, but is faster."
@@ -3534,7 +2691,6 @@ msgstr ""
 "Normalización de intensidad. Se Normaliza la intensidad percibida utilizando el filtro \"​loudnorm\", el cual implementa el algoritmo EBU R128.\n"
 "Ideal par normalización en vivo. Produce peores resultados que la normalización de intensidad en dos pasos de Alta calidad, pero es mas rápida."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:740
 msgid ""
 "High-quality two-pass Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements\n"
 "the EBU R128 algorithm. Ideal for postprocessing."
@@ -3542,23 +2698,18 @@ msgstr ""
 "Normalización de intensidad Alta calidad en dos pasos. Se Normaliza la intensidad percibida utilizando el filtro \"​loudnorm\", el cual\n"
 "implementa el algoritmo EBU R128. Ideal para postprocesado."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:789
 msgid "You need to import at least one file"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:63
 msgid "Subtitle Mapping:"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:77
 msgid "Copy Chapters"
 msgstr "Copiar capítulos"
 
-#: ../../vdms_panels/miscellaneous/miscell.py:79
 msgid "Copy Metadata"
 msgstr "Copiar metadatos"
 
-#: ../../vdms_panels/miscellaneous/miscell.py:85
 msgid ""
 "Select \"All\" to include any source file subtitles in the output video.\n"
 "\n"
@@ -3572,152 +2723,68 @@ msgstr ""
 "\n"
 "Se ignora esta opción sil la salida es archivo de audio."
 
-#: ../../vdms_panels/miscellaneous/miscell.py:90
 msgid "Copy the chapter markers as is from source file. This option is automatically ignored for output audio files."
 msgstr "Copiar las marcas de capítulos desde la fuente. Se ignora esta opción sil la salida es archivo de audio."
 
-#: ../../vdms_panels/miscellaneous/miscell.py:93
 msgid "Copy all incoming metadata from source file, such as audio/video tags, titles, unique marks, and so on."
 msgstr "Copiar todos los metadatos desde la fuente, cosas como etiquetas de audio/video, títulos, marcas únicas, etc."
 
-#: ../../vdms_panels/miscellaneous/miscell.py:108
 #, fuzzy
 msgid "Additional options"
 msgstr "Argumentos Adicionales"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:89
-#: ../../vdms_panels/video_encoders/av1_svt.py:120
-#: ../../vdms_panels/video_encoders/avc_x264.py:90
-#: ../../vdms_panels/video_encoders/hevc_x265.py:98
-#: ../../vdms_panels/video_encoders/mpeg4.py:71
-#: ../../vdms_panels/video_encoders/vp9_webm.py:131
 #, fuzzy
 msgid "Reload"
 msgstr "Recargar"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:101
-#: ../../vdms_panels/video_encoders/av1_svt.py:129
-#: ../../vdms_panels/video_encoders/avc_x264.py:101
-#: ../../vdms_panels/video_encoders/hevc_x265.py:109
-#: ../../vdms_panels/video_encoders/mpeg4.py:82
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:97
-#: ../../vdms_panels/video_encoders/vp9_webm.py:141
 #, fuzzy
 msgid "Optimize for Web"
 msgstr "Para uso en Web"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:247
-#: ../../vdms_panels/video_encoders/av1_svt.py:313
-#: ../../vdms_panels/video_encoders/avc_x264.py:242
-#: ../../vdms_panels/video_encoders/hevc_x265.py:250
-#: ../../vdms_panels/video_encoders/mpeg4.py:198
-#: ../../vdms_panels/video_encoders/vp9_webm.py:288
 msgid "Reloads the selected video encoder settings. Changes will be discarded."
 msgstr "Recargar configuración del codificador de video. Se descartaran los cambios."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:250
-#: ../../vdms_panels/video_encoders/avc_x264.py:273
-#: ../../vdms_panels/video_encoders/hevc_x265.py:277
-#: ../../vdms_panels/video_encoders/vp9_webm.py:291
 #, fuzzy
 msgid "Constant rate factor. Lower values correspond to higher quality and greater file size. Set to -1 to disable this control."
 msgstr "Factor de frecuencia Constante. Valores mas bajos = mejor calidad y mayor tamaño de archivo. -1 deshabilita este control."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:254
-#: ../../vdms_panels/video_encoders/av1_svt.py:357
-#: ../../vdms_panels/video_encoders/vp9_webm.py:295
 msgid "Number of tile rows to use, default changes per resolution"
 msgstr "Renglones a usar, el predeterminado cambia según resolución"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:256
-#: ../../vdms_panels/video_encoders/av1_svt.py:359
-#: ../../vdms_panels/video_encoders/vp9_webm.py:297
 msgid "Number of tile columns to use, default changes per resolution"
 msgstr "Columnas a usar, el predeterminado cambia según resolución"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:259
-#: ../../vdms_panels/video_encoders/av1_svt.py:368
-#: ../../vdms_panels/video_encoders/avc_x264.py:253
-#: ../../vdms_panels/video_encoders/hevc_x265.py:261
-#: ../../vdms_panels/video_encoders/mpeg4.py:201
-#: ../../vdms_panels/video_encoders/vp9_webm.py:300
 msgid "Set the Group Of Picture (GOP). Set to -1 to disable this control."
 msgstr "Tamaño del grupo de imágenes (GOP). -1 para desactiva este control."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:262
-#: ../../vdms_panels/video_encoders/av1_svt.py:371
-#: ../../vdms_panels/video_encoders/avc_x264.py:256
-#: ../../vdms_panels/video_encoders/hevc_x265.py:264
-#: ../../vdms_panels/video_encoders/mpeg4.py:204
-#: ../../vdms_panels/video_encoders/vp9_webm.py:303
 msgid "It can reduce the file size, but takes longer."
 msgstr "Puede reducir el tamaño del archivo, pero dilatar más."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:264
-#: ../../vdms_panels/video_encoders/av1_svt.py:373
-#: ../../vdms_panels/video_encoders/avc_x264.py:258
-#: ../../vdms_panels/video_encoders/hevc_x265.py:266
-#: ../../vdms_panels/video_encoders/mpeg4.py:206
-#: ../../vdms_panels/video_encoders/vp9_webm.py:305
 msgid "Set minimum bitrate tolerance. Most useful in setting up a CBR encode. It is of little use otherwise. Set to -1 to disable this control."
 msgstr "Tolerancia de bitrate mínimo. Mas util usada con codificación CBR. Es de poca utilidad en otros casos. -1 deshabilita el control."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:268
-#: ../../vdms_panels/video_encoders/av1_svt.py:377
-#: ../../vdms_panels/video_encoders/avc_x264.py:262
-#: ../../vdms_panels/video_encoders/hevc_x265.py:270
-#: ../../vdms_panels/video_encoders/mpeg4.py:210
-#: ../../vdms_panels/video_encoders/vp9_webm.py:309
 msgid "Specifies a maximum tolerance. Requires bufsize to be set. Set to -1 to disable this control."
 msgstr "Especificar tolerancia máxima. Requiere fijar tamaño del buffer. -1 desactiva este control."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:271
-#: ../../vdms_panels/video_encoders/av1_svt.py:380
-#: ../../vdms_panels/video_encoders/avc_x264.py:265
-#: ../../vdms_panels/video_encoders/hevc_x265.py:273
-#: ../../vdms_panels/video_encoders/mpeg4.py:213
-#: ../../vdms_panels/video_encoders/vp9_webm.py:312
 msgid "Set ratecontrol buffer size, which determines the variability of the output bitrate. Set to -1 to disable this control."
 msgstr "Fija control de razón del tamaño de buffer, determina la variabilidad de la frecuencia de bits de salida. -1 desactiva este control."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:275
-#: ../../vdms_panels/video_encoders/av1_svt.py:384
-#: ../../vdms_panels/video_encoders/avc_x264.py:277
-#: ../../vdms_panels/video_encoders/hevc_x265.py:281
-#: ../../vdms_panels/video_encoders/mpeg4.py:231
-#: ../../vdms_panels/video_encoders/vp9_webm.py:316
 msgid "Specifies the target (average) bit rate for the encoder to use. Higher value = higher quality. Set -1 to disable this control."
 msgstr "Especifica la frecuencia de bits (promedio) que usara el codificador. Un valor más alto =  mejor calidad. -1 deshabilita este control."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:279
-#: ../../vdms_panels/video_encoders/av1_svt.py:388
-#: ../../vdms_panels/video_encoders/avc_x264.py:281
-#: ../../vdms_panels/video_encoders/hevc_x265.py:285
-#: ../../vdms_panels/video_encoders/mpeg4.py:235
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:131
-#: ../../vdms_panels/video_encoders/vp9_webm.py:320
 msgid "Video width and video height ratio."
 msgstr "Proporción ancho y alto de video."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:281
-#: ../../vdms_panels/video_encoders/av1_svt.py:390
-#: ../../vdms_panels/video_encoders/avc_x264.py:283
-#: ../../vdms_panels/video_encoders/hevc_x265.py:287
-#: ../../vdms_panels/video_encoders/mpeg4.py:237
-#: ../../vdms_panels/video_encoders/vp9_webm.py:322
 #, fuzzy
 msgid "Frame rate (frames per second). Frames repeat a given number of times per second. In some countries this is 30 for NTSC, other countries (like Italy) use 25 for PAL"
 msgstr "Los cuadros se repiten un dado numero de veces por segundo. En algunos países es 30 para NTSC, en otros  (como Italia) usan 25 para PAL"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:285
 msgid "Quality/Speed ratio modifier. CPU Used sets how efficient the compression will be. Lower values mean slower encoding with better quality, and vice-versa. Valid values are from 0 to 8 inclusive."
 msgstr "Razón Calidad/Velocidad. Fija la eficiencia de la compresión. Valores bajos equivale a una codificación más lenta con mejor calidad, y viceversa. Valores validos incluyen 0 a 8 ."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:290
 msgid "Quality and compression efficiency vs speed trade-off. \"good\" is the default and recommended for most applications; \"realtime\" is recommended for live/fast encoding (live streaming, video conferencing, etc); \"allintra\" for All Intra encoding."
 msgstr "Calidad y compresión del intercambio  eficiencia vs calidad. \"good\" es lo predeterminado y recomendado para muchas aplicaciones;  \"realtime\" recomendado para directos, videoconferencia, etc; «allintra» para la codificación All Intra."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:297
 msgid ""
 "Row Multi-Threading enables row-based multi-threading which maximizes CPU usage.\n"
 "\n"
@@ -3731,7 +2798,6 @@ msgstr ""
 "\n"
 "Activarlo solo es mas rápido si el CPU tiene más hilos que el numero total de cuadros."
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:316
 msgid ""
 "presets 1-3 represent extremely high efficiency, for use when encode time is not important and quality/size of the resulting video file is critical.\n"
 "\n"
@@ -3749,7 +2815,6 @@ msgstr ""
 "\n"
 "Preset 13 es aun más rápido pero no esta dirigido al consumo humano directo --puede usarse por ejemplo para comparaciones por escena de aplicaciones VOD. Solo se debe usar el preset más bajo tolerable."
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:327
 msgid ""
 "Constant rate factor. This parameter governs the quality/size trade-off.\n"
 "\n"
@@ -3767,7 +2832,6 @@ msgstr ""
 "\n"
 " -1 deshabilita el control."
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:334
 msgid ""
 "The \"Film Grain\" parameter allows SVT-AV1 to detect and delete film grain from the source video, and replace it with synthetic grain of the same character, resulting in significant bitrate savings.\n"
 "\n"
@@ -3789,7 +2853,6 @@ msgstr ""
 "\n"
 "Si la fuente de video no tiene grano, se puede desactivar con -1 o usar 0."
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:346
 msgid ""
 "If enabled, the \"Film Grain Denoiser\" option can mitigate the detail removal caused by high \"Film Grain\" values required to preserve the look of very grainy films\n"
 "\n"
@@ -3799,55 +2862,36 @@ msgstr ""
 "\n"
 "Por omisión los cuadros procesados son pasados para ser codificados como imágenes finales, esta caracteristica hara que se usen los cuadros originales. "
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:353
 msgid "Enables encoder optimization to produce faster (less CPU intensive) bit streams to decode, similar to the fastdecode tuning in x264 and x265."
 msgstr "Optimizar codificador para producir un flujo de bits mas rápido (menor uso de CPU) a decodificar, similar al ajuste fastdecode en x264 y x265."
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:362
-#: ../../vdms_panels/video_encoders/avc_x264.py:247
-#: ../../vdms_panels/video_encoders/hevc_x265.py:255
 msgid "Set profile restrictions"
 msgstr "Restricciones de perfil"
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:364
-#: ../../vdms_panels/video_encoders/avc_x264.py:249
-#: ../../vdms_panels/video_encoders/hevc_x265.py:257
 msgid "Specify level for a selected profile"
 msgstr "Especifique nivel del perfil seleccionado"
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:366
-#: ../../vdms_panels/video_encoders/avc_x264.py:251
-#: ../../vdms_panels/video_encoders/hevc_x265.py:259
 msgid "Tune the encoding params"
 msgstr "Afinar parámetros de codificación"
 
-#: ../../vdms_panels/video_encoders/avc_x264.py:245
-#: ../../vdms_panels/video_encoders/hevc_x265.py:253
 msgid "Set the encoding preset (default \"medium\")"
 msgstr "Preset de codificación (por omisión \"medio\")"
 
-#: ../../vdms_panels/video_encoders/avc_x264.py:269
 msgid "specifies the target (average) bit rate for the encoder to use. Higher value = higher quality. Set -1 to disable this control."
 msgstr "especifica la frecuencia de bits (promedio) que usara el codificador. Un valor más alto =  mejor calidad. -1 deshabilita este control."
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:217
 msgid "Variable Bit Rate. From 0-30, with 1 being highest quality/largest filesize and 30 being the lowest quality/smallest filesize. Set to -1 to disable this control."
 msgstr "Flujo Variable de Bits. De 0-30, siendo 1 mayor calidad/mayor tamaño y 30 menor calidad/menor tamaño.  -1 desactiva este control."
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:222
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:133
 msgid "Frames repeat a given number of times per second. In some countries this is 30 for NTSC, other countries (like Italy) use 25 for PAL"
 msgstr "Los cuadros se repiten un dado numero de veces por segundo. En algunos países es 30 para NTSC, en otros  (como Italia) usan 25 para PAL"
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:226
 msgid "The default FourCC stored in an MPEG-4-coded file will be FMP4. If you want a different FourCC, set this option to xvid to force the FourCC xvid to be stored as the video FourCC rather than the default."
 msgstr "El valor FourCC en un video MPEG-4-seria FMP4. Si quiere un valor FourCC diferente, use xvid para forzar FourCC xvid en el video en vez del predeterminado."
 
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:162
 msgid "Copy Video Codec"
 msgstr "Copiar Codec de Video"
 
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:163
 msgid ""
 "This will just copy the video track as is, without any video re-encoding.\n"
 "You will only be able to change output format, select other audio encoders and\n"
@@ -3857,11 +2901,9 @@ msgstr ""
 "Solo podrá cambiar el formato de salida, seleccionar otro codificador de audio y\n"
 "otras pocas opciones."
 
-#: ../../vdms_panels/video_encoders/video_no_enc.py:74
 msgid "Video export disabled"
 msgstr "Exportación de Video desactivada"
 
-#: ../../vdms_panels/video_encoders/video_no_enc.py:75
 msgid ""
 "The Media target you just selected will only allow you to export files as audio tracks.\n"
 "You can then process audio source files only or extract indexed audio streams on\n"
@@ -3871,7 +2913,6 @@ msgstr ""
 "Entonces solo podrá procesar archivos de audio o extraer el audio indicado de\n"
 "los archivos de video."
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:326
 msgid ""
 "Speed sets how efficient the compression will be.\n"
 "\n"
@@ -3893,7 +2934,6 @@ msgstr ""
 "\n"
 "Si Calidad es realtime, los valores de Velocidad son de 0 a 8."
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:335
 msgid ""
 "Time to spend encoding.\n"
 "\n"
@@ -3911,24 +2951,23 @@ msgstr ""
 "\n"
 "\"realtime\" se recomienda para codificaciones en directo/rapidas."
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:341
-msgid "If enabled, adds support for row based multithreading which greatly enhances the number of threads the encoder can utilise. This improves encoding speed significantly on systems that are otherwise underutilised when encoding VP9. Since the amount of additional threads depends on the number of \"tiles\", which itself depends on the video resolution, encoding higher resolution videos will see a larger performance improvement."
-msgstr "Habilitarla, añade multiproceso por renglón que mejora el numero de hilos que el codificador puede usar. Esto mejora significativamente la velocidad de codificado al codificar en VP9, en sistemas que de otra manera están subutilizados. Ya que la cantidad adicional de hilos  depende del numero de \"cuadros\", lo que depende del la resolución del video, codificar videos con altas resoluciones mostrara un gran incremento en el desempeño."
+msgid ""
+"If enabled, adds support for row based multithreading which greatly enhances the number of threads the encoder can utilise. This improves encoding speed significantly on systems that are otherwise underutilised when encoding VP9. Since the amount of additional threads depends on the number of \"tiles\", which itself depends on the video resolution, encoding higher resolution videos will see a "
+"larger performance improvement."
+msgstr ""
+"Habilitarla, añade multiproceso por renglón que mejora el numero de hilos que el codificador puede usar. Esto mejora significativamente la velocidad de codificado al codificar en VP9, en sistemas que de otra manera están subutilizados. Ya que la cantidad adicional de hilos  depende del numero de \"cuadros\", lo que depende del la resolución del video, codificar videos con altas resoluciones "
+"mostrara un gran incremento en el desempeño."
 
-#: ../../vdms_utils/presets_manager_utils.py:46
 #, python-brace-format
 msgid "Supports ({0}) formats only, not ({1})"
 msgstr "Formatos soportados ({0}), no soporta ({1})"
 
-#: ../../vdms_utils/presets_manager_utils.py:49
 msgid "File formats not supported by the selected profile"
 msgstr "Formatos de archivo no soportados por el perfil selecciondo"
 
-#: ../../vdms_utils/presets_manager_utils.py:52
 msgid "Warning"
 msgstr "Advertencia"
 
-#: ../../vdms_utils/presets_manager_utils.py:90
 msgid ""
 "No presets found.\n"
 "\n"
@@ -3938,11 +2977,9 @@ msgstr ""
 "\n"
 "Posible solución: abra el panel del Administrador de Presets, ir a la columna presets y presionar el botón \"Restaurar todo...\""
 
-#: ../../vdms_utils/queue_utils.py:54
 msgid "Import queue file"
 msgstr "Importar archivo de lista"
 
-#: ../../vdms_utils/queue_utils.py:89
 #, python-brace-format
 msgid ""
 "ERROR: invalid data found loading queue file.\n"
@@ -3955,11 +2992,9 @@ msgstr ""
 "\n"
 "No puede contener múltiples valores de `destino`."
 
-#: ../../vdms_utils/queue_utils.py:118
 msgid "Videomass - Add Items to Queue"
 msgstr "Videomass - Añadir Entradas a Lista"
 
-#: ../../vdms_utils/queue_utils.py:119
 msgid ""
 "Multiple items with identical names and destination paths cannot coexist.\n"
 "Please choose one of the following actions:"
@@ -3967,15 +3002,12 @@ msgstr ""
 "Múltiples entradas con nombres y destinos idénticos no pueden coexistir.\n"
 "Elija una de las siguientes acciones:"
 
-#: ../../vdms_utils/queue_utils.py:123
 msgid "Replace occurrences with items from the imported queue."
 msgstr "Reemplace ocurrencias con entradas de la lista importada."
 
-#: ../../vdms_utils/queue_utils.py:124
 msgid "Add only the currently missing items to the queue."
 msgstr "Añadir solo entradas faltantes a la lista."
 
-#: ../../vdms_utils/queue_utils.py:125
 msgid "Remove the current queue and replace it with the imported one."
 msgstr "Eliminar lista actual y reemplazar con la importada."
 
@@ -3987,4 +3019,7 @@ msgstr "Eliminar lista actual y reemplazar con la importada."
 
 #~ msgid "Subtitle Mapping"
 #~ msgstr "Mapeo de Subtitulos"
+
+#~ msgid "Shortest"
+#~ msgstr "MiniPrueba"
 

--- a/videomass/data/locale/es_CU/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/es_CU/LC_MESSAGES/videomass.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Videomass 5.0.18\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-30 11:02+0200\n"
+"POT-Creation-Date: 2025-07-30 15:28+0200\n"
 "PO-Revision-Date: 2024-08-26 17:29-0600\n"
 "Last-Translator: José Alberto Valle Cid j.alberto.vc@gmail.com\n"
 "Language: es_CU\n"
@@ -3010,16 +3010,4 @@ msgstr "Añadir solo entradas faltantes a la lista."
 
 msgid "Remove the current queue and replace it with the imported one."
 msgstr "Eliminar lista actual y reemplazar con la importada."
-
-#~ msgid "Some text boxes are still incomplete"
-#~ msgstr "Algunas cajas de texto están incompletas"
-
-#~ msgid "FFplay"
-#~ msgstr "FFplay"
-
-#~ msgid "Subtitle Mapping"
-#~ msgstr "Mapeo de Subtitulos"
-
-#~ msgid "Shortest"
-#~ msgstr "MiniPrueba"
 

--- a/videomass/data/locale/es_ES/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/es_ES/LC_MESSAGES/videomass.po
@@ -1,13 +1,13 @@
-# Spanish translation for Videomass.
-# Copyleft -  2024 Gianluca Pernigotto
-# This file is distributed under the same license as the Videomass package
-# FIRST AUTHOR Gianluca Pernigotto <jeanlucperni@gmail.com>, 2021
+# Spanish (Spain) translations for Videomass.
+# Copyright (C) 2025 ORGANIZATION
+# This file is distributed under the same license as the Videomass project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Videomass 5.0.18\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-26 15:04+0200\n"
+"POT-Creation-Date: 2025-07-30 11:02+0200\n"
 "PO-Revision-Date: 2024-08-26 17:29-0600\n"
 "Last-Translator: José Alberto Valle Cid j.alberto.vc@gmail.com\n"
 "Language: es_ES\n"
@@ -18,7 +18,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
-#: ../../gui_app.py:196
 #, python-brace-format
 msgid ""
 "Unexpected error while deleting file contents:\n"
@@ -29,162 +28,111 @@ msgstr ""
 "\n"
 "{0}"
 
-#: ../../vdms_dialogs/about_dialog.py:52
 msgid "Cross-platform graphical user interface for FFmpeg\n"
 msgstr ""
 
-#: ../../vdms_dialogs/audioproperties.py:224
 msgid "Videomass supports mono and stereo audio channels. If you are not sure set to \"Auto\" and source values will be copied."
 msgstr "Videomass soporta canales de audio mono y estéreo. Si no esta seguro elija \"Auto\" y se copiaran los valores de la fuente."
 
-#: ../../vdms_dialogs/audioproperties.py:228
 msgid "The audio Rate (or sample-rate) is the sound sampling frequency and is measured in Hertz. The higher the frequency, the more true it will be to the sound source and the more the file will increase in size. For audio CD playback, set a sampling frequency of 44100 kHz. If you are not sure, set to \"Auto\" and source values will be copied."
 msgstr "La Frecuencia de audio (o frecuencia de muestreo) es la frecuencia de toma de muestras del audio y se mide en Hertz. A mayor frecuencia, la fuente de sonido tendrá mayor fidelidad y se incrementara el tamaño del archivo. Para calidad CD , elija una frecuencia de muestreo de 44100 kHz. Si no esta seguro elija \"Auto\" y se copiaran los valores de la fuente."
 
-#: ../../vdms_dialogs/audioproperties.py:237
 msgid "The audio bitrate affects the file compression and thus the quality of listening. The higher the value, the higher the quality."
 msgstr "La frecuencia de bits (bitrate) del audio afecta la compresión y la calidad de audio. Los valores mas altos implican mejor calidad."
 
-#: ../../vdms_dialogs/audioproperties.py:241
 msgid "Bit depth is the number of bits of information in each sample, and it directly corresponds to the resolution of each sample. Bit depth is only meaningful in reference to a PCM digital signal. Non-PCM formats, such as lossy compression formats, do not have associated bit depths."
 msgstr "La profundidad de bites el numero de bits de información en cada muestra, y se corresponde directamente a al resolución de cada muestra. La profundidad de bit solo es relevante para señales digitales PCM. Los formatos No-PCM, como los formatos compresos/con perdidas, no tienen asociados una profundidad de bits."
 
-#: ../../vdms_dialogs/epilogue.py:74 ../../vdms_dialogs/queuedlg.py:120
 msgid "When finished, once the operations have been completed successfully:"
 msgstr "Al finalizar las operaciones con éxito:"
 
-#: ../../vdms_dialogs/epilogue.py:80 ../../vdms_dialogs/queuedlg.py:126
 msgid "Trash the source files"
 msgstr "Desechar archivos fuente"
 
-#: ../../vdms_dialogs/epilogue.py:84 ../../vdms_dialogs/queuedlg.py:130
 msgid "Clear the File List"
 msgstr "Limpia la Lista de Archivos"
 
-#: ../../vdms_dialogs/epilogue.py:91 ../../vdms_dialogs/queuedlg.py:142
-#: ../../vdms_main/main_frame.py:1322
 msgid "Run"
 msgstr "Ejecutar"
 
-#: ../../vdms_dialogs/epilogue.py:97
 msgid "Videomass - Batch Mode"
 msgstr "Videomass - Proceso por lotes"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:47
 msgid "FFmpeg encoders"
 msgstr "Codificadores FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:48
 msgid "supported encoders"
 msgstr "codificadores soportados"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:50
 msgid "FFmpeg decoders"
 msgstr "Decodificadores FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:51
 msgid "supported decoders"
 msgstr "decodificadores soportados"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:77
-#: ../../vdms_panels/av_conversions.py:293
 msgid "Video"
 msgstr "Video"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:87
-#: ../../vdms_panels/av_conversions.py:305
 msgid "Audio"
 msgstr "Audio"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:97
 msgid "Subtitle"
 msgstr "Subtitulo"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:114
-#: ../../vdms_dialogs/ffmpeg_codecs.py:123
-#: ../../vdms_dialogs/ffmpeg_codecs.py:132
-#: ../../vdms_dialogs/ffmpeg_formats.py:112
-#: ../../vdms_dialogs/ffmpeg_formats.py:115
-#: ../../vdms_dialogs/ffmpeg_formats.py:118
 msgid "description"
 msgstr "descripción"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:72
 msgid "Informations"
 msgstr "Informaciones"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:83
 msgid "Flags settings"
 msgstr "Configurar banderas"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:93
 msgid "Flags enabled"
 msgstr "Banderas activas"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:103
 msgid "Flags disabled"
 msgstr "Deshabilitar banderas"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:116
 msgid "FFmpeg configuration"
 msgstr "Configuración de FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:124
 msgid "flags"
 msgstr "banderas"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:125 ../../vdms_dialogs/ffmpeg_conf.py:129
-#: ../../vdms_dialogs/ffmpeg_conf.py:133
 msgid "options"
 msgstr "opciones"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:128 ../../vdms_dialogs/ffmpeg_conf.py:132
 msgid "status"
 msgstr "estado"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:167
 msgid "FFprobe   ...not found !"
 msgstr "¡No se encontró FFprobe !"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:175
 msgid "FFplay   ...not found !"
 msgstr "¡No se encontró FFplay !"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:205
-#: ../../vdms_panels/sequence_to_video.py:706
-#: ../../vdms_panels/video_to_sequence.py:606
 msgid "Enabled"
 msgstr "Habilitado"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:216
-#: ../../vdms_panels/sequence_to_video.py:706
-#: ../../vdms_panels/video_to_sequence.py:610
 msgid "Disabled"
 msgstr "Deshabilitado"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:71
 msgid "Demuxing only"
 msgstr "Solo Desmezclar"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:82
 msgid "Muxing only"
 msgstr "Solo Mezclar"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:93
 msgid "Demuxing/Muxing support"
 msgstr "Soporte Desmezclar/Mezclar"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:104
 msgid "FFmpeg file formats"
 msgstr "Formatos de archivos FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:111
-#: ../../vdms_dialogs/ffmpeg_formats.py:114
-#: ../../vdms_dialogs/ffmpeg_formats.py:117
 msgid "supported formats"
 msgstr "formatos soportados"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:46
 msgid ""
 "Contextual help based on the argument entered in the additional text field.\n"
 "Each argument consists of the type and a type-specific name.\n"
@@ -210,117 +158,84 @@ msgstr ""
 "\n"
 "Algunos ejemplos:"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:68 ../../vdms_dialogs/ffmpeg_help.py:301
-#: ../../vdms_dialogs/ffmpeg_help.py:315
 msgid "Help topic"
 msgstr "Temas de ayuda"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:69
 msgid "List basic options"
 msgstr "Mostrar opciones básicas"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:70
 msgid "List more options"
 msgstr "Mostrar más opciones"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:71
 msgid "List all options (very long)"
 msgstr "Mostrar todas las opciones (muy largo)"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:72
 msgid "Show available devices"
 msgstr "Ver dispositivos disponibles"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:73
 msgid "Show available bit stream filters"
 msgstr "Ver filtros disponibles para flujo de bits"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:74
 msgid "Show available protocols"
 msgstr "Ver protocolos disponibles"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:75
 msgid "Show available filters"
 msgstr "Ver filtros disponibles"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:76
 msgid "Show available pixel formats"
 msgstr "Ver formatos de pixel disponibles"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:77
 msgid "Show available audio sample formats"
 msgstr "Ver formatos disponibles para muestreo de audio"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:78
 msgid "Show available color names"
 msgstr "Ver nombres de color disponibles"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:79
 msgid "List sources of the input device"
 msgstr "Lista fuentes del dispositivo de entrada"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:80
 msgid "List sinks of the output device"
 msgstr "Lista receptores del dispositivo de salida"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:81
 msgid "Show available HW acceleration methods"
 msgstr "Ver métodos de aceleración por HW"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:82
 msgid "Show license"
 msgstr "Mostrar licensia"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:117 ../../vdms_dialogs/filter_scale.py:76
-#: ../../vdms_dialogs/shownormlist.py:98 ../../vdms_dialogs/shownormlist.py:107
-#: ../../vdms_dialogs/shownormlist.py:116 ../../vdms_miniframes/timeline.py:263
-#: ../../vdms_miniframes/timeline.py:283 ../../vdms_panels/concatenate.py:117
-#: ../../vdms_panels/sequence_to_video.py:117
-#: ../../vdms_panels/video_to_sequence.py:81
 msgid "Read me"
 msgstr "Leame"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:123 ../../vdms_main/main_frame.py:534
 msgid "Show configuration"
 msgstr "Mostrar configuración"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:127 ../../vdms_main/main_frame.py:542
 msgid "Encoders"
 msgstr "Codificadores"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:131 ../../vdms_main/main_frame.py:545
 msgid "Decoders"
 msgstr "Decodificadores"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:135 ../../vdms_main/main_frame.py:538
 msgid "Muxers and Demuxers"
 msgstr "Mezcladores y Dezmezcladores"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:165
 msgid "help topic list"
 msgstr "lista de temas de ayuda"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:184
 msgid "Type the argument here and confirm with the enter key on your keyboard"
 msgstr "Teclee aquí el argumento y presione la tecla enter de su teclado"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:192
 msgid "The search function allows you to find entries in the current topic"
 msgstr "La función de búsqueda le permite encontrar entradas del tema actual"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:195
 msgid "Ignore case"
 msgstr "Ignorar mayúsculas"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:196
 msgid "Ignore case distinctions: characters with different case will match."
 msgstr "Ignorar mayúsculas: las letras mayúsculas y minúsculas serán iguales."
 
-#: ../../vdms_dialogs/ffmpeg_help.py:206
 msgid "FFmpeg help topics"
 msgstr "Temas de ayuda de FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:254
 msgid ""
 "This is a multifunctional search tool useful for local help searches\n"
 "on multiple FFmpeg topics and options. The search control, to\n"
@@ -342,8 +257,6 @@ msgstr ""
 "es seguro que su versión de FFmpeg es muy antigua o no tenga configuradas\n"
 "esas características."
 
-#: ../../vdms_dialogs/ffmpeg_help.py:320 ../../vdms_dialogs/ffmpeg_help.py:345
-#: ../../vdms_dialogs/ffmpeg_help.py:371
 msgid ""
 "\n"
 "  ..Nothing available"
@@ -351,7 +264,6 @@ msgstr ""
 "\n"
 "  ..Nada disponible"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:391
 msgid ""
 "\n"
 "  ..Not found"
@@ -359,217 +271,121 @@ msgstr ""
 "\n"
 "...No encontrado"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:91
 msgid "Before"
 msgstr "Antes"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:97
 msgid "After"
 msgstr "Despues"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:103
-#: ../../vdms_dialogs/filter_crop.py:239
 msgid "Search for a specific frame"
 msgstr "Buscar un cuadro especifico"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:117
-#: ../../vdms_dialogs/filter_crop.py:253
 msgid "Load"
 msgstr "Cargar"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:120
 msgid "Color EQ"
 msgstr "Color EQ"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:126
 msgid "Contrast:"
 msgstr "Contraste:"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:134
-#: ../../vdms_dialogs/filter_colorcorrection.py:148
 msgid "-100 to +100, default value 0"
 msgstr "-100 a +100, valor por defecto 0"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:139
 msgid "Brightness:"
 msgstr "Brillo:"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:158
 msgid "Saturation:"
 msgstr "Saturación:"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:166
 msgid "0 to 300, default value 100"
 msgstr "0 a 300, valor por defecto 100"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:170
 msgid "Gamma:"
 msgstr "Gamma:"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:179
 msgid "0 to 100, default value 10"
 msgstr "0 a 100, valor por defecto 10"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:187
-#: ../../vdms_dialogs/filter_crop.py:306
-#: ../../vdms_dialogs/filter_deinterlace.py:209
-#: ../../vdms_dialogs/filter_denoisers.py:110
-#: ../../vdms_dialogs/filter_scale.py:210 ../../vdms_dialogs/filter_stab.py:316
-#: ../../vdms_dialogs/filter_transpose.py:105
-#: ../../vdms_miniframes/timeline.py:262 ../../vdms_miniframes/timeline.py:281
 msgid "Reset"
 msgstr "Reiniciar"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:207
 msgid "Color Correction EQ Tool"
 msgstr "Corrección de EQ Color"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:343
-#: ../../vdms_dialogs/filter_colorcorrection.py:383
-#: ../../vdms_dialogs/filter_colorcorrection.py:390
-#: ../../vdms_dialogs/filter_crop.py:417 ../../vdms_dialogs/filter_scale.py:287
-#: ../../vdms_dialogs/filter_scale.py:394 ../../vdms_dialogs/filter_stab.py:473
-#: ../../vdms_dialogs/filter_stab.py:483 ../../vdms_dialogs/filter_stab.py:494
-#: ../../vdms_dialogs/filter_transpose.py:182
-#: ../../vdms_dialogs/mediainfo.py:245 ../../vdms_dialogs/mediainfo.py:265
-#: ../../vdms_dialogs/mediainfo.py:285 ../../vdms_dialogs/mediainfo.py:305
-#: ../../vdms_dialogs/setting_profiles.py:281
-#: ../../vdms_dialogs/setting_profiles.py:289 ../../vdms_io/checkup.py:45
-#: ../../vdms_io/checkup.py:93 ../../vdms_io/io_tools.py:144
-#: ../../vdms_main/main_frame.py:904 ../../vdms_main/main_frame.py:939
-#: ../../vdms_main/main_frame.py:961 ../../vdms_main/main_frame.py:979
-#: ../../vdms_main/main_frame.py:999
-#: ../../vdms_panels/audio_encoders/acodecs.py:510
-#: ../../vdms_panels/audio_encoders/acodecs.py:800
-#: ../../vdms_panels/concatenate.py:186
-#: ../../vdms_panels/long_processing_task.py:60
-#: ../../vdms_panels/presets_manager.py:426
-#: ../../vdms_panels/presets_manager.py:490
-#: ../../vdms_panels/presets_manager.py:560
-#: ../../vdms_panels/presets_manager.py:599
-#: ../../vdms_panels/presets_manager.py:619
-#: ../../vdms_panels/presets_manager.py:657
-#: ../../vdms_panels/presets_manager.py:701
-#: ../../vdms_panels/presets_manager.py:714
-#: ../../vdms_panels/presets_manager.py:721
-#: ../../vdms_panels/presets_manager.py:756
-#: ../../vdms_panels/presets_manager.py:785
-#: ../../vdms_panels/presets_manager.py:791
-#: ../../vdms_panels/sequence_to_video.py:467
-#: ../../vdms_panels/sequence_to_video.py:473
-#: ../../vdms_panels/sequence_to_video.py:561
-#: ../../vdms_panels/sequence_to_video.py:571
-#: ../../vdms_panels/sequence_to_video.py:588
-#: ../../vdms_panels/sequence_to_video.py:596
-#: ../../vdms_panels/sequence_to_video.py:602
-#: ../../vdms_panels/sequence_to_video.py:643
-#: ../../vdms_panels/sequence_to_video.py:689
-#: ../../vdms_panels/video_to_sequence.py:512
-#: ../../vdms_panels/video_to_sequence.py:583
-#: ../../vdms_threads/ffplay_file.py:43
-#: ../../vdms_utils/presets_manager_utils.py:86
-#: ../../vdms_utils/presets_manager_utils.py:95
-#: ../../vdms_utils/queue_utils.py:68 ../../vdms_utils/queue_utils.py:82
-#: ../../vdms_utils/queue_utils.py:95
 msgid "Videomass - Error!"
 msgstr "Videomass - ¡Error!"
 
-#: ../../vdms_dialogs/filter_crop.py:228 ../../vdms_dialogs/filter_scale.py:109
 #, python-brace-format
 msgid "Source size: {0} x {1} pixels"
 msgstr "Tamaño de la fuente: {0} x {1} pixeles"
 
-#: ../../vdms_dialogs/filter_crop.py:236
 msgid "Crop color"
 msgstr "Color de Recorte"
 
-#: ../../vdms_dialogs/filter_crop.py:256
 msgid "Cropping area selection "
 msgstr "Recortar area seleccionada "
 
-#: ../../vdms_dialogs/filter_crop.py:261 ../../vdms_dialogs/filter_scale.py:121
 msgid "Height"
 msgstr "Altura"
 
-#: ../../vdms_dialogs/filter_crop.py:281
 msgid "Center"
 msgstr "Centro"
 
-#: ../../vdms_dialogs/filter_crop.py:292 ../../vdms_dialogs/filter_scale.py:121
 msgid "Width"
 msgstr "Ancho"
 
-#: ../../vdms_dialogs/filter_crop.py:334
 msgid "Crop Tool"
 msgstr "Herramienta de Recorte"
 
-#: ../../vdms_dialogs/filter_crop.py:335
 msgid "Choose the color to draw the cropping area"
 msgstr "Seleccione el color para dibujar el área de recorte"
 
-#: ../../vdms_dialogs/filter_crop.py:337
 msgid "Crop to width"
 msgstr "Recortar ancho"
 
-#: ../../vdms_dialogs/filter_crop.py:338
 msgid "Move vertically (set to -1 to center the vertical axis)"
 msgstr "Mover verticalmente ( -1 para centrar el eje vertical)"
 
-#: ../../vdms_dialogs/filter_crop.py:340
 msgid "Move horizontally (set to -1 to center the horizontal axis)"
 msgstr "Mover horizontalmente (-1 para centrar el eje horizontal)"
 
-#: ../../vdms_dialogs/filter_crop.py:342
 msgid "Crop to height"
 msgstr "Recortar altura"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:56
 msgid "Advanced Options"
 msgstr "Opciones Avanzadas"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:57
-#: ../../vdms_panels/av_conversions.py:351
 msgid "Deinterlace"
 msgstr "Desentrelazado"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:59
 msgid "Interlace"
 msgstr "Entrelazado"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:63
 msgid "Deinterlaces with w3fdif filter"
 msgstr "Desentrelazar con el filtro w3fdif"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:77
 msgid "Deinterlaces with yadif filter"
 msgstr "Desentrelazar con el filtro yadif"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:101
 msgid "Interlaces with interlace filter"
 msgstr "Entrelazar con el filtro entrelazar"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:118
 msgid "Deinterlacing and Interlacing"
 msgstr "Desenetrelazar y entrelazar"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:144
 msgid "Deinterlace the input video with `w3fdif` filter"
 msgstr "Desentrelazar el video de entrada con el filtro `w3fdif`"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:146
 msgid "Set the interlacing filter coefficients."
 msgstr "Fijar los coeficientes del filtro de entrelazado."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:148
-#: ../../vdms_dialogs/filter_deinterlace.py:158
 msgid "Specify which frames to deinterlace."
 msgstr "Especificar los cuadros a desentrelazar."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:150
 msgid "Deinterlace the input video with `yadif` filter. Using FFmpeg, this is the best and fastest choice"
 msgstr "Desentrelazar el video de entrada con el filtro `yadif` . Utilizar FFmpeg, es la mejor opción y la más rápida"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:153
 msgid ""
 "mode\n"
 "The interlacing mode to adopt."
@@ -577,7 +393,6 @@ msgstr ""
 "modo\n"
 "El modo de entrelazado."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:155
 msgid ""
 "parity\n"
 "The picture field parity assumed for the input interlaced video."
@@ -585,11 +400,9 @@ msgstr ""
 "paridad\n"
 "La paridad del campo imagen asumida por el video entrelazado de entrada."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:160
 msgid "Simple interlacing filter from progressive contents."
 msgstr "Filtro de entrelazado simple proveniente de contenidos progresivos."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:162
 msgid ""
 "scan:\n"
 "determines whether the interlaced frame is taken from the even (tff - default) or odd (bff) lines of the progressive frame."
@@ -597,7 +410,6 @@ msgstr ""
 "scan:\n"
 "determina si el cuadro entrelazado proviene de las lineas pares (tff - predeterminado) o impares (bff) del cuadro progresivo."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:166
 msgid ""
 "lowpass:\n"
 "Enable (default) or disable the vertical lowpass filter to avoid twitter interlacing and reduce moire patterns.\n"
@@ -607,31 +419,24 @@ msgstr ""
 "Habilita (predeterminado) o deshabilita el filtro vertical pasabajos para evitar el entrelazado twitter y reducir  el efecto Moiré.\n"
 "No esta configurado valor predeterminado."
 
-#: ../../vdms_dialogs/filter_denoisers.py:56
 msgid "Denoiser Filters"
 msgstr "Filtros ReduceRuido"
 
-#: ../../vdms_dialogs/filter_denoisers.py:60
 msgid "Enable nlmeans denoiser"
 msgstr "Habilita filtro nlmeans"
 
-#: ../../vdms_dialogs/filter_denoisers.py:73
 msgid "nlmeans options"
 msgstr "opciones de nlmeans"
 
-#: ../../vdms_dialogs/filter_denoisers.py:82
 msgid "Enable hqdn3d denoiser"
 msgstr "Habilitar filtro hqdn3d"
 
-#: ../../vdms_dialogs/filter_denoisers.py:91
 msgid "hqdn3d options"
 msgstr "opciones de hqdn3d"
 
-#: ../../vdms_dialogs/filter_denoisers.py:116
 msgid "Denoiser Tool"
 msgstr "Reduce Ruido"
 
-#: ../../vdms_dialogs/filter_denoisers.py:117
 msgid ""
 "nlmeans:\n"
 "Denoise frames using Non-Local Means algorithm is capable of restoring video sequences, even with strong noise. It is ideal for enhancing the quality of old VHS tapes."
@@ -639,7 +444,6 @@ msgstr ""
 "nlmeans:\n"
 "Mejora los cuadros usando el algoritmo  Medios No-Locales, es capaz de restaurar incluso secuencias de video con fuerte ruido. Es ideal para mejorar la calidad de las antiguas cintas VHS."
 
-#: ../../vdms_dialogs/filter_denoisers.py:122
 msgid ""
 "hqdn3d:\n"
 "This is a high precision/quality 3d denoise filter. It aims to reduce image noise, producing smooth images and making still images really still. It should enhance compressibility."
@@ -647,65 +451,48 @@ msgstr ""
 "hqdn3d:\n"
 "Estes es un filtro reductor de alta precisión/calidad 3d . Su objetivo es reducir el ruido de la imagen, produciendo imágenes suaves y hacer que las imágenes fijas sean realmente fijas. Debe mejorar la compresibilidad."
 
-#: ../../vdms_dialogs/filter_scale.py:81
 msgid "View result"
 msgstr "Ver resultado"
 
-#: ../../vdms_dialogs/filter_scale.py:85
 msgid "New size in pixels"
 msgstr "Nuevo tamaño en pixeles"
 
-#: ../../vdms_dialogs/filter_scale.py:89
 msgid "Width:"
 msgstr "Ancho:"
 
-#: ../../vdms_dialogs/filter_scale.py:99
 msgid "Height:"
 msgstr "Alto:"
 
-#: ../../vdms_dialogs/filter_scale.py:115
 msgid "Constrain proportions (keep aspect ratio)"
 msgstr "Restringir proporciones (mantener relación de aspecto)"
 
-#: ../../vdms_dialogs/filter_scale.py:120
 msgid "Which dimension to adjust?"
 msgstr "¿Que dimensión se ajustara?"
 
-#: ../../vdms_dialogs/filter_scale.py:129
 msgid "Aspect Ratio"
 msgstr "Relación de Aspecto"
 
-#: ../../vdms_dialogs/filter_scale.py:132
 msgid "Setdar filter (display aspect ratio) example 16/9, 4/3 "
 msgstr "Filtro Setdar  (relación de aspecto de pantalla) ejemplo 16/9, 4/3 "
 
-#: ../../vdms_dialogs/filter_scale.py:137
-#: ../../vdms_dialogs/filter_scale.py:171
 msgid "Numerator"
 msgstr "Numerador"
 
-#: ../../vdms_dialogs/filter_scale.py:162
-#: ../../vdms_dialogs/filter_scale.py:196
 msgid "Denominator"
 msgstr "Denominador"
 
-#: ../../vdms_dialogs/filter_scale.py:166
 msgid "Setsar filter (sample aspect ratio) example 1/1"
 msgstr "Filtro Setsar  (relación de aspecto de la muestra) ejemplo 1/1"
 
-#: ../../vdms_dialogs/filter_scale.py:217
 msgid "Resize Tool"
 msgstr "Redimensionar"
 
-#: ../../vdms_dialogs/filter_scale.py:218
 msgid "Scale filter, set to 0 to disable"
 msgstr "Filtro Escala, poner a 0 para deshabilitar"
 
-#: ../../vdms_dialogs/filter_scale.py:221
 msgid "Display Aspect Ratio. Set to 0 to disable"
 msgstr "Relación de Aspecto de Pantalla. Poner a 0 para deshabilitar"
 
-#: ../../vdms_dialogs/filter_scale.py:224
 msgid ""
 "Sample (aka Pixel) Aspect Ratio.\n"
 "Set to 0 to disable"
@@ -713,7 +500,6 @@ msgstr ""
 "Relación de Aspecto de Muestra (Pixel) .\n"
 "Poner a 0 para deshabilitar"
 
-#: ../../vdms_dialogs/filter_scale.py:366
 msgid ""
 "If you want to keep the aspect ratio, select \"Constrain proportions\" below and\n"
 "specify only one dimension, either width or height, and set the other dimension\n"
@@ -723,156 +509,121 @@ msgstr ""
 "especifique sólo una dimensión, ya sea la anchura o la altura, y fije la otra dimensión\n"
 "a -1 o -2 (algunos códecs requieren -2, por lo que deberá hacer algunas pruebas primero)."
 
-#: ../../vdms_dialogs/filter_stab.py:81
 msgid "Enable stabilizer"
 msgstr "Habilitar estabilizador"
 
-#: ../../vdms_dialogs/filter_stab.py:83
 msgid "Create a side-by-side comparison video"
 msgstr "Crear un video de comparación lado a lado"
 
-#: ../../vdms_dialogs/filter_stab.py:88
 msgid "Create a snapshot"
 msgstr "Crear nueva instantanea"
 
-#: ../../vdms_dialogs/filter_stab.py:106
-#: ../../vdms_panels/audio_encoders/acodecs.py:167
 msgid "Preview"
 msgstr "Previsualizar"
 
-#: ../../vdms_dialogs/filter_stab.py:109
 msgid "Duration seconds:"
 msgstr "Duración en segundos:"
 
-#: ../../vdms_dialogs/filter_stab.py:118
 msgid "Video Detect"
 msgstr "Detectar Video"
 
-#: ../../vdms_dialogs/filter_stab.py:176
 msgid "[TRIPOD] Enable tripod mode if checked"
 msgstr "[TRIPOD] Al marcar se habilita el modo tripie"
 
-#: ../../vdms_dialogs/filter_stab.py:183
 msgid "Video transform"
 msgstr "Transformación de video"
 
-#: ../../vdms_dialogs/filter_stab.py:202
 msgid "[OPTALGO] optimization algorithm"
 msgstr "[OPTALGO] algoritmo de optimización"
 
-#: ../../vdms_dialogs/filter_stab.py:224
 msgid "[CROP] Specify how to deal with borders at movement compensation"
 msgstr "[CROP] Especifica como lidiar con los bordes al compensar el movimiento"
 
-#: ../../vdms_dialogs/filter_stab.py:231
 msgid "[INVERT] Invert transforms if checked"
 msgstr "[INVERT] Al marcar, invierte las transformaciones"
 
-#: ../../vdms_dialogs/filter_stab.py:234
 msgid "[RELATIVE] Consider transforms as relative to previous frame if checked, absolute if unchecked"
 msgstr "[RELATIVE] Marcado considera las transformaciones como relativas al cuadro previo, desmarcado como absolutas"
 
-#: ../../vdms_dialogs/filter_stab.py:279
 msgid "Specify type of interpolation"
 msgstr "Especificar tipo de interpolación"
 
-#: ../../vdms_dialogs/filter_stab.py:287
 msgid "[TRIPOD2] virtual tripod mode, equivalent to relative=unchecked:smoothing=0"
 msgstr "[TRIPOD2] modo de tripie virtual, equivalente a relative=desmarcado:smoothing=0"
 
-#: ../../vdms_dialogs/filter_stab.py:294
 msgid "Unsharp filter:"
 msgstr "Filtro desenfoque:"
 
-#: ../../vdms_dialogs/filter_stab.py:323
 msgid "Seek to a position on the video."
 msgstr "Ir a una posición del video."
 
-#: ../../vdms_dialogs/filter_stab.py:325
 msgid "Make a snapshot of the video with the settings made."
 msgstr "Hacer instantánea del video con las configuraciones usadas."
 
-#: ../../vdms_dialogs/filter_stab.py:327
 msgid "Set the snapshot duration from 3 to 15 seconds from the seek position, default is 5 seconds."
 msgstr "Fijar duración de instantánea  de 3 a 15 segundos,  5 es lo predeterminado."
 
-#: ../../vdms_dialogs/filter_stab.py:331
 msgid "Set how shaky the video is and how quick the camera is. A value of 1 means little shakiness, a value of 10 means strong shakiness. Default value is 5."
 msgstr "Fija el grado de temblor del vídeo y la rapidez de la cámara. Un valor de 1 significa poca vibración, un valor de 10 significa mucha vibración. El valor predeterminado es 5."
 
-#: ../../vdms_dialogs/filter_stab.py:335
 msgid "Set the accuracy of the detection process. A value of 1 means low accuracy, a value of 15 means high accuracy. Default value is 15."
 msgstr "Fija la precisión del proceso de detección. Un valor de 1 significa poca precisión, un valor de 15(predeterminado) significa alta precisión."
 
-#: ../../vdms_dialogs/filter_stab.py:339
 msgid "Set stepsize of the search process. The region around minimum is scanned with 1 pixel resolution. Default value is 6."
 msgstr "Fija el paso del proceso de búsqueda. La resolución mínima de la región es de 1 pixel. Valor predeterminado 6."
 
-#: ../../vdms_dialogs/filter_stab.py:343
 msgid "Set minimum contrast. Below this value a local measurement field is discarded. The range is 0-1. Default value is 0.25."
 msgstr "Fija el contraste mínimo. Bajo este valor la medida del campo local es descartada. El rango es 0-1. Valor predeterminado 0.25."
 
-#: ../../vdms_dialogs/filter_stab.py:346
 msgid "Set reference frame number for tripod mode. If enabled, the motion of the frames is compared to a reference frame in the filtered stream, identified by the specified number. The idea is to compensate all movements in a more-or-less static scene and keep the camera view absolutely still. The frames are counted starting from 1."
 msgstr "Fija el numero de cuadro de referencia para el modo tripod. Si se habilita, el movimiento de los cuadros se compara con un cuadro de referencia en el flujo filtrado, identificado por el numero especificado. The idea is to compensate all movements in a more-or-less static scene and keep the camera view absolutely still. The frames are counted starting from 1."
 
-#: ../../vdms_dialogs/filter_stab.py:355
-msgid "Set the number of frames (value*2 + 1) used for lowpass filtering the camera movements. Default value is 15. For example a number of 10 means that 21 frames are used (10 in the past and 10 in the future) to smoothen the motion in the video. A larger value leads to a smoother video, but limits the acceleration of the camera (pan/tilt movements). 0 is a special case where a static camera is simulated."
-msgstr "Fijar el numero de cuadros (valor*2 + 1) usados por pasabajos para filtrar movimientos de cámara. Valor predeterminado 15. Por ejemplo un valor de 10 significa que  se utilizan 21 cuadros (10 en el pasado 10 en el futuro) para suavizar el movimiento en el video. Un valor mayor produce un vídeo más suave, pero limita la aceleración de la cámara (movimientos de giro/inclinación). 0 es un caso especial en el que se simula una cámara estática."
+msgid ""
+"Set the number of frames (value*2 + 1) used for lowpass filtering the camera movements. Default value is 15. For example a number of 10 means that 21 frames are used (10 in the past and 10 in the future) to smoothen the motion in the video. A larger value leads to a smoother video, but limits the acceleration of the camera (pan/tilt movements). 0 is a special case where a static camera is "
+"simulated."
+msgstr ""
+"Fijar el numero de cuadros (valor*2 + 1) usados por pasabajos para filtrar movimientos de cámara. Valor predeterminado 15. Por ejemplo un valor de 10 significa que  se utilizan 21 cuadros (10 en el pasado 10 en el futuro) para suavizar el movimiento en el video. Un valor mayor produce un vídeo más suave, pero limita la aceleración de la cámara (movimientos de giro/inclinación). 0 es un caso "
+"especial en el que se simula una cámara estática."
 
-#: ../../vdms_dialogs/filter_stab.py:363
 msgid "Set the camera path optimization algorithm. Values are: `gauss`: gaussian kernel low-pass filter on camera motion (default), and `avg`: averaging on transformations"
 msgstr "Fija el algoritmo de optimización para la trayectoria de camera. Valores: `gauss`: filtro pasabajos núcleo gaussiano para el movimiento de cámara (predeterminado), y `avg`: promedio de transformaciones"
 
-#: ../../vdms_dialogs/filter_stab.py:367
 msgid "Set maximal angle in radians (degree*PI/180) to rotate frames. Default value is -1, meaning no limit."
 msgstr "Fija angulo máximo en radianes (grados*PI/180) para rotar los cuadros. Valor predeterminado -1, significa sin limites."
 
-#: ../../vdms_dialogs/filter_stab.py:370
 msgid "Specify how to deal with borders that may be visible due to movement compensation. Values are: `keep` keep image information from previous frame (default), `black` fill the border black"
 msgstr "Especifica como lidiar con los bordes visibles al compensar el movimiento. Valores: `mantener` mantener la información de la imagen del cuadro previo (predeterminado), `negro` rellenar lo negro en el borde"
 
-#: ../../vdms_dialogs/filter_stab.py:375
 msgid "Invert transforms if checked. Default is unchecked."
 msgstr "Si se marca Invierte transformaciones. Desmarcado es lo predeterminado."
 
-#: ../../vdms_dialogs/filter_stab.py:377
 msgid "Consider transforms as relative to previous frame if checked, absolute if unchecked. Default is checked."
 msgstr "Marcado considera las transformaciones como relativas al cuadro previo, desmarcado como absolutas. Desmarcado es lo predeterminado."
 
-#: ../../vdms_dialogs/filter_stab.py:380
 msgid "Set percentage to zoom. A positive value will result in a zoom-in effect, a negative value in a zoom-out effect. Default value is 0 (no zoom)."
 msgstr "Fija el porcentaje de aumento. Un valor positivo produce efecto de acercamiento, un valor negativo de alejamiento. Valor predeterminado 0 (sin aumento)."
 
-#: ../../vdms_dialogs/filter_stab.py:384
 msgid "Set optimal zooming to avoid borders. Accepted values are: `0` disabled, `1` optimal static zoom value is determined (only very strong movements will lead to visible borders) (default), `2` optimal adaptive zoom value is determined (no borders will be visible), see zoomspeed. Note that the value given at zoom is added to the one calculated here."
 msgstr "Fija el aumento optimo para evitar bordes. Valores aceptados: `0` desactivado, `1` se determina el nivel de aumento optimo (solo los movimientos muy fuertes producen bordes visibles) (predeterminado), `2` se determina el nivel de aumento optimo adaptativo (no habrá bordes visibles), vea zoomspeed. Note que el valor dado en aumento se añade al calculado aquí."
 
-#: ../../vdms_dialogs/filter_stab.py:391
 msgid "Set percent to zoom maximally each frame (enabled when optzoom is set to 2). Range is from 0 to 5, default value is 0.25."
 msgstr "Fija el porcentaje de aumento máximo en cada cuadro (habilitado cuando optzoom se fija a 2). Rango de 0 to 5, valor predeterminado 0.25."
 
-#: ../../vdms_dialogs/filter_stab.py:395
 msgid "Specify type of interpolation. Available values are: `no` no interpolation, `linear` linear only horizontal, `bilinear` linear in both directions (default), `bicubic` cubic in both directions (slow)"
 msgstr "Especifica tipo de interpolación. Valores disponibles: `no` = sin interpolación, `linear` lineal solo horizontal, `bilinear` lineal en ambas direcciones (predeterminado), `bicubic’`cubica en ambas direcciones (lenta)"
 
-#: ../../vdms_dialogs/filter_stab.py:400
 msgid "Enable virtual tripod mode if checked, which is equivalent to relative=0:smoothing=0. Default is unchecked. Use also tripod option of vidstabdetect."
 msgstr "Habilita el modo de tripie virtual, equivalente a relative=0:smoothing=0. Desmarcado por omisión. Use junto a la opción tripod de vidstabdetect."
 
-#: ../../vdms_dialogs/filter_stab.py:405
 msgid "Sharpen or blur the input video. Note the use of the unsharp filter which is always recommended."
 msgstr "Enfoca o desenfoca el vídeo de entrada.. Se recomienda siempre usar el filtro de desenfoque."
 
-#: ../../vdms_dialogs/filter_stab.py:409
 msgid "Video Stabilizer Tool"
 msgstr "Herramienta Estabilizador de video"
 
-#: ../../vdms_dialogs/filter_stab.py:541 ../../vdms_io/io_tools.py:73
 msgid "Videomass - Loading..."
 msgstr "Videomass - Cargando..."
 
-#: ../../vdms_dialogs/filter_stab.py:542
 msgid ""
 "Please wait,\n"
 "This process will take a few seconds."
@@ -880,135 +631,96 @@ msgstr ""
 "Por favor espere,\n"
 "Este proceso tomar unos segundos."
 
-#: ../../vdms_dialogs/filter_transpose.py:80
-#: ../../vdms_dialogs/filter_transpose.py:293
 msgid "Default position"
 msgstr "Posición predeterminada"
 
-#: ../../vdms_dialogs/filter_transpose.py:86
 msgid "Rotation setting"
 msgstr "Rotación"
 
-#: ../../vdms_dialogs/filter_transpose.py:94
 msgid "90° (left)"
 msgstr "90° (izq)"
 
-#: ../../vdms_dialogs/filter_transpose.py:96
 msgid "90° (right)"
 msgstr "90° (der)"
 
-#: ../../vdms_dialogs/filter_transpose.py:100
 msgid "180°"
 msgstr "180°"
 
-#: ../../vdms_dialogs/filter_transpose.py:115
 msgid "Transpose Tool"
 msgstr "Herramienta Transposición"
 
-#: ../../vdms_dialogs/filter_transpose.py:229
 msgid "Rotate 90 degrees right"
 msgstr "Rotar 90 grados a la derecha"
 
-#: ../../vdms_dialogs/filter_transpose.py:251
 msgid "Rotate 180 degrees"
 msgstr "Rotar 180 grados"
 
-#: ../../vdms_dialogs/filter_transpose.py:272
 msgid "Rotate 90 degrees left"
 msgstr "Rotar 90 grados a la izquierda"
 
-#: ../../vdms_dialogs/mediainfo.py:82
 msgid "Format"
 msgstr "Formato"
 
-#: ../../vdms_dialogs/mediainfo.py:96
 msgid "Video Stream"
 msgstr "Flujo de Video"
 
-#: ../../vdms_dialogs/mediainfo.py:109
 msgid "Audio Streams"
 msgstr "Flujos de Audio"
 
-#: ../../vdms_dialogs/mediainfo.py:122
 msgid "Subtitle Streams"
 msgstr "Flujos de Subtítulos"
 
-#: ../../vdms_dialogs/mediainfo.py:126
 msgid "Copy to clipboard"
 msgstr "Copiar al portapapeles"
 
-#: ../../vdms_dialogs/mediainfo.py:137
 msgid "FILE SELECTION"
 msgstr "SELECCIÓN DE ARCHIVO"
 
-#: ../../vdms_dialogs/mediainfo.py:139 ../../vdms_dialogs/mediainfo.py:142
-#: ../../vdms_dialogs/mediainfo.py:145 ../../vdms_dialogs/mediainfo.py:148
-#: ../../vdms_main/main_frame.py:1318
 msgid "Properties"
 msgstr "Propiedades"
 
-#: ../../vdms_dialogs/mediainfo.py:140 ../../vdms_dialogs/mediainfo.py:143
-#: ../../vdms_dialogs/mediainfo.py:146 ../../vdms_dialogs/mediainfo.py:149
 msgid "Values"
 msgstr "Valores"
 
-#: ../../vdms_dialogs/mediainfo.py:152
 msgid "Streams Properties"
 msgstr "Propiedades de los Flujos"
 
-#: ../../vdms_dialogs/mediainfo.py:244
 msgid "Unable to open the clipboard on Format tab"
 msgstr "Np se puede abrir el portapapeles en la pestaña Formato"
 
-#: ../../vdms_dialogs/mediainfo.py:263
 msgid "Unable to open the clipboard on Video Streams tab"
 msgstr "Np se puede abrir el portapapeles en la pestaña Flujos de Video"
 
-#: ../../vdms_dialogs/mediainfo.py:283
 msgid "Unable to open the clipboard on Audio Streams tab"
 msgstr "Np se puede abrir el portapapeles en la pestaña Flujos de Audio"
 
-#: ../../vdms_dialogs/mediainfo.py:303
 msgid "Unable to open the clipboard on Subtitle Streams tab"
 msgstr "Np se puede abrir el portapapeles en la pestaña Flujos de Subtitulos"
 
-#: ../../vdms_dialogs/preferences.py:90
 msgid "Where do you prefer to save your transcodes?"
 msgstr "¿Donde prefiere guardar sus resultados?"
 
-#: ../../vdms_dialogs/preferences.py:101 ../../vdms_dialogs/preferences.py:128
-#: ../../vdms_dialogs/preferences.py:149 ../../vdms_dialogs/preferences.py:161
-#: ../../vdms_dialogs/preferences.py:173 ../../vdms_panels/filedrop.py:284
 msgid "Change"
 msgstr "Cambiar"
 
-#: ../../vdms_dialogs/preferences.py:103
-#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:602
-#: ../../vdms_panels/presets_manager.py:1050
 msgid "Same destination paths as source files"
 msgstr "Misma carpeta destino que archivos fuente"
 
-#: ../../vdms_dialogs/preferences.py:108
 msgid "Assign optional suffix to destination file names:"
 msgstr "Asignar un sufijo opcional a los archivos de salida:"
 
-#: ../../vdms_dialogs/preferences.py:114
 msgid "File removal preferences"
 msgstr "Preferencias de borrado de archivo"
 
-#: ../../vdms_dialogs/preferences.py:118
 msgid "Trash the source files after successful encoding"
 msgstr "Desechar archivos fuente después de codificación exitosa"
 
-#: ../../vdms_dialogs/preferences.py:131
 msgid "File Preferences"
 msgstr "Preferencias de Archivo"
 
-#: ../../vdms_dialogs/preferences.py:138
 msgid "Location of executables"
 msgstr "Trayectoria de ejecutables"
 
-#: ../../vdms_dialogs/preferences.py:140
 msgid ""
 "FFmpeg can be built by enabling/disabling its options and this depends on your needs.\n"
 "For some use cases it is possible to provide a custom build of FFmpeg where you can specify\n"
@@ -1018,107 +730,81 @@ msgstr ""
 "En algunos caso es posible proporcionar una compilación personalizada de  FFmpeg, la cual puede\n"
 "especificar en esta pestaña."
 
-#: ../../vdms_dialogs/preferences.py:147
 msgid "Enable a custom location to run FFmpeg"
 msgstr "Habilitar FFmpeg en otra trayectoria"
 
-#: ../../vdms_dialogs/preferences.py:159
 msgid "Enable a custom location to run FFprobe"
 msgstr "Habilitar FFprobe en otra trayectoria"
 
-#: ../../vdms_dialogs/preferences.py:171
 msgid "Enable a custom location to run FFplay"
 msgstr "Habilitar FFplay en otra trayectoria"
 
-#: ../../vdms_dialogs/preferences.py:183
 msgid "FFmpeg"
 msgstr "FFmpeg"
 
-#: ../../vdms_dialogs/preferences.py:189
 msgid "Look and Feel (requires application restart)"
 msgstr "Apariencia de la aplicación (requiere reiniciar la aplicación)"
 
-#: ../../vdms_dialogs/preferences.py:194
 msgid "Icon themes"
 msgstr "Temas de iconos"
 
-#: ../../vdms_dialogs/preferences.py:208
 msgid "At the top of window (default)"
 msgstr "Parte superior de la ventana (predeterminado)"
 
-#: ../../vdms_dialogs/preferences.py:209
 msgid "At the bottom of window"
 msgstr "Parte inferior de la ventana"
 
-#: ../../vdms_dialogs/preferences.py:210
 msgid "At the right of window"
 msgstr "A la derecha de la ventana"
 
-#: ../../vdms_dialogs/preferences.py:211
 msgid "At the left of window"
 msgstr "A la izquierda de la ventana"
 
-#: ../../vdms_dialogs/preferences.py:213
 msgid "Place the toolbar"
 msgstr "Situar la barra de herramientas"
 
-#: ../../vdms_dialogs/preferences.py:222
 msgid "Toolbar's icons size:"
 msgstr "Tamaño de iconos:"
 
-#: ../../vdms_dialogs/preferences.py:236
 msgid "Application Language (requires application restart)"
 msgstr "Idioma de la aplicación (requiere reiniciar la aplicación)"
 
-#: ../../vdms_dialogs/preferences.py:248
 msgid "Look and Language"
 msgstr "Apariencia e Idioma"
 
-#: ../../vdms_dialogs/preferences.py:254
 msgid "Upon exiting the application"
 msgstr "Al salir de la aplicación"
 
-#: ../../vdms_dialogs/preferences.py:259
 msgid "Always ask me to confirm"
 msgstr "Siempre pedir confirmación"
 
-#: ../../vdms_dialogs/preferences.py:261
 msgid "Clean the log files"
 msgstr "Limpiar los archivos de registro"
 
-#: ../../vdms_dialogs/preferences.py:264
 msgid "Remove cached files"
 msgstr "Eliminar archivos cache"
 
-#: ../../vdms_dialogs/preferences.py:268
 msgid "On operations completion"
 msgstr "Al completar operación"
 
-#: ../../vdms_dialogs/preferences.py:271
 msgid "These settings will remain active until the application is closed, If necessary, remember to reactivate them."
 msgstr "Estas configuraciones permanecen activas hasta que se cierre la aplicación, De ser necesario recuerde reactivarlas."
 
-#: ../../vdms_dialogs/preferences.py:276
 msgid "Exit the application"
 msgstr "Salir de la aplicación"
 
-#: ../../vdms_dialogs/preferences.py:279
 msgid "Shutdown the system"
 msgstr "Apagar el sistema"
 
-#: ../../vdms_dialogs/preferences.py:283
 msgid "SUDO password:"
 msgstr "contraseña para sudo:"
 
-#: ../../vdms_dialogs/preferences.py:292
 msgid "Exit and Shutdown"
 msgstr "Salir y Apagar"
 
-#: ../../vdms_dialogs/preferences.py:298
 msgid "Specify the character encoding format"
 msgstr "Especificar formato de caracteres"
 
-#: ../../vdms_dialogs/preferences.py:301
 msgid ""
 "Although UTF-8 is the default and most widely used standard encoding format, it is not the only encoding format available.\n"
 "Some file metadata may still contain non-UTF-8 character encodings resulting in the error \"'utf-8' codec can't decode bytes...\".\n"
@@ -1128,31 +814,24 @@ msgstr ""
 "Algunos metadatos aun pueden contener caracteres distintos a los de UTF-8, produciendo el error \"'utf-8' codec can't decode bytes...\".\n"
 "Si sabe el formato de caracteres usado por el archivo, puede intentar especificarlo aquí, ej. ISO 8859-1, ISO 8859-16, etc."
 
-#: ../../vdms_dialogs/preferences.py:311
 msgid "Character encoding:"
 msgstr "Formato de caracteres:"
 
-#: ../../vdms_dialogs/preferences.py:320
 msgid "Default application directories"
 msgstr "Carpetas predeterminadas de la aplicación"
 
-#: ../../vdms_dialogs/preferences.py:324
 msgid "Configuration directory"
 msgstr "Configuración de carpeta"
 
-#: ../../vdms_dialogs/preferences.py:337
 msgid "Cache directory"
 msgstr "Carpeta para Cache"
 
-#: ../../vdms_dialogs/preferences.py:349
 msgid "Log directory"
 msgstr "Carpeta de registros"
 
-#: ../../vdms_dialogs/preferences.py:363
 msgid "Advanced"
 msgstr "Avanzadas"
 
-#: ../../vdms_dialogs/preferences.py:369
 msgid ""
 "The following settings affect output messages and the log messages during transcoding processes.\n"
 "Be careful, by changing these settings some functions of the application may not work correctly,\n"
@@ -1162,121 +841,73 @@ msgstr ""
 "Sea cauteloso, cambiar las configuraciones de algunas funciones de la aplicación puede no funcionar,\n"
 "cámbielas solo si sabe lo que esta haciendo.\n"
 
-#: ../../vdms_dialogs/preferences.py:376
 msgid "Set logging level flags used by FFmpeg"
 msgstr "Fijar opciones de nivel de registro de FFmpeg"
 
-#: ../../vdms_dialogs/preferences.py:383
 msgid "Set logging level flags used by FFplay"
 msgstr "Fijar opciones de nivel de registro de FFplay"
 
-#: ../../vdms_dialogs/preferences.py:391
 msgid "FFmpeg logging levels"
 msgstr "Nivel de registro de FFmpeg"
 
-#: ../../vdms_dialogs/preferences.py:437
 msgid "By assigning an additional suffix you could avoid overwriting files"
 msgstr "Asignar un sufijo adicional evita la reescritura de archivos"
 
-#: ../../vdms_dialogs/preferences.py:440
 msgid "Type sudo password here, only for Unix-like operating systems, not for MS Windows"
 msgstr "Teclee contraseña para sudo, solo para sistemas tipo Unix, no para MS Windows"
 
-#: ../../vdms_dialogs/preferences.py:443
 msgid "Preferences"
 msgstr "Preferencias"
 
-#: ../../vdms_dialogs/preferences.py:596 ../../vdms_dialogs/preferences.py:676
-#: ../../vdms_main/main_frame.py:879 ../../vdms_main/main_frame.py:1060
 msgid "Choose Destination"
 msgstr "Elija Destino"
 
-#: ../../vdms_dialogs/preferences.py:627
 msgid "Enter only alphanumeric characters. You can also use the hyphen (\"-\") and the underscore (\"_\"). Spaces are not allowed."
 msgstr "Teclee solo caracteres alfanuméricos. Puede utilizar el guion (\"-\") y el guion bajo (\"_\"). No se permiten espacios."
 
-#: ../../vdms_dialogs/preferences.py:642
-#: ../../vdms_dialogs/setting_profiles.py:257
-#: ../../vdms_dialogs/setting_profiles.py:264
-#: ../../vdms_dialogs/setting_profiles.py:286
-#: ../../vdms_dialogs/setting_profiles.py:309 ../../vdms_main/main_frame.py:399
-#: ../../vdms_main/main_frame.py:421 ../../vdms_panels/av_conversions.py:605
-#: ../../vdms_panels/av_conversions.py:612
-#: ../../vdms_panels/sequence_to_video.py:352
-#: ../../vdms_panels/video_to_sequence.py:399
 msgid "Videomass - Warning!"
 msgstr "Videomass - ¡Advertencia!"
 
-#: ../../vdms_dialogs/preferences.py:731 ../../vdms_dialogs/preferences.py:771
-#: ../../vdms_dialogs/preferences.py:811 ../../vdms_dialogs/wizard_dlg.py:365
-#: ../../vdms_dialogs/wizard_dlg.py:384 ../../vdms_dialogs/wizard_dlg.py:403
 #, python-brace-format
 msgid "{} location"
 msgstr "Trayectoria de {}"
 
-#: ../../vdms_dialogs/queue_edit.py:36
-#: ../../vdms_dialogs/setting_profiles.py:38
 msgid "One-Pass, Do not start with `ffmpeg -i filename`; do not end with `output-filename`"
 msgstr "Un-Paso, No inicie con `ffmpeg -i archivo`; no termine con `archivo-destino`"
 
-#: ../../vdms_dialogs/queue_edit.py:40
-#: ../../vdms_dialogs/setting_profiles.py:42
 msgid "Two-Pass (optional), Do not start with `ffmpeg -i filename`; do not end with `output-filename`"
 msgstr "Dos-Pasos (opcional), No inicie con `ffmpeg -i archivo`; no termine con `archivo-destino`"
 
-#: ../../vdms_dialogs/queue_edit.py:59
 msgid "Videomass - Edit the selected item in the queue"
 msgstr "Videomass - Editar entrada seleccionada en la lista"
 
-#: ../../vdms_dialogs/queue_edit.py:71
-#: ../../vdms_dialogs/setting_profiles.py:92
 msgid "Pre-input arguments for One-Pass (optional)"
 msgstr "Argumentos Pre-input para Un-paso (opcional)"
 
-#: ../../vdms_dialogs/queue_edit.py:82
-#: ../../vdms_dialogs/setting_profiles.py:151
-#: ../../vdms_panels/presets_manager.py:255
 msgid "FFmpeg arguments for one-pass encoding"
 msgstr "Argumentos de FFmpeg para codificación en un-paso"
 
-#: ../../vdms_dialogs/queue_edit.py:88
-#: ../../vdms_dialogs/setting_profiles.py:158
-#: ../../vdms_panels/presets_manager.py:259
 msgid "Any optional arguments to add before input file on the one-pass encoding, e.g required names of some hardware accelerations like -hwaccel to use with CUDA."
 msgstr "Cualquier argumento adicional previo al archivo de entrada para la codificación un-paso, ej. nombres de aceleradores de hardware como -hwaccel para usar con CUDA."
 
-#: ../../vdms_dialogs/queue_edit.py:102
-#: ../../vdms_dialogs/setting_profiles.py:98
 msgid "Pre-input arguments for Two-Pass (optional)"
 msgstr "Argumentos Pre-input para Dos-pasos (opcional)"
 
-#: ../../vdms_dialogs/queue_edit.py:113
-#: ../../vdms_dialogs/setting_profiles.py:152
-#: ../../vdms_panels/presets_manager.py:257
 msgid "FFmpeg arguments for two-pass encoding"
 msgstr "Argumentos de FFmpeg para codificación en dos-pasoa"
 
-#: ../../vdms_dialogs/queue_edit.py:120
-#: ../../vdms_dialogs/setting_profiles.py:162
-#: ../../vdms_panels/presets_manager.py:263
 msgid "Any optional arguments to add before input file on the two-pass encoding, e.g required names of some hardware accelerations like -hwaccel to use with CUDA."
 msgstr "Cualquier argumento adicional previo al archivo de entrada para la codificación dos-pasos, ej. nombres de aceleradores de hardware como -hwaccel para usar con CUDA."
 
-#: ../../vdms_dialogs/queuedlg.py:65 ../../vdms_main/main_frame.py:508
-#: ../../vdms_panels/presets_manager.py:189
-#: ../../vdms_panels/video_to_sequence.py:171
 msgid "Edit"
 msgstr "Editar"
 
-#: ../../vdms_dialogs/queuedlg.py:68
 msgid "Remove"
 msgstr "Eliminar"
 
-#: ../../vdms_dialogs/queuedlg.py:71
 msgid "Remove all"
 msgstr "Eliminar todo"
 
-#: ../../vdms_dialogs/queuedlg.py:74
 msgid ""
 "Export\n"
 "queue file"
@@ -1284,7 +915,6 @@ msgstr ""
 "Exportar\n"
 "lista de archivos"
 
-#: ../../vdms_dialogs/queuedlg.py:77
 msgid ""
 "Import\n"
 "queue file"
@@ -1292,30 +922,22 @@ msgstr ""
 "Importar\n"
 "archivo de lista"
 
-#: ../../vdms_dialogs/queuedlg.py:85 ../../vdms_panels/filedrop.py:273
 #, fuzzy
 msgid "Destination file name"
 msgstr "Archivo de Salida"
 
-#: ../../vdms_dialogs/queuedlg.py:137
 msgid "Remove all items in the queue"
 msgstr "Eliminar todas las entradas de la lista"
 
-#: ../../vdms_dialogs/queuedlg.py:151
 msgid "Videomass - Queue"
 msgstr "Videomass - Lista"
 
-#: ../../vdms_dialogs/queuedlg.py:228
 msgid "Export queue file"
 msgstr "Exportar archivo de lista"
 
-#: ../../vdms_dialogs/queuedlg.py:296 ../../vdms_panels/av_conversions.py:1192
-#: ../../vdms_panels/presets_manager.py:1044
-#: ../../vdms_panels/video_to_sequence.py:600
 msgid "Same as source"
 msgstr "Igual que la fuente"
 
-#: ../../vdms_dialogs/queuedlg.py:301
 msgid ""
 "Source\n"
 "File destination\n"
@@ -1333,81 +955,60 @@ msgstr ""
 "Segmento de Inicio\n"
 "Duración de Clip"
 
-#: ../../vdms_dialogs/renamer.py:76
 msgid "# will be replaced by ascending numbers starting with:"
 msgstr "# Se reemplazara con números incrementales desde:"
 
-#: ../../vdms_dialogs/set_timestamp.py:87
 msgid "Font Size"
 msgstr "Tamaño de Letra"
 
-#: ../../vdms_dialogs/set_timestamp.py:111
 msgid "Font Color"
 msgstr "Color de Letra"
 
-#: ../../vdms_dialogs/set_timestamp.py:121
 msgid "Shadow Color"
 msgstr "Color de Sombra"
 
-#: ../../vdms_dialogs/set_timestamp.py:132
 msgid "Show text box"
 msgstr "Mostrar caja de texto"
 
-#: ../../vdms_dialogs/set_timestamp.py:136
 msgid "Box Color"
 msgstr "Color de la Caja"
 
-#: ../../vdms_dialogs/set_timestamp.py:156
 msgid "The timestamp size does not auto-adjust to the video size, you have to set the size here"
 msgstr "El tamaño de la estampa de tiempo no se auto ajusta al tamaño de video, configure aquí el tamaño"
 
-#: ../../vdms_dialogs/set_timestamp.py:160 ../../vdms_main/main_frame.py:559
 msgid "Timestamp settings"
 msgstr "Configurar Estampa de tiempo"
 
-#: ../../vdms_dialogs/setting_profiles.py:46
 msgid "Supported Formats list (optional). Do not include the `.`"
 msgstr "Lista de formatos soportados (opcional). No incluya el `.`"
 
-#: ../../vdms_dialogs/setting_profiles.py:47
 msgid "Output Format. Empty to copy format and codec. Do not include the `.`"
 msgstr "Formato de Salida. Vacio, copia el formato y codec. No incluya el `.`"
 
-#: ../../vdms_dialogs/setting_profiles.py:70
 msgid "Profile Name"
 msgstr "Nombre de Perfil"
 
-#: ../../vdms_dialogs/setting_profiles.py:74
-#: ../../vdms_panels/presets_manager.py:404
 msgid "Description"
 msgstr "Descripción"
 
-#: ../../vdms_dialogs/setting_profiles.py:149
 msgid "A short profile name"
 msgstr "Un nombre corto de perfil"
 
-#: ../../vdms_dialogs/setting_profiles.py:150
 msgid "A long description of the profile"
 msgstr "Una descripción amplia del perfil"
 
-#: ../../vdms_dialogs/setting_profiles.py:153
 msgid "One or more comma-separated format names compatible with this profile"
 msgstr "Uno o más nombres de formato compatibles con este perfil, separados por comas"
 
-#: ../../vdms_dialogs/setting_profiles.py:155
 msgid "Output format extension. Leave empty to copy codec and format"
 msgstr "Extensión del formato de salida. Deje vació para copiar codec y formato"
 
-#: ../../vdms_dialogs/setting_profiles.py:256
 msgid "Incomplete profile assignments"
 msgstr "Asignaciones de perfil incompletas"
 
-#: ../../vdms_dialogs/setting_profiles.py:263
 msgid "Formats must be comma-separated"
 msgstr "Debe separar con coma los formatos"
 
-#: ../../vdms_dialogs/setting_profiles.py:279
-#: ../../vdms_utils/queue_utils.py:80
 #, python-brace-format
 msgid ""
 "ERROR: Keys mismatched for requested data.\n"
@@ -1416,105 +1017,69 @@ msgstr ""
 "ERROR: No coinciden llaves para datos requeridos.\n"
 "Archivo invalido: «{0}»"
 
-#: ../../vdms_dialogs/setting_profiles.py:285
-#: ../../vdms_dialogs/setting_profiles.py:308
 msgid "Profile already stored with same name"
 msgstr "Ya existe perfil con ese nombre"
 
-#: ../../vdms_dialogs/setting_profiles.py:293
 msgid "Profile stored successfully!"
 msgstr "¡Perfil guardado exitosamente!"
 
-#: ../../vdms_dialogs/setting_profiles.py:311
 msgid "Profile change successful!"
 msgstr "¡Cambio de Perfil exitosol!"
 
-#: ../../vdms_dialogs/showlogs.py:80
 msgid "Log file list"
 msgstr "Lista de archivos de registro"
 
-#: ../../vdms_dialogs/showlogs.py:82 ../../vdms_dialogs/showlogs.py:116
 msgid "Log messages"
 msgstr "Registro de mensajes"
 
-#: ../../vdms_dialogs/showlogs.py:105
 msgid "Refresh log messages"
 msgstr "Refrescar mensajes de registro"
 
-#: ../../vdms_dialogs/showlogs.py:107
 msgid "Clear log messages"
 msgstr "Limpiar mensajes de registro"
 
-#: ../../vdms_dialogs/showlogs.py:160
 msgid "Select a log file"
 msgstr "Seleccionar archivo de registro"
 
-#: ../../vdms_dialogs/showlogs.py:167
 msgid "Are you sure you want to clear the selected log file?"
 msgstr "¿Seguro desea limpiar el archivo de registro?"
 
-#: ../../vdms_dialogs/showlogs.py:168 ../../vdms_dialogs/wizard_dlg.py:251
-#: ../../vdms_io/checkup.py:68 ../../vdms_main/main_frame.py:205
-#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1685
-#: ../../vdms_panels/presets_manager.py:349
-#: ../../vdms_panels/presets_manager.py:550
-#: ../../vdms_panels/presets_manager.py:590
-#: ../../vdms_panels/presets_manager.py:649
-#: ../../vdms_panels/presets_manager.py:684
-#: ../../vdms_panels/presets_manager.py:749
-#: ../../vdms_panels/presets_manager.py:775
-#: ../../vdms_panels/presets_manager.py:874
-#: ../../vdms_panels/presets_manager.py:904
 msgid "Please confirm"
 msgstr "Por favor Confirme"
 
-#: ../../vdms_dialogs/shownormlist.py:83
 msgid "File name"
 msgstr "Nombre de archivo"
 
-#: ../../vdms_dialogs/shownormlist.py:84
 msgid "Max volume dBFS"
 msgstr "Volumen máximo dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:85
 msgid "Mean volume dBFS"
 msgstr "Volumen promedio dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:86
 msgid "Offset dBFS"
 msgstr "Desplazamiento dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:87
 msgid "Result dBFS"
 msgstr "Resultado dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:92
 msgid "Post-normalization references:"
 msgstr "Referencias post-normalización:"
 
-#: ../../vdms_dialogs/shownormlist.py:102
 msgid "=  Clipped peaks"
 msgstr "=  Picos recortados"
 
-#: ../../vdms_dialogs/shownormlist.py:111
 msgid "=  No changes"
 msgstr "=  Sin cambios"
 
-#: ../../vdms_dialogs/shownormlist.py:121
 msgid "=  Below max peak"
 msgstr "=  Pico inferior máximo"
 
-#: ../../vdms_dialogs/shownormlist.py:166
-#: ../../vdms_panels/audio_encoders/acodecs.py:841
 msgid "RMS-based volume statistics"
 msgstr "Estadísticas de volumen basadas en RMS"
 
-#: ../../vdms_dialogs/shownormlist.py:191
-#: ../../vdms_panels/audio_encoders/acodecs.py:839
 msgid "PEAK-based volume statistics"
 msgstr "Estadísticas de volumen basadas en Picos"
 
-#: ../../vdms_dialogs/shownormlist.py:216
 msgid ""
 "...It means the resulting audio will be clipped,\n"
 "because its volume is higher than the maximum 0 db\n"
@@ -1526,7 +1091,6 @@ msgstr ""
 "de 0 db. Esto provoca perdida de datos y el audio \n"
 "podría sonar distorsionado."
 
-#: ../../vdms_dialogs/shownormlist.py:242
 msgid ""
 "...It means the resulting audio will not change,\n"
 "because it's equal to the source."
@@ -1534,7 +1098,6 @@ msgstr ""
 "...Significa que el audio resultante no tendrá\n"
 "cambios y sera igual al de la fuente."
 
-#: ../../vdms_dialogs/shownormlist.py:266
 msgid ""
 "...It means an audio signal will be produced with\n"
 "a lower volume than the source."
@@ -1542,15 +1105,12 @@ msgstr ""
 "...Significa que la señal de audio se producirá\n"
 "con un volumen menor al original."
 
-#: ../../vdms_dialogs/videomass_check_version.py:63
 msgid "Get Latest Version"
 msgstr "Obtenga la Ultima Version"
 
-#: ../../vdms_dialogs/videomass_check_version.py:67
 msgid "Checking for newer version"
 msgstr "Comprobando versión más reciente"
 
-#: ../../vdms_dialogs/videomass_check_version.py:95
 msgid ""
 "\n"
 "\n"
@@ -1560,7 +1120,6 @@ msgstr ""
 "\n"
 "Las nuevas versiones corrigen fallos y añaden características."
 
-#: ../../vdms_dialogs/videomass_check_version.py:96
 #, python-brace-format
 msgid ""
 "\n"
@@ -1573,7 +1132,6 @@ msgstr ""
 "Videomass versión. {0}\n"
 "\n"
 
-#: ../../vdms_dialogs/while_playing.py:37
 msgid ""
 "q, ESC\n"
 "f\n"
@@ -1615,65 +1173,51 @@ msgstr ""
 "click botón derecho\n"
 "doble click botón izquierdo"
 
-#: ../../vdms_dialogs/while_playing.py:92
 msgid "Shortcut keys while playing with FFplay"
 msgstr "Atajos del teclado al reproducir con FFplay"
 
-#: ../../vdms_dialogs/widget_utils.py:120 ../../vdms_main/main_frame.py:1326
 msgid "Stop"
 msgstr "Parar"
 
-#: ../../vdms_dialogs/wizard_dlg.py:63
 msgid "Please take a moment to set up the application"
 msgstr "Por favor configure la aplicación"
 
-#: ../../vdms_dialogs/wizard_dlg.py:64
 msgid "Click the \"Next\" button to get started"
 msgstr "Presione el botón \"Siguiente\" para iniciar"
 
-#: ../../vdms_dialogs/wizard_dlg.py:79
 msgid "Welcome to the Videomass Wizard!"
 msgstr "¡Bienvenido al asistente de Videomass!"
 
-#: ../../vdms_dialogs/wizard_dlg.py:123
 msgid "Videomass is an application based on FFmpeg\n"
 msgstr "Videomass es una aplicación basada en FFmpeg\n"
 
-#: ../../vdms_dialogs/wizard_dlg.py:125
 msgid "If FFmpeg is not on your computer, this application will be unusable"
 msgstr "Si FFmpeg no esta en su equipo, esta aplicación es inútil"
 
-#: ../../vdms_dialogs/wizard_dlg.py:128
 msgid ""
 "If you have already installed FFmpeg on your operating system,\n"
 "click the \"Auto-detection\" button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:131
 msgid ""
 "If you want to use a version of FFmpeg located on your filesystem\n"
 "but not installed on your operating system,\n"
 "click the \"Locate\" button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:162
 msgid "Auto-detection"
 msgstr "Auto-detectar"
 
-#: ../../vdms_dialogs/wizard_dlg.py:164
 msgid "Locate"
 msgstr "Localizar"
 
-#: ../../vdms_dialogs/wizard_dlg.py:214
 msgid "Click the \"Next\" button"
 msgstr "Presione el botón \"Siguiente\""
 
-#: ../../vdms_dialogs/wizard_dlg.py:235
 #, python-brace-format
 msgid "'{}' is not installed on your computer. Install it or indicate another location by clicking the 'Locate' button."
 msgstr "'{}' no esta instalado en su equipo. Instalelo o indique su ubicación presionando el botón 'Localizar'."
 
-#: ../../vdms_dialogs/wizard_dlg.py:249
 msgid ""
 "Videomass already seems to include FFmpeg.\n"
 "\n"
@@ -1683,11 +1227,9 @@ msgstr ""
 "\n"
 "¿Desea utilizarlo?"
 
-#: ../../vdms_dialogs/wizard_dlg.py:275
 msgid "Locating FFmpeg executables\n"
 msgstr "Localizando ejecutables de FFmpeg\n"
 
-#: ../../vdms_dialogs/wizard_dlg.py:277
 msgid ""
 "\"ffmpeg\", \"ffprobe\" and \"ffplay\" are required. Complete all\n"
 "the text boxes below by clicking on the respective buttons."
@@ -1695,40 +1237,30 @@ msgstr ""
 "Se requiere \"ffmpeg\", \"ffprobe\" y \"ffplay\". Complete todas\n"
 "las cajas de texto presionando en los botones respectivos."
 
-#: ../../vdms_dialogs/wizard_dlg.py:437
 msgid "Wizard completed successfully!\n"
 msgstr "¡Asistente completado con éxito!\n"
 
-#: ../../vdms_dialogs/wizard_dlg.py:438
 msgid "Remember that you can always change these settings later, through the Preferences dialog."
 msgstr "Recuerde que puede cambiar estas configuraciones posteriormente, mediante el dialogo Preferencias."
 
-#: ../../vdms_dialogs/wizard_dlg.py:440
 msgid "Thank You!"
 msgstr "¡Gracias!"
 
-#: ../../vdms_dialogs/wizard_dlg.py:441
 msgid "To exit click the \"Finish\" button"
 msgstr "Para salir presione el botón \"Finalizar\""
 
-#: ../../vdms_dialogs/wizard_dlg.py:527
 msgid "< Previous"
 msgstr "< Anterior"
 
-#: ../../vdms_dialogs/wizard_dlg.py:530 ../../vdms_dialogs/wizard_dlg.py:613
 msgid "Next >"
 msgstr "Siguiente >"
 
-#: ../../vdms_dialogs/wizard_dlg.py:535
 msgid "Videomass Wizard"
 msgstr "Asistente de Videomass"
 
-#: ../../vdms_dialogs/wizard_dlg.py:563 ../../vdms_dialogs/wizard_dlg.py:586
-#: ../../vdms_dialogs/wizard_dlg.py:591
 msgid "Finish"
 msgstr "Finalizar"
 
-#: ../../vdms_io/checkup.py:44 ../../vdms_io/checkup.py:92
 #, python-brace-format
 msgid ""
 "Output folder does not exist:\n"
@@ -1739,32 +1271,25 @@ msgstr ""
 "\n"
 "\"{}\"\n"
 
-#: ../../vdms_io/checkup.py:65
 msgid "Files already exist, do you want to overwrite them?"
 msgstr "Ya existe archivo, ¿quiere sobreecribirlo?"
 
-#: ../../vdms_io/checkup.py:67
 msgid "Already exist"
 msgstr "Ya existe"
 
-#: ../../vdms_io/checkup.py:81
 msgid "Not found"
 msgstr "No encontrado"
 
-#: ../../vdms_io/checkup.py:82 ../../vdms_panels/filedrop.py:196
 msgid "Error list"
 msgstr "Lista de Error"
 
-#: ../../vdms_io/checkup.py:83
 msgid "File(s) not found"
 msgstr "Archivo(s) no encontrado(s)"
 
-#: ../../vdms_io/io_tools.py:56
 #, python-format
 msgid "File does not exist or is invalid:  %s"
 msgstr "Archivo no existe o invalido:  %s"
 
-#: ../../vdms_io/io_tools.py:74
 msgid ""
 "Wait....\n"
 "Audio peak analysis."
@@ -1772,16 +1297,12 @@ msgstr ""
 "Espere....\n"
 "Analizando Picos de Audio."
 
-#: ../../vdms_io/io_tools.py:179
 msgid "Videomass - Downloading..."
 msgstr "Videomass - Descargando..."
 
-#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1409
-#: ../../vdms_main/main_frame.py:1441
 msgid "Ready"
 msgstr "Listo"
 
-#: ../../vdms_main/main_frame.py:203
 msgid ""
 "Not all items in the queue were completed.\n"
 "\n"
@@ -1791,343 +1312,256 @@ msgstr ""
 "\n"
 "¿Desea mantenerlas en la lista?"
 
-#: ../../vdms_main/main_frame.py:224
 #, python-brace-format
 msgid "Queue ({0})"
 msgstr "Lista ({0})"
 
-#: ../../vdms_main/main_frame.py:229 ../../vdms_main/main_frame.py:1334
 msgid "Queue"
 msgstr "Lista"
 
-#: ../../vdms_main/main_frame.py:396 ../../vdms_main/main_frame.py:418
 msgid "There are still active windows with running processes, make sure you finish your work before exit."
 msgstr "Aun hay ventanas activas con procesos ejecutándose, asegúrese de finalizar su trabajo antes de salir."
 
-#: ../../vdms_main/main_frame.py:403
 msgid "Are you sure you want to exit the application?"
 msgstr "¿Seguro que desea salir?"
 
-#: ../../vdms_main/main_frame.py:405
 msgid "Exit"
 msgstr "Salir"
 
-#: ../../vdms_main/main_frame.py:463
 msgid "Import files\tCtrl+O"
 msgstr "Importar archivos\tCtrl+O"
 
-#: ../../vdms_main/main_frame.py:466
 msgid "Open destination folder of encodings\tCtrl+D"
 msgstr "Carpeta destino para codificaciones\tCtrl+D"
 
-#: ../../vdms_main/main_frame.py:469
 msgid "Load queue file"
 msgstr "Cargar archivo de Lista"
 
-#: ../../vdms_main/main_frame.py:470
 msgid "Load a previously exported queue file"
 msgstr "Cargar archivo de Lista previamente exportado"
 
-#: ../../vdms_main/main_frame.py:473
 msgid "Open trash"
 msgstr "Abrir Papelera"
 
-#: ../../vdms_main/main_frame.py:474
 msgid "Open the Videomass trash folder"
 msgstr "Abre carpeta de la papelera de Videomass"
 
-#: ../../vdms_main/main_frame.py:476
 msgid "Empty trash"
 msgstr "Vaciar papelera"
 
-#: ../../vdms_main/main_frame.py:477
 msgid "Delete all files in the Videomass trash folder"
 msgstr "Borrar todo de la papelera de Videomass"
 
-#: ../../vdms_main/main_frame.py:480
 msgid "Exit\tCtrl+Q"
 msgstr "Salir\tCtrl+Q"
 
-#: ../../vdms_main/main_frame.py:481
 msgid "Completely exit the application"
 msgstr "Salir de la aplicación"
 
-#: ../../vdms_main/main_frame.py:482
 msgid "File"
 msgstr "Archivo"
 
-#: ../../vdms_main/main_frame.py:486 ../../vdms_panels/filedrop.py:340
-#: ../../vdms_panels/filedrop.py:381
 msgid "Rename selected file\tCtrl+R"
 msgstr "Renombrar archivo seleccionado\tCtrl+R"
 
-#: ../../vdms_main/main_frame.py:487
 msgid "Rename the destination of the selected file"
 msgstr "Renombra destino de archivo seleccionado"
 
-#: ../../vdms_main/main_frame.py:490 ../../vdms_panels/filedrop.py:341
-#: ../../vdms_panels/filedrop.py:384
 #, fuzzy
 msgid "Batch rename files\tCtrl+B"
 msgstr "Renombrado en lote\tCtrl+B"
 
-#: ../../vdms_main/main_frame.py:491
 msgid "Numerically renames the destination of all items in the list"
 msgstr "Ennumerar el destino de todas las entradas de la lista"
 
-#: ../../vdms_main/main_frame.py:496 ../../vdms_panels/filedrop.py:343
-#: ../../vdms_panels/filedrop.py:388
 msgid "Remove selected entry\tDEL"
 msgstr "Quitar entrada seleccionada\tDEL"
 
-#: ../../vdms_main/main_frame.py:497
 msgid "Remove the selected file from the list"
 msgstr "Eliminar archivo seleccionado de la lista"
 
-#: ../../vdms_main/main_frame.py:500 ../../vdms_panels/filedrop.py:344
-#: ../../vdms_panels/filedrop.py:391
 msgid "Clear list\tShift+DEL"
 msgstr "Vaciar lista\tShift+DEL"
 
-#: ../../vdms_main/main_frame.py:501
 msgid "Clear the file list"
 msgstr "Limpiar la lista de archivos"
 
-#: ../../vdms_main/main_frame.py:506
 msgid "Preferences\tCtrl+P"
 msgstr "Preferencias\tCtrl+P"
 
-#: ../../vdms_main/main_frame.py:507
 msgid "Application preferences"
 msgstr "Preferencias de la aplicación"
 
-#: ../../vdms_main/main_frame.py:512
 msgid "Find FFmpeg topics"
 msgstr "Encontrar temas sobre FFmpeg"
 
-#: ../../vdms_main/main_frame.py:513
 msgid "A useful tool to search for FFmpeg help topics and options"
 msgstr "Una herramienta util para buscar temas de la ayuda de FFmpeg"
 
-#: ../../vdms_main/main_frame.py:518
 msgid "Check for preset updates"
 msgstr "Buscar nuevos presets"
 
-#: ../../vdms_main/main_frame.py:519
 #, python-brace-format
 msgid "Check for new presets updates from {0}"
 msgstr "Buscar nuevos presets en {0}"
 
-#: ../../vdms_main/main_frame.py:521
 msgid "Get latest presets"
 msgstr "Obtener los últimos preset"
 
-#: ../../vdms_main/main_frame.py:522
 #, python-brace-format
 msgid "Get the latest presets from {0}"
 msgstr "Obtener los últimos preset desde {0}"
 
-#: ../../vdms_main/main_frame.py:525
 msgid "Work notes\tCtrl+N"
 msgstr "Notas de trabajo\tCtrl+N"
 
-#: ../../vdms_main/main_frame.py:526
 msgid "Read and write useful notes and reminders."
 msgstr "Lea y escriba recordatorios y notas."
 
-#: ../../vdms_main/main_frame.py:528
 msgid "Tools"
 msgstr "Herramientas"
 
-#: ../../vdms_main/main_frame.py:535
 msgid "Show FFmpeg's built-in configuration capabilities"
 msgstr "Mostrar capacidades de  configuración integradas en FFmpeg"
 
-#: ../../vdms_main/main_frame.py:539
 msgid "Muxers and demuxers available on your version of FFmpeg"
 msgstr "Mezcladores y Desmezcladores disponibles en el FFmpeg utilizado"
 
-#: ../../vdms_main/main_frame.py:543
 msgid "Encoders available on your version of FFmpeg"
 msgstr "Muestra los codificadores disponibles en FFmpeg"
 
-#: ../../vdms_main/main_frame.py:546
 msgid "Decoders available on your version of FFmpeg"
 msgstr "Muestra los decodificadores disponibles en FFmpeg"
 
-#: ../../vdms_main/main_frame.py:550
 msgid "Enable timestamps on playback"
 msgstr "Mostrar marcas de tiempo al reproducir"
 
-#: ../../vdms_main/main_frame.py:551
 msgid "Displays timestamp when playing media with FFplay"
 msgstr "Mostrar marcas de tiempo al reproducir con FFplay"
 
-#: ../../vdms_main/main_frame.py:554
 msgid "Auto-exit after playback"
 msgstr "Salir al terminar reproducción"
 
-#: ../../vdms_main/main_frame.py:555
 msgid "If checked, the FFplay window will auto-close when playback is complete"
 msgstr "Al activar, la ventana de FFplay se cerrara al finalizar la reproducción"
 
-#: ../../vdms_main/main_frame.py:559
 msgid "Customize the timestamp style"
 msgstr "Personalizar Estampa de tiempo"
 
-#: ../../vdms_main/main_frame.py:562
 msgid "While playing..."
 msgstr "Durante reproducción..."
 
-#: ../../vdms_main/main_frame.py:563
 msgid "Show useful shortcut keys when playing or previewing using FFplay"
 msgstr "Mostrar atajos de teclado al reproducir o previsualizar con FFplay"
 
-#: ../../vdms_main/main_frame.py:567
 msgid "Show timeline editor\tCtrl+T"
 msgstr "Editor de linea de tiempo\tCtrl+T"
 
-#: ../../vdms_main/main_frame.py:568
 msgid "Set duration or trim slices of time to remove unwanted parts from your files"
 msgstr "Fijar lduración o recortar pedazos de tiempo, eliminar partes no deseadas de archivos"
 
-#: ../../vdms_main/main_frame.py:572
 msgid "View"
 msgstr "Ver"
 
-#: ../../vdms_main/main_frame.py:579
 msgid "Home panel\tCtrl+Shift+H"
 msgstr "Panel principal\tCtrl+Shift+H"
 
-#: ../../vdms_main/main_frame.py:580
 msgid "Go to the «Home» panel"
 msgstr "Ir al panel «Principal»"
 
-#: ../../vdms_main/main_frame.py:583
 msgid "Presets Manager\tCtrl+Shift+P"
 msgstr "Administrador de Presets\tCtrl+Shift+P"
 
-#: ../../vdms_main/main_frame.py:584
 msgid "Go to the «Presets Manager» panel"
 msgstr "Ir al panel «Administrador de Presets»"
 
-#: ../../vdms_main/main_frame.py:586
 msgid "A/V Conversions\tCtrl+Shift+V"
 msgstr "Conversiones A/V \tCtrl+Shift+V"
 
-#: ../../vdms_main/main_frame.py:587
 msgid "Go to the «A/V Conversions» panel"
 msgstr "Ir al panel «Conversiones A/V»"
 
-#: ../../vdms_main/main_frame.py:589
 msgid "Concatenate Demuxer\tCtrl+Shift+D"
 msgstr "Encadenar Dezmezclador\tCtrl+Shift+D"
 
-#: ../../vdms_main/main_frame.py:590
 msgid "Go to the «Concatenate Demuxer» panel"
 msgstr "Ir al panel «Encadenar Desmezcladores»"
 
-#: ../../vdms_main/main_frame.py:593
 msgid "Still Image Maker\tCtrl+Shift+I"
 msgstr "Creador de Imágenes Fijas\tCtrl+Shift+I"
 
-#: ../../vdms_main/main_frame.py:594
 msgid "Go to the «Still Image Maker» panel"
 msgstr "Ir al panel «Productor de Imágenes Fijas»"
 
-#: ../../vdms_main/main_frame.py:596
 msgid "From Movie to Pictures\tCtrl+Shift+S"
 msgstr "De Película a Imágenes\tCtrl+Shift+S"
 
-#: ../../vdms_main/main_frame.py:597
 msgid "Go to the «From Movie to Pictures» panel"
 msgstr "Ir al panel «De Película a Imágenes»"
 
-#: ../../vdms_main/main_frame.py:600
 msgid "Output monitor\tCtrl+Shift+O"
 msgstr "Monitor de Salida\tCtrl+Shift+O"
 
-#: ../../vdms_main/main_frame.py:601
 msgid "Keeps track of the output for debugging errors"
 msgstr "Mantener rastro de la salida para depuración de errores"
 
-#: ../../vdms_main/main_frame.py:603
 msgid "Go"
 msgstr "Ir a"
 
-#: ../../vdms_main/main_frame.py:607
 msgid "User guide"
 msgstr "Guía de usuario"
 
-#: ../../vdms_main/main_frame.py:611
 msgid "System version"
 msgstr "Versión del Sistema"
 
-#: ../../vdms_main/main_frame.py:612
 msgid "Get version about your operating system, version of Python and wxPython."
 msgstr "Obteniendo versiones de su sistema, Python y wxPython."
 
-#: ../../vdms_main/main_frame.py:616
 msgid "Show log files\tCtrl+L"
 msgstr "Mostrar Registros\tCtrl+L"
 
-#: ../../vdms_main/main_frame.py:617
 msgid "Viewing log messages"
 msgstr "Ver mensajes de registro"
 
-#: ../../vdms_main/main_frame.py:620
 msgid "Issue tracker"
 msgstr "Seguimiento de fallos"
 
-#: ../../vdms_main/main_frame.py:624
 msgid "Contribute to the project"
 msgstr "Contribuir al proyecto"
 
-#: ../../vdms_main/main_frame.py:627
 msgid "Sponsor this project"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:628
 msgid "Become a developer supporter"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:629
 msgid "Donate"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:630
 msgid "Donate to the app developer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:634
 msgid "Other projects by the developer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:650
 msgid "About Videomass"
 msgstr "Sobre Videomass"
 
-#: ../../vdms_main/main_frame.py:651
 msgid "Check for newer version"
 msgstr "Comprobanr versión más reciente"
 
-#: ../../vdms_main/main_frame.py:652
 msgid "Check for the latest Videomass version"
 msgstr "Comprobar ultima versión de Videomass"
 
-#: ../../vdms_main/main_frame.py:654
 msgid "Help"
 msgstr "Ayuda"
 
-#: ../../vdms_main/main_frame.py:729
 msgid "Import files"
 msgstr "Importar archivos"
 
-#: ../../vdms_main/main_frame.py:752
 msgid "No default folder has been set for the destination of the encodings. The current setting is \"Same destination paths as source files\"."
 msgstr "No se fijo carpeta destino para las conversiones. La configuración actual es \"Misma carpeta que archivos fuente\"."
 
-#: ../../vdms_main/main_frame.py:784 ../../vdms_main/main_frame.py:809
 #, python-brace-format
 msgid ""
 "'{}':\n"
@@ -2136,11 +1570,9 @@ msgstr ""
 "'{}':\n"
 "No existe archivo o carpeta"
 
-#: ../../vdms_main/main_frame.py:797
 msgid "Are you sure to empty trash folder?"
 msgstr "¿Seguro que desea vaciar la papelera?"
 
-#: ../../vdms_main/main_frame.py:805
 #, python-brace-format
 msgid ""
 "'{}':\n"
@@ -2149,17 +1581,14 @@ msgstr ""
 "'{}':\n"
 "No hay archivos a borrar."
 
-#: ../../vdms_main/main_frame.py:862
 #, python-brace-format
 msgid "Installed release v{0}. A new presets release is available {1}"
 msgstr "Versión instalada v{0}. Nueva versión de presets disponible {1}"
 
-#: ../../vdms_main/main_frame.py:866
 #, python-brace-format
 msgid "Installed release v{0}. No new updates found."
 msgstr "Versión instalada v{0}. No se encontró actualizaciones."
 
-#: ../../vdms_main/main_frame.py:896
 msgid ""
 "Wait....\n"
 "The archive is being downloaded"
@@ -2167,16 +1596,13 @@ msgstr ""
 "Espere....\n"
 "El archivo esta siendo descargado"
 
-#: ../../vdms_main/main_frame.py:908
 #, python-brace-format
 msgid "Successfully downloaded to \"{0}\""
 msgstr "Descargado exitosamente en \"{0}\""
 
-#: ../../vdms_main/main_frame.py:1120
 msgid "Some changes require restarting the application."
 msgstr "Algunos cambios requieren reiniciar aplicación."
 
-#: ../../vdms_main/main_frame.py:1126
 #, python-brace-format
 msgid ""
 "{0}\n"
@@ -2187,116 +1613,85 @@ msgstr ""
 "\n"
 "¿Quiere reiniciar aplicación ahora?"
 
-#: ../../vdms_main/main_frame.py:1128
 msgid "Restart Videomass?"
 msgstr "¿Reiniciar Videomass?"
 
-#: ../../vdms_main/main_frame.py:1207
 #, python-brace-format
 msgid "A new release is available - v.{0}\n"
 msgstr "Una nueva versión esta disponible . {0}\n"
 
-#: ../../vdms_main/main_frame.py:1210
 msgid "You are using a development version that has not yet been released!\n"
 msgstr "¡Esta utilizando una versión de desarrollo!\n"
 
-#: ../../vdms_main/main_frame.py:1213
 msgid "Congratulation! You are already using the latest version.\n"
 msgstr "¡Felicitaciones! Ya esta utilizando la ultima versión versión.\n"
 
-#: ../../vdms_main/main_frame.py:1301
 msgid "Previous panel"
 msgstr "Panel anterior"
 
-#: ../../vdms_main/main_frame.py:1302
 msgid "Back"
 msgstr "Regresar"
 
-#: ../../vdms_main/main_frame.py:1305
 msgid "Next panel"
 msgstr "Siguiente panel"
 
-#: ../../vdms_main/main_frame.py:1306
 msgid "Next"
 msgstr "Siguiente"
 
-#: ../../vdms_main/main_frame.py:1309
 msgid "Home panel"
 msgstr "Panel Principal"
 
-#: ../../vdms_main/main_frame.py:1310
 msgid "Home"
 msgstr "Principal"
 
-#: ../../vdms_main/main_frame.py:1313
 msgid "Play the selected imput file"
 msgstr "Reproducir archivo de entrada seleccionado"
 
-#: ../../vdms_main/main_frame.py:1314
 msgid "Play"
 msgstr "Reproducir"
 
-#: ../../vdms_main/main_frame.py:1317
 msgid "Get informative data about imported media streams"
 msgstr "Obtiene información de flujos Multimedia importados"
 
-#: ../../vdms_main/main_frame.py:1321
 msgid "Start batch processing"
 msgstr "Comenzar proceso por lote"
 
-#: ../../vdms_main/main_frame.py:1325
 msgid "Stops current process"
 msgstr "Detener proceso actual"
 
-#: ../../vdms_main/main_frame.py:1329
 msgid "Add an item to Queue"
 msgstr "Añadir entrada a la Lista"
 
-#: ../../vdms_main/main_frame.py:1330
 msgid "Add to Queue"
 msgstr "Añadir a la Lista"
 
-#: ../../vdms_main/main_frame.py:1333
 msgid "Show queue"
 msgstr "Mostrar lista"
 
-#: ../../vdms_main/main_frame.py:1408 ../../vdms_panels/presets_manager.py:569
 msgid "Videomass"
 msgstr "Videomass"
 
-#: ../../vdms_main/main_frame.py:1442
 msgid "Videomass - File List"
 msgstr "Videomass - Lista de Archivos"
 
-#: ../../vdms_main/main_frame.py:1459
 msgid "Videomass - AV Conversions"
 msgstr "Videomass - Conversiones AV"
 
-#: ../../vdms_main/main_frame.py:1488
 msgid "Videomass - Presets Manager"
 msgstr "Videomass - Administrador de Presets"
 
-#: ../../vdms_main/main_frame.py:1518
 msgid "Videomass - Concatenate Demuxer"
 msgstr "Videomass - Encadenar Dezmezcladores"
 
-#: ../../vdms_main/main_frame.py:1547
 msgid "Videomass - From Movie to Pictures"
 msgstr "Videomass -De Película a Imágenes"
 
-#: ../../vdms_main/main_frame.py:1576
 msgid "Videomass - Still Image Maker"
 msgstr "Videomass -Productor de Imágenes Fijas"
 
-#: ../../vdms_main/main_frame.py:1660 ../../vdms_panels/av_conversions.py:577
-#: ../../vdms_panels/filedrop.py:500 ../../vdms_panels/filedrop.py:616
-#: ../../vdms_panels/sequence_to_video.py:322
-#: ../../vdms_panels/video_to_sequence.py:369
-#: ../../vdms_panels/video_to_sequence.py:501
 msgid "Have to select an item in the file list first"
 msgstr "Primero elija un archivo en la lista"
 
-#: ../../vdms_main/main_frame.py:1682
 msgid ""
 "An item with the same destination file already exists.\n"
 "\n"
@@ -2306,84 +1701,63 @@ msgstr ""
 "\n"
 "¿Desea reemplazarlo añadiendo la entrada a la lista?"
 
-#: ../../vdms_main/main_frame.py:1703
 msgid "Videomass - FFmpeg Message Monitoring"
 msgstr "Videomass - Monitor de mensajes de FFmpeg"
 
-#: ../../vdms_main/main_frame.py:1828
 #, python-brace-format
 msgid "The system will turn off in {0} seconds"
 msgstr "El sistema se apagara en {0} segundos"
 
-#: ../../vdms_main/main_frame.py:1829
 msgid "Videomass - Shutdown!"
 msgstr "Videomass - ¡Apagando!"
 
-#: ../../vdms_main/main_frame.py:1836
 msgid "Error while shutting down. Please see file log for details."
 msgstr "Error al apagar. Vea el archivo de registro para detalles."
 
-#: ../../vdms_main/main_frame.py:1848
 #, python-brace-format
 msgid "Exiting the application in {0} seconds"
 msgstr "La aplicación se cerrara en {0} segundos"
 
-#: ../../vdms_main/main_frame.py:1849
 msgid "Videomass - Exiting!"
 msgstr "Videomass - ¡Saliendo!"
 
-#: ../../vdms_miniframes/timeline.py:46
 msgid "Start point adjustment"
 msgstr "Punto de ajuste inicial"
 
-#: ../../vdms_miniframes/timeline.py:48
 msgid "End point adjustment"
 msgstr "Ajuste de punto final"
 
-#: ../../vdms_miniframes/timeline.py:105
 msgid "Hours"
 msgstr "Horas"
 
-#: ../../vdms_miniframes/timeline.py:106
 msgid "Minutes"
 msgstr "Minutos"
 
-#: ../../vdms_miniframes/timeline.py:107
 msgid "Seconds"
 msgstr "Segundos"
 
-#: ../../vdms_miniframes/timeline.py:108
 msgid "Milliseconds"
 msgstr "Milisegundos"
 
-#: ../../vdms_miniframes/timeline.py:189 ../../vdms_miniframes/timeline.py:312
 msgid "No source duration:"
 msgstr "Sin duraci´on de la fuente:"
 
-#: ../../vdms_miniframes/timeline.py:208 ../../vdms_miniframes/timeline.py:298
-#: ../../vdms_miniframes/timeline.py:333 ../../vdms_miniframes/timeline.py:338
-#: ../../vdms_miniframes/timeline.py:441
 #, python-brace-format
 msgid "{0} {1}  |  Segment Duration: {2}"
 msgstr "{0} {1}  |  Duración de Segmento: {2}"
 
-#: ../../vdms_miniframes/timeline.py:260 ../../vdms_miniframes/timeline.py:277
 msgid "End adjustment"
 msgstr "Ajuste de final"
 
-#: ../../vdms_miniframes/timeline.py:261 ../../vdms_miniframes/timeline.py:279
 msgid "Start adjustment"
 msgstr "Iniciar ajuste"
 
-#: ../../vdms_miniframes/timeline.py:320
 msgid "Source duration:"
 msgstr "Duración de fuente:"
 
-#: ../../vdms_miniframes/timeline.py:387
 msgid "WARNING: Invalid selection, out of range."
 msgstr "ADVERTENCIA: Selección invalida, fuera de rango."
 
-#: ../../vdms_miniframes/timeline.py:461
 msgid ""
 "Start by dragging the bottom left handle,\n"
 "or right-click for options."
@@ -2392,15 +1766,12 @@ msgstr ""
 "\n"
 "o presione con el botón derecho para ver las opciones."
 
-#: ../../vdms_miniframes/timeline.py:497
 msgid "Start"
 msgstr "Iniciar"
 
-#: ../../vdms_miniframes/timeline.py:498
 msgid "End"
 msgstr "Fin"
 
-#: ../../vdms_miniframes/timeline.py:548
 msgid ""
 "The timeline editor is a tool that allows you to trim slices of time on selected imported media (see File List panel).\n"
 "\n"
@@ -2422,39 +1793,30 @@ msgstr ""
 "\n"
 "Los valores \"Inicio\"/\"Fin\" siempre refieren al valor inicial de la linea de tiempo: 00:00:00.000. Para información sobre la duración del segmento y advertencias vea los mensajes en la barra de estado."
 
-#: ../../vdms_miniframes/timeline.py:565
 msgid "Timeline Editor Usage"
 msgstr "Uso del Editor de Linea de Tiempo"
 
-#: ../../vdms_panels/av_conversions.py:153
 msgid "Media:"
 msgstr "Medio:"
 
-#: ../../vdms_panels/av_conversions.py:169
 msgid "Container:"
 msgstr "Contenedor:"
 
-#: ../../vdms_panels/av_conversions.py:180
 msgid "Save profile"
 msgstr "Guardar perfil"
 
-#: ../../vdms_panels/av_conversions.py:183
 msgid "Target"
 msgstr "Destino"
 
-#: ../../vdms_panels/av_conversions.py:316
 msgid "Miscellaneous"
 msgstr "Misceláneos"
 
-#: ../../vdms_panels/av_conversions.py:323
 msgid "Save as a new profile of the Presets Manager."
 msgstr "Guardar nuevo perfil del Administrador de Presets."
 
-#: ../../vdms_panels/av_conversions.py:325
 msgid "Available video encoders. \"Copy\" means that the video stream will not be re-encoded and will allow you (depending on the encoder) to change the container, audio codec and a few other parameters."
 msgstr "Codificadores de video disponibles. \"Copiar\" indica que el flujo de video no sera recodificado y permite (según el codificador) cambiar el contenedor, codificador de audio y algunos otros parámetros."
 
-#: ../../vdms_panels/av_conversions.py:330
 msgid ""
 "Container format. It is usually represented by the file extension (output format).\n"
 "\n"
@@ -2468,7 +1830,6 @@ msgstr ""
 "\n"
 "If the media target is set to \"Audio\", you can extract only the audio streams from videos, or simply convert audio source files."
 
-#: ../../vdms_panels/av_conversions.py:338
 msgid ""
 "Set output files target: \"Video\" to save output files as video files; \"Audio\" to save files using an audio encoder and format.\n"
 "\n"
@@ -2478,46 +1839,34 @@ msgstr ""
 "\n"
 "Note que al usar \"Audio\" como destino, aun podrá trabajar sobre los archivos video originales pero solo podrá extraer los flujos de  audio, convertirlos y aplicarles filtros como el de normalización."
 
-#: ../../vdms_panels/av_conversions.py:346
 msgid "Preview video filters"
 msgstr "Previsualizar filtros de video"
 
-#: ../../vdms_panels/av_conversions.py:347
 msgid "Disable active filters"
 msgstr "Desactivar filtros activos"
 
-#: ../../vdms_panels/av_conversions.py:348
-#: ../../vdms_panels/sequence_to_video.py:156
-#: ../../vdms_panels/video_to_sequence.py:113
 msgid "Resize"
 msgstr "Redimencionar"
 
-#: ../../vdms_panels/av_conversions.py:349
 msgid "Crop"
 msgstr "Recortar"
 
-#: ../../vdms_panels/av_conversions.py:350
 msgid "Transpose"
 msgstr "Transponer"
 
-#: ../../vdms_panels/av_conversions.py:352
 #, fuzzy
 msgid "Denoise"
 msgstr "ReduceRuido"
 
-#: ../../vdms_panels/av_conversions.py:353
 msgid "Stabilize"
 msgstr "Estabilizar"
 
-#: ../../vdms_panels/av_conversions.py:354
 msgid "Equalize"
 msgstr "Equalizar"
 
-#: ../../vdms_panels/av_conversions.py:517
 msgid "Unable to preview Video Stabilizer filter"
 msgstr "No se puede previsualizar el filtro Estabilizador de Video"
 
-#: ../../vdms_panels/av_conversions.py:602
 msgid ""
 "Unsupported file:\n"
 "Missing decoder or library? Check FFmpeg configuration."
@@ -2525,22 +1874,15 @@ msgstr ""
 "Archivo no soportado:\n"
 "¿Falta decodificador o librería? Revise la configuración de FFmpeg."
 
-#: ../../vdms_panels/av_conversions.py:611
-#: ../../vdms_panels/sequence_to_video.py:351
-#: ../../vdms_panels/video_to_sequence.py:398
 msgid "The file is not a frame or a video file"
 msgstr "El archivo no es un cuadro o archivo de video"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:434
-#: ../../vdms_panels/av_conversions.py:861
 msgid "Undetected volume values! Click the \"Volume detect\" button to analyze audio volume data."
 msgstr "¡No se detectaron valores de volumen! Presione el botón \"Detectar Volumen\" para analizar los datos del audio."
 
-#: ../../vdms_panels/av_conversions.py:1186
 msgid "Off"
 msgstr "Apagado"
 
-#: ../../vdms_panels/av_conversions.py:1203
 msgid ""
 "Batch processing items\n"
 "Destination\n"
@@ -2566,109 +1908,81 @@ msgstr ""
 "Segmento inicial\n"
 "Duración de Clip"
 
-#: ../../vdms_panels/av_conversions.py:1246
-#: ../../vdms_panels/presets_manager.py:814
 #, python-brace-format
 msgid "Write profile on «{0}»"
 msgstr "Escribir perfil en «{0}»"
 
-#: ../../vdms_panels/av_conversions.py:1266
-#: ../../vdms_panels/presets_manager.py:513
 msgid "Enter name for new preset"
 msgstr "Intorduzca nombre del nuevo preset"
 
-#: ../../vdms_panels/av_conversions.py:1276
-#: ../../vdms_panels/presets_manager.py:524
 msgid "Invalid file name, make sure to provide a valid name including the «.json» extension"
 msgstr "Nombre de archivo invalido, asegúrese de proporcionar un nombre valido incluyendo la extensión «.json»"
 
-#: ../../vdms_panels/av_conversions.py:1284
 #, python-brace-format
 msgid "Cannot save current data in file «{}»."
 msgstr "No se puede guardar la información actual en '{}'."
 
-#: ../../vdms_panels/av_conversions.py:1289
 msgid "Open Videomass preset"
 msgstr "Abrir preset de Videomass"
 
-#: ../../vdms_panels/av_conversions.py:1307
 msgid "Videomass - Save new profile"
 msgstr "Videomass - Guardar nuevo perfil"
 
-#: ../../vdms_panels/av_conversions.py:1308
 msgid "Where do you want to save this profile?"
 msgstr "¿Desea guardar el perfil?"
 
-#: ../../vdms_panels/av_conversions.py:1309
 msgid "Save the profile to a new preset"
 msgstr "Guardar perfil en nuevo preset"
 
-#: ../../vdms_panels/av_conversions.py:1310
 msgid "Save the profile to an existing preset"
 msgstr "Guardar perfil en preset existente"
 
-#: ../../vdms_panels/choose_topic.py:69
 msgid "Welcome to Videomass"
 msgstr "Bienvenido a Videomass"
 
-#: ../../vdms_panels/choose_topic.py:71
 #, python-brace-format
 msgid "Version {}"
 msgstr "Versión {}"
 
-#: ../../vdms_panels/choose_topic.py:82
 msgid "Presets Manager"
 msgstr "Administrador de Presets"
 
-#: ../../vdms_panels/choose_topic.py:85
 msgid "AV-Conversions"
 msgstr "Conversiones-AV"
 
-#: ../../vdms_panels/choose_topic.py:88
 msgid "Concatenate media files"
 msgstr "Encadenar archivos de medios"
 
-#: ../../vdms_panels/choose_topic.py:91
 msgid "Still Image Maker"
 msgstr "Productor de Imágenes Fijas"
 
-#: ../../vdms_panels/choose_topic.py:94
 msgid "From Movie to Pictures"
 msgstr "De Película a Imágenes"
 
-#: ../../vdms_panels/choose_topic.py:123
 msgid "Create, edit and use quickly your favorite FFmpeg presets and profiles with full formats support and codecs."
 msgstr "Crear, editar y usar rápidamente sus presets y perfiles favoritos de FFmpeg con un completo soporte de formatos y codecs."
 
-#: ../../vdms_panels/choose_topic.py:127
 msgid "A set of useful tools for audio and video conversions. Save your profiles and reuse them with Presets Manager."
 msgstr "Un conjunto de herramientas útiles para conversiones de audio y video. Guarde sus perfiles y reutilicelos con el Administrador de Presets."
 
-#: ../../vdms_panels/choose_topic.py:131
 msgid "Concatenate multiple media files based on import order without re-encoding"
 msgstr "Encadenar múltiples archivos de medios en base a su orden de importación sin recodificar"
 
-#: ../../vdms_panels/choose_topic.py:134
 msgid "Create video from a sequence of images, based on import order, with the ability to add an audio file."
 msgstr "Crear video a partir de una secuencia de imágenes, ordenadas según se importan, con la posibilidad de añadir un archivo de audio file."
 
-#: ../../vdms_panels/choose_topic.py:137
 msgid "Extract images (frames) from your movies in JPG, PNG, BMP, GIF formats."
 msgstr "Extraer cuadros desde películas  a imágenes  en formatos JPG, PNG, BMP, GIF ."
 
-#: ../../vdms_panels/concatenate.py:47
 msgid "At least two files are required to perform concatenation."
 msgstr "Se requieren al menos dos archivos para realizar la encadenación."
 
-#: ../../vdms_panels/concatenate.py:63
 msgid "Invalid data found"
 msgstr "Información invalida"
 
-#: ../../vdms_panels/concatenate.py:68
 msgid "The files do not have the same \"codec_types\", same \"sample_rate\" or same \"width\" or \"height\". Unable to proceed."
 msgstr "Los archivos no tienen los mismos \"codec\", \"frec. muestreo\" o \"ancho\" o \"altura\". No se puede proceder."
 
-#: ../../vdms_panels/concatenate.py:84
 msgid ""
 "\n"
 "- The concatenation function is performed only with Audio files or only with Video files.\n"
@@ -2696,17 +2010,12 @@ msgstr ""
 "\n"
 "- Los archivo de Audio deben tener los mismos formatos, codecs y frecuencia de muestreo."
 
-#: ../../vdms_panels/concatenate.py:125
 msgid "Videomass Documentation:"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:136
-#: ../../vdms_panels/sequence_to_video.py:212
-#: ../../vdms_panels/video_to_sequence.py:181
 msgid "Official FFmpeg documentation:"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:253
 msgid ""
 "Items to concatenate\n"
 "File destination\n"
@@ -2720,254 +2029,192 @@ msgstr ""
 "Tipo de salida multimedia\n"
 "Duración"
 
-#: ../../vdms_panels/filedrop.py:45
 msgid "File has illegal characters like:"
 msgstr "Archivo con caracteres ilegales:"
 
-#: ../../vdms_panels/filedrop.py:46
 msgid "Invalid character found in path name: (\")"
 msgstr "Carácter invalido en la trayectoria: (\")"
 
-#: ../../vdms_panels/filedrop.py:47
 msgid "Directories are not allowed, just add files, please."
 msgstr "No se permiten Carpetas, por favor solo añada archivos."
 
-#: ../../vdms_panels/filedrop.py:48
 msgid "File without format extension: please give an appropriate extension to the file name, example '.mkv', '.avi', '.mp3', etc."
 msgstr "Archivo sin extensión de formato: ponga una extensión apropiada al archivo, ejemplo '.mkv', '.avi','.mp3', etc."
 
-#: ../../vdms_panels/filedrop.py:84
 #, python-brace-format
 msgid "Name has illegal characters like: {0}"
 msgstr "Nombre con caracteres invalidos: {0}"
 
-#: ../../vdms_panels/filedrop.py:85
 msgid "Name already in use:"
 msgstr "El nombre ya esta en uso:"
 
-#: ../../vdms_panels/filedrop.py:185
 msgid "Duplicate file, it has already been added to the list."
 msgstr "El archivo ya esta en la lista."
 
-#: ../../vdms_panels/filedrop.py:197
 msgid "Rejected files"
 msgstr "Archivos Rechazados"
 
-#: ../../vdms_panels/filedrop.py:269
 msgid "Source file"
 msgstr "Archivo fuente"
 
-#: ../../vdms_panels/filedrop.py:270
 msgid "Duration"
 msgstr "Duración"
 
-#: ../../vdms_panels/filedrop.py:271
 msgid "Media type"
 msgstr "Tipo de Medio"
 
-#: ../../vdms_panels/filedrop.py:272
 msgid "Size"
 msgstr "Tamaño"
 
-#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:405
 msgid "Drag one or more files below"
 msgstr "Arrastre uno o más archivos abajo"
 
-#: ../../vdms_panels/filedrop.py:282
 msgid "Save to:"
 msgstr "Guardar a:"
 
-#: ../../vdms_panels/filedrop.py:306
 msgid "Set a new destination folder for encodings"
 msgstr "Carpeta destino para codificaciones"
 
-#: ../../vdms_panels/filedrop.py:308
 msgid "Encodings destination folder"
 msgstr "Carpeta destino para codificaciones"
 
-#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:394
 msgid "Play file"
 msgstr "Reproducir archivo"
 
-#: ../../vdms_panels/filedrop.py:408
 msgid "Drag two or more Audio/Video files below"
 msgstr "Arrastre dos o más archivos Audio/Video abajo"
 
-#: ../../vdms_panels/filedrop.py:412
 #, fuzzy
 msgid "Drag one or more Image files below"
 msgstr "Arrastre uno o más archivos abajo"
 
-#: ../../vdms_panels/filedrop.py:415
 msgid "Drag one or more Video files below"
 msgstr "Arrastre uno o más archivos Video abajo"
 
-#: ../../vdms_panels/filedrop.py:623
 msgid "Rename the file destination"
 msgstr "Renombra archivo destino"
 
-#: ../../vdms_panels/filedrop.py:624
 msgid "Rename the selected file to:"
 msgstr "Renombrar archivo seleccionado a:"
 
-#: ../../vdms_panels/filedrop.py:638 ../../vdms_panels/filedrop.py:648
-#: ../../vdms_panels/filedrop.py:679
 msgid "Add Files"
 msgstr "Añadir Archivos"
 
-#: ../../vdms_panels/filedrop.py:655
 msgid "Rename in batch"
 msgstr "Renombrar por lote"
 
-#: ../../vdms_panels/filedrop.py:656
 #, python-brace-format
 msgid "Rename the {0} items to:"
 msgstr "Renombrar {0} objetos a:"
 
-#: ../../vdms_panels/filedrop.py:658
 msgid "New Name #"
 msgstr "Nombre Nuevo #"
 
-#: ../../vdms_panels/long_processing_task.py:114
 msgid "Sorry, all task failed !"
 msgstr "¡Ha fallado la tarea !"
 
-#: ../../vdms_panels/long_processing_task.py:115
 msgid "The process was stopped due to a fatal error."
 msgstr "Proceso detenido debido a error fatal."
 
-#: ../../vdms_panels/long_processing_task.py:116
 msgid "Interrupted Process !"
 msgstr "¡Proceso Interrumpido !"
 
-#: ../../vdms_panels/long_processing_task.py:117
 msgid "Successfully completed !"
 msgstr "¡Completado exitosamente !"
 
-#: ../../vdms_panels/long_processing_task.py:118
 msgid "Not everything was successful."
 msgstr "No todo fue exitoso."
 
-#: ../../vdms_panels/long_processing_task.py:148
 msgid "Encoding Status"
 msgstr "Estado de codificación"
 
-#: ../../vdms_panels/long_processing_task.py:152
 msgid "Current Log"
 msgstr "Registro"
 
-#: ../../vdms_panels/long_processing_task.py:354
 msgid "Fatal Error !"
 msgstr "¡Error Fatal !"
 
-#: ../../vdms_panels/long_processing_task.py:363
 msgid "Get your files at the destination you specified"
 msgstr "Guarde sus archivos en el destino especificado"
 
-#: ../../vdms_panels/long_processing_task.py:377
 msgid "For more details please read the Current Log."
 msgstr "Para mas detalles vea el Registro."
 
-#: ../../vdms_panels/long_processing_task.py:380
 msgid "...Finished"
 msgstr "...Completado"
 
-#: ../../vdms_panels/long_processing_task.py:399
 msgid "Please wait... interruption in progress"
 msgstr "Por favor espere.. Abortando"
 
-#: ../../vdms_panels/long_processing_task.py:402
 msgid "...Interrupted"
 msgstr "...Interrumpido"
 
-#: ../../vdms_panels/presets_manager.py:166
 msgid "Presets"
 msgstr "Presets"
 
-#: ../../vdms_panels/presets_manager.py:180
 msgid "Write"
 msgstr "Escribir"
 
-#: ../../vdms_panels/presets_manager.py:184
 msgid "Delete"
 msgstr "Borrar"
 
-#: ../../vdms_panels/presets_manager.py:194
 msgid "Duplicate"
 msgstr "Duplicado"
 
-#: ../../vdms_panels/presets_manager.py:199
 msgid "Profiles"
 msgstr "Perfiles"
 
-#: ../../vdms_panels/presets_manager.py:206
 msgid "One-Pass Encoding"
 msgstr "Codificación en Un-Paso"
 
-#: ../../vdms_panels/presets_manager.py:218
 msgid "Two-Pass Encoding"
 msgstr "Codificación en Dos-Pasos"
 
-#: ../../vdms_panels/presets_manager.py:232
 msgid "Choose a preset and view its profiles"
 msgstr "Elija un preset y vea sus perfiles"
 
-#: ../../vdms_panels/presets_manager.py:233
 #, fuzzy
 msgid "Write a new profile and save it in the selected preset"
 msgstr "Crear un nuevo perfil y guardarlo en el preset seleccionado"
 
-#: ../../vdms_panels/presets_manager.py:235
 msgid "Delete the selected profile"
 msgstr "Borrar perfil seleccionado"
 
-#: ../../vdms_panels/presets_manager.py:236
 msgid "Edit the selected profile"
 msgstr "Editar perfil seleccionado"
 
-#: ../../vdms_panels/presets_manager.py:237
 msgid "Duplicate the selected profile"
 msgstr "Duplicar perfil seleccionado"
 
-#: ../../vdms_panels/presets_manager.py:238
 #, fuzzy
 msgid "Create new preset"
 msgstr "Crear nuevo preset"
 
-#: ../../vdms_panels/presets_manager.py:240
 msgid "Remove selected preset"
 msgstr "Quitar preset seleccionado"
 
-#: ../../vdms_panels/presets_manager.py:242
 msgid "Backup selected preset"
 msgstr "Respaldar preset seleccionado"
 
-#: ../../vdms_panels/presets_manager.py:244
 msgid "Backup the presets folder"
 msgstr "Respaldar carpeta de presets"
 
-#: ../../vdms_panels/presets_manager.py:246
 msgid "Restore a preset"
 msgstr "Restablecer un preset"
 
-#: ../../vdms_panels/presets_manager.py:248
 msgid "Restore a presets folder"
 msgstr "Restablecer carpeta de presets"
 
-#: ../../vdms_panels/presets_manager.py:250
 msgid "Resets the selected preset to default values"
 msgstr "Restablecer preset seleccionado"
 
-#: ../../vdms_panels/presets_manager.py:252
 msgid "Reset all presets to default values"
 msgstr "Restablecer todos los presets"
 
-#: ../../vdms_panels/presets_manager.py:254
 #, fuzzy
 msgid "Refresh the presets list"
 msgstr "Actualizar lista de presets"
 
-#: ../../vdms_panels/presets_manager.py:338
 #, python-brace-format
 msgid ""
 "Outdated presets version found: v{1}\n"
@@ -2990,28 +2237,22 @@ msgstr ""
 "\n"
 "¿Desea actualizar?"
 
-#: ../../vdms_panels/presets_manager.py:403
 msgid "Name"
 msgstr "Nombre"
 
-#: ../../vdms_panels/presets_manager.py:405
 msgid "Output Format"
 msgstr "Formato de Salida"
 
-#: ../../vdms_panels/presets_manager.py:406
 msgid "Supported Format List"
 msgstr "Lista de formatos soportados"
 
-#: ../../vdms_panels/presets_manager.py:531
 #, python-brace-format
 msgid "Cannot save current data in file '{}'."
 msgstr "No se puede guardar la información actual en '{}'."
 
-#: ../../vdms_panels/presets_manager.py:535
 msgid "You just successfully created a new preset!"
 msgstr "¡Preset creado exitosamente!"
 
-#: ../../vdms_panels/presets_manager.py:547
 #, python-brace-format
 msgid ""
 "Are you sure you want to remove \"{}\" preset?\n"
@@ -3022,7 +2263,6 @@ msgstr ""
 "\n"
 "Se moverá a la carpeta \"Removals\" dentro de la carpeta de presets."
 
-#: ../../vdms_panels/presets_manager.py:558
 #, python-brace-format
 msgid ""
 "{}\n"
@@ -3033,30 +2273,22 @@ msgstr ""
 "\n"
 "Fallo al eliminar, no se puede continuar.."
 
-#: ../../vdms_panels/presets_manager.py:568
 #, python-brace-format
 msgid "The preset \"{0}\" was successfully removed"
 msgstr "El preset \"{0}\" se elimino con exito"
 
-#: ../../vdms_panels/presets_manager.py:583
-#: ../../vdms_panels/presets_manager.py:612
 msgid "Open a destination folder"
 msgstr "Abrir carpeta destino"
 
-#: ../../vdms_panels/presets_manager.py:588
 msgid "A file with this name already exists, do you want to overwrite it?"
 msgstr "Ya existe archivo con ese nombres, ¿quiere sobreecribirlo?"
 
-#: ../../vdms_panels/presets_manager.py:602
-#: ../../vdms_panels/presets_manager.py:622
 msgid "Backup completed successfully"
 msgstr "¡Respaldo completado con éxito!"
 
-#: ../../vdms_panels/presets_manager.py:631
 msgid "Open the preset you want to restore"
 msgstr "Abra el preset a restaurar"
 
-#: ../../vdms_panels/presets_manager.py:645
 msgid ""
 "This preset already exists and is about to be updated. Don't worry, it will keep all your saved profiles.\n"
 "\n"
@@ -3066,11 +2298,9 @@ msgstr ""
 "\n"
 "¿Desea continuar?"
 
-#: ../../vdms_panels/presets_manager.py:663
 msgid "Restore successful"
 msgstr "¡Restauración exitosa!"
 
-#: ../../vdms_panels/presets_manager.py:681
 msgid ""
 "This will update the presets database. Don't worry, it will keep all your saved profiles.\n"
 "\n"
@@ -3080,19 +2310,15 @@ msgstr ""
 "\n"
 "¿Desea continuar?"
 
-#: ../../vdms_panels/presets_manager.py:689
 msgid "Open the presets folder to restore"
 msgstr "Abrir carpeta de presets a restaurar"
 
-#: ../../vdms_panels/presets_manager.py:725
 msgid "The presets database has been successfully updated"
 msgstr "Base de datos de presets actualizada con exito"
 
-#: ../../vdms_panels/presets_manager.py:740
 msgid "The selected preset is not part of Videomass's default presets."
 msgstr "Preset seleccionado no es parte de Videomass."
 
-#: ../../vdms_panels/presets_manager.py:745
 msgid ""
 "Be careful! The selected preset will be overwritten with the default one. Your profiles may be deleted!\n"
 "\n"
@@ -3102,12 +2328,9 @@ msgstr ""
 "\n"
 "¿Desea continuar?"
 
-#: ../../vdms_panels/presets_manager.py:760
-#: ../../vdms_panels/presets_manager.py:794
 msgid "Successful recovery"
 msgstr "Recuperación exitosa"
 
-#: ../../vdms_panels/presets_manager.py:769
 msgid ""
 "Be careful! This action will restore all presets to default ones. Your profiles may be deleted!\n"
 "\n"
@@ -3121,20 +2344,16 @@ msgstr ""
 "\n"
 "¿Desea continuar?"
 
-#: ../../vdms_panels/presets_manager.py:833
 #, python-brace-format
 msgid "Edit profile on «{0}»"
 msgstr "Editar perfil en «{0}»"
 
-#: ../../vdms_panels/presets_manager.py:872
 msgid "Are you sure you want to delete the selected profile? It will no longer be possible to recover it."
 msgstr "¿Seguro que desea borrar el perfil seleccionado? No sera posible recuperarlo."
 
-#: ../../vdms_panels/presets_manager.py:891
 msgid "First select a profile in the list"
 msgstr "Primero elija un perfil en la lista"
 
-#: ../../vdms_panels/presets_manager.py:899
 msgid ""
 "The selected profile command has been changed manually.\n"
 "Do you want to apply it during the conversion process?"
@@ -3142,11 +2361,9 @@ msgstr ""
 "El comando del perfil seleccionado se cambio manualmente.\n"
 "¿Desea aplicarlo durante el proceso de conversión?"
 
-#: ../../vdms_panels/presets_manager.py:909
 msgid "Don't show this dialog again"
 msgstr "No mostrar nuevamente este dialogo"
 
-#: ../../vdms_panels/presets_manager.py:1054
 msgid ""
 "Batch processing items\n"
 "Destination\n"
@@ -3166,12 +2383,10 @@ msgstr ""
 "Inicio de segmento\n"
 "Duración de Clip"
 
-#: ../../vdms_panels/sequence_to_video.py:54
 #, fuzzy
 msgid "Images need to be resized, please use Resize function."
 msgstr "Las Imágenes deben redimencionarse, por favor use la función Redimensionar."
 
-#: ../../vdms_panels/sequence_to_video.py:73
 msgid ""
 "\n"
 "1. Import one or more image files such as JPG, PNG and BMP formats, then select one.\n"
@@ -3202,11 +2417,9 @@ msgstr ""
 "El video producido tendrá el nombre del archivo seleccionado en el panel 'Lista de Archivos' , \n"
 "y sera guardado en una carpeta llamada 'Still_Images' con un digito progresivo, en la trayectoria especificada."
 
-#: ../../vdms_panels/sequence_to_video.py:129
 msgid "Enable a single still image"
 msgstr "Habilitar solo una imagen fija"
 
-#: ../../vdms_panels/sequence_to_video.py:162
 msgid ""
 "Force original aspect ratio using\n"
 "padding rather than stretching"
@@ -3214,28 +2427,21 @@ msgstr ""
 "Forzar la relación de aspecto original usando\n"
 "rellenar en lugar de estirar"
 
-#: ../../vdms_panels/sequence_to_video.py:170
 msgid "Include audio file"
 msgstr "Incluir archivo de audio"
 
-#: ../../vdms_panels/sequence_to_video.py:173
 msgid "Play the video until audio track finishes"
 msgstr "Reproducir video hasta que la pista de audio finalice"
 
-#: ../../vdms_panels/sequence_to_video.py:180
-#: ../../vdms_panels/sequence_to_video.py:439
 msgid "Open audio file"
 msgstr "Abrir archivo de audio"
 
-#: ../../vdms_panels/sequence_to_video.py:199
 msgid "Additional arguments"
 msgstr "Argumentos Adicionales"
 
-#: ../../vdms_panels/sequence_to_video.py:454
 msgid "Open Audio File"
 msgstr "Abrir Archivo de Audio"
 
-#: ../../vdms_panels/sequence_to_video.py:466
 #, python-brace-format
 msgid ""
 "Invalid file: '{}'\n"
@@ -3246,7 +2452,6 @@ msgstr ""
 "\n"
 "{}"
 
-#: ../../vdms_panels/sequence_to_video.py:471
 #, python-brace-format
 msgid ""
 "Invalid file: '{}'\n"
@@ -3257,21 +2462,14 @@ msgstr ""
 "\n"
 "No parece un archivo de audio."
 
-#: ../../vdms_panels/sequence_to_video.py:560
-#: ../../vdms_panels/sequence_to_video.py:587
-#: ../../vdms_panels/video_to_sequence.py:511
 #, python-brace-format
 msgid "Invalid file: '{}'"
 msgstr "Archivo invalido: \"{}\""
 
-#: ../../vdms_panels/sequence_to_video.py:570
-#: ../../vdms_panels/sequence_to_video.py:595
 #, python-brace-format
 msgid "Unsupported format '{}'"
 msgstr "Formato no soportado '{}'"
 
-#: ../../vdms_panels/sequence_to_video.py:576
-#: ../../vdms_panels/sequence_to_video.py:600
 #, python-brace-format
 msgid ""
 "File does not exist:\n"
@@ -3282,15 +2480,9 @@ msgstr ""
 "\n"
 "\"{}\"\n"
 
-#: ../../vdms_panels/sequence_to_video.py:577
 msgid "ERROR"
 msgstr "ERROR"
 
-#: ../../vdms_panels/sequence_to_video.py:707
-msgid "Shortest"
-msgstr "MiniPrueba"
-
-#: ../../vdms_panels/sequence_to_video.py:715
 msgid ""
 "Items to concatenate\n"
 "Output filename\n"
@@ -3318,7 +2510,6 @@ msgstr ""
 "Duración de Imagen Fija\n"
 "Duración total de Video"
 
-#: ../../vdms_panels/video_to_sequence.py:50
 msgid ""
 "\n"
 "1. Import one or more video files, then select one.\n"
@@ -3348,51 +2539,39 @@ msgstr ""
 "Las imágenes producidas serán guardadas en una carpeta llamada 'Movie_to_Pictures'\n"
 "con un digito progresivo, en la trayectoria especificada."
 
-#: ../../vdms_panels/video_to_sequence.py:86
 msgid "Create thumbnails"
 msgstr "Crear miniaturas"
 
-#: ../../vdms_panels/video_to_sequence.py:87
 msgid "Create tiled mosaics"
 msgstr "Crear mosaicos"
 
-#: ../../vdms_panels/video_to_sequence.py:88
 msgid "Create animated GIF"
 msgstr "Crear GIF animado"
 
-#: ../../vdms_panels/video_to_sequence.py:90
 msgid "Options"
 msgstr "Opciones"
 
-#: ../../vdms_panels/video_to_sequence.py:119
 msgid "Output format:"
 msgstr "Formato de Salida:"
 
-#: ../../vdms_panels/video_to_sequence.py:131
 msgid "Rows:"
 msgstr "Renglones:"
 
-#: ../../vdms_panels/video_to_sequence.py:141
 msgid "Columns:"
 msgstr "Columnas:"
 
-#: ../../vdms_panels/video_to_sequence.py:205
 msgid "Other unofficial resources:"
 msgstr "Otros recursos no oficiales:"
 
-#: ../../vdms_panels/video_to_sequence.py:229
 msgid "Set FPS control from 0.1 to 30.0 fps. The higher this value, the more images will be extracted."
 msgstr "Fijar el control de FPS, desde 0.1 hasta 30.0 fps. Entre más alto el valor se extraen más imágenes."
 
-#: ../../vdms_panels/video_to_sequence.py:232
 msgid "Spaces around the mosaic tiles. From 0 to 32 pixels"
 msgstr "Espacio entre mosaicos. Desde 0 hasta 32 pixels"
 
-#: ../../vdms_panels/video_to_sequence.py:234
 msgid "Spaces around the mosaic borders. From 0 to 32 pixels"
 msgstr "Espacio entre bordes de mosaicos. Desde 0 hasta 32 pixels"
 
-#: ../../vdms_panels/video_to_sequence.py:626
 msgid ""
 "Selected File\n"
 "Output Format\n"
@@ -3420,51 +2599,39 @@ msgstr ""
 "Inicio de segmento\n"
 "Duración"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:118
 msgid "Audio encoder settings, mapping and filters"
 msgstr "Configuración de codificador de Audio, mapeo y filtros"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:128
 msgid "Audio Encoder"
 msgstr "Codificador de Audio"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:137
 msgid "Settings"
 msgstr "Configuraciones"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:148
 msgid "Index Selection:"
 msgstr "Selecciòn de Indice:"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:157
 msgid "Map:"
 msgstr "Mapear:"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:180
 msgid "Normalization"
 msgstr "Normalización"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:191
 msgid "Volume detect"
 msgstr "Detectar Volumen"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:195
 msgid "Volume Statistics"
 msgstr "Estadísticas de Volumen"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:199
 msgid "Target level:"
 msgstr "Nivel Objetivo:"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:264
 msgid "Gets maximum volume and average volume data in dBFS, then calculates the offset amount for audio normalization."
 msgstr "Obtiene el volumen máximo y promedio en dBFs, y calcula el desplazamiento para normalizar el audio."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:267
 msgid "Limiter for the maximum peak level or the mean level (when switch to RMS) in dBFS. From -99.0 to +0.0; default for PEAK level is -1.0; default for RMS is -20.0"
 msgstr "Limita por máximo nivel de pico o por nivel promedio (cuando se usa RMS) en dBFS. Desde -99 a +0.0; predeterminado para nivel de pico es -1.0; para RMS es 20.0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:271
 msgid ""
 "Normally on a video with correctly indexed streams and having one or more audio streams, the first audio stream should be indexed at \"1\", the second at \"2\" and so on (the video stream on the other hand is always indexed at \"0\"). In this case it is recommended to select the desired stream by setting a specific index, e.g \"1\" for for the first available audio stream.\n"
 "\n"
@@ -3474,7 +2641,6 @@ msgstr ""
 "\n"
 "Ponga este control en \"Auto\" si la fuente es una pista de audio ."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:280
 msgid ""
 "\"Auto\" keeps all audio streams and processes only the one selected by the \"Index Selection\" control.\n"
 "\n"
@@ -3488,28 +2654,22 @@ msgstr ""
 "\n"
 "\"Solo el Indice\" procesa solo el flujo de audio seleccionado en el control \"Selección de Indice\" y elimina el resto"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:288
 msgid "Integrated Loudness Target in LUFS. From -70.0 to -5.0, default is -16.0"
 msgstr "Intensidad Destino Integrada en LUFS. Desde -70.0 a -5.0, predeterminado -16.0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:291
 msgid "Maximum True Peak in dBTP. From -1.5 to +0.0, default is -2.0"
 msgstr "Pico Máximo Real en dBTP. Desde -9.0 a +0.0, predeterminado -2.0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:294
 #, fuzzy
 msgid "Loudness Range Target in LUFS. From +1.0 to +20.0, default is +11.0"
 msgstr "Rango de Intensidad Destino en LUFS. Desde +1.0 a +20.0, predeterminado +7.0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:297
 msgid "Play the audio stream selected in the \"Index Selection\" control. Using this function you can test the result of audio normalization."
 msgstr "Reproducir el flujo de audio seleccionado en la \"Selección de Indice\". Con esta función puede probar el resultado de normalizar el audio."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:503
 msgid "Selected index does not exist or does not contain any audio streams"
 msgstr "El indice seleccionado no existe o no contiene flujos de audio"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:508
 #, python-brace-format
 msgid ""
 "ERROR: Missing audio stream:\n"
@@ -3518,15 +2678,12 @@ msgstr ""
 "ERROR: Falta flujo de audio:\n"
 "\"{}\""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:726
 msgid "PEAK level normalization, which will produce a maximum peak level equal to the set target level."
 msgstr "Normalización de nivel de pico, produce un nivel de pico máximo igual al configurado."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:729
 msgid "RMS-based normalization, which according to mean volume calculates the amount of gain to reach same average power signal."
 msgstr "Normalización RMS, se calcula la ganancia de acuerdo al volumen medio para lograr la misma potencia promedio de señal."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:733
 msgid ""
 "Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements the EBU R128 algorithm.\n"
 "Ideal for live normalization. It produces worse results than the High-quality two-pass Loudnorm normalization, but is faster."
@@ -3534,7 +2691,6 @@ msgstr ""
 "Normalización de intensidad. Se Normaliza la intensidad percibida utilizando el filtro \"​loudnorm\", el cual implementa el algoritmo EBU R128.\n"
 "Ideal par normalización en vivo. Produce peores resultados que la normalización de intensidad en dos pasos de Alta calidad, pero es mas rápida."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:740
 msgid ""
 "High-quality two-pass Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements\n"
 "the EBU R128 algorithm. Ideal for postprocessing."
@@ -3542,23 +2698,18 @@ msgstr ""
 "Normalización de intensidad Alta calidad en dos pasos. Se Normaliza la intensidad percibida utilizando el filtro \"​loudnorm\", el cual\n"
 "implementa el algoritmo EBU R128. Ideal para postprocesado."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:789
 msgid "You need to import at least one file"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:63
 msgid "Subtitle Mapping:"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:77
 msgid "Copy Chapters"
 msgstr "Copiar capítulos"
 
-#: ../../vdms_panels/miscellaneous/miscell.py:79
 msgid "Copy Metadata"
 msgstr "Copiar metadatos"
 
-#: ../../vdms_panels/miscellaneous/miscell.py:85
 msgid ""
 "Select \"All\" to include any source file subtitles in the output video.\n"
 "\n"
@@ -3572,152 +2723,68 @@ msgstr ""
 "\n"
 "Se ignora esta opción sil la salida es archivo de audio."
 
-#: ../../vdms_panels/miscellaneous/miscell.py:90
 msgid "Copy the chapter markers as is from source file. This option is automatically ignored for output audio files."
 msgstr "Copiar las marcas de capítulos desde la fuente. Se ignora esta opción sil la salida es archivo de audio."
 
-#: ../../vdms_panels/miscellaneous/miscell.py:93
 msgid "Copy all incoming metadata from source file, such as audio/video tags, titles, unique marks, and so on."
 msgstr "Copiar todos los metadatos desde la fuente, cosas como etiquetas de audio/video, títulos, marcas únicas, etc."
 
-#: ../../vdms_panels/miscellaneous/miscell.py:108
 #, fuzzy
 msgid "Additional options"
 msgstr "Argumentos Adicionales"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:89
-#: ../../vdms_panels/video_encoders/av1_svt.py:120
-#: ../../vdms_panels/video_encoders/avc_x264.py:90
-#: ../../vdms_panels/video_encoders/hevc_x265.py:98
-#: ../../vdms_panels/video_encoders/mpeg4.py:71
-#: ../../vdms_panels/video_encoders/vp9_webm.py:131
 #, fuzzy
 msgid "Reload"
 msgstr "Recargar"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:101
-#: ../../vdms_panels/video_encoders/av1_svt.py:129
-#: ../../vdms_panels/video_encoders/avc_x264.py:101
-#: ../../vdms_panels/video_encoders/hevc_x265.py:109
-#: ../../vdms_panels/video_encoders/mpeg4.py:82
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:97
-#: ../../vdms_panels/video_encoders/vp9_webm.py:141
 #, fuzzy
 msgid "Optimize for Web"
 msgstr "Para uso en Web"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:247
-#: ../../vdms_panels/video_encoders/av1_svt.py:313
-#: ../../vdms_panels/video_encoders/avc_x264.py:242
-#: ../../vdms_panels/video_encoders/hevc_x265.py:250
-#: ../../vdms_panels/video_encoders/mpeg4.py:198
-#: ../../vdms_panels/video_encoders/vp9_webm.py:288
 msgid "Reloads the selected video encoder settings. Changes will be discarded."
 msgstr "Recargar configuración del codificador de video. Se descartaran los cambios."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:250
-#: ../../vdms_panels/video_encoders/avc_x264.py:273
-#: ../../vdms_panels/video_encoders/hevc_x265.py:277
-#: ../../vdms_panels/video_encoders/vp9_webm.py:291
 #, fuzzy
 msgid "Constant rate factor. Lower values correspond to higher quality and greater file size. Set to -1 to disable this control."
 msgstr "Factor de frecuencia Constante. Valores mas bajos = mejor calidad y mayor tamaño de archivo. -1 deshabilita este control."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:254
-#: ../../vdms_panels/video_encoders/av1_svt.py:357
-#: ../../vdms_panels/video_encoders/vp9_webm.py:295
 msgid "Number of tile rows to use, default changes per resolution"
 msgstr "Renglones a usar, el predeterminado cambia según resolución"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:256
-#: ../../vdms_panels/video_encoders/av1_svt.py:359
-#: ../../vdms_panels/video_encoders/vp9_webm.py:297
 msgid "Number of tile columns to use, default changes per resolution"
 msgstr "Columnas a usar, el predeterminado cambia según resolución"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:259
-#: ../../vdms_panels/video_encoders/av1_svt.py:368
-#: ../../vdms_panels/video_encoders/avc_x264.py:253
-#: ../../vdms_panels/video_encoders/hevc_x265.py:261
-#: ../../vdms_panels/video_encoders/mpeg4.py:201
-#: ../../vdms_panels/video_encoders/vp9_webm.py:300
 msgid "Set the Group Of Picture (GOP). Set to -1 to disable this control."
 msgstr "Tamaño del grupo de imágenes (GOP). -1 para desactiva este control."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:262
-#: ../../vdms_panels/video_encoders/av1_svt.py:371
-#: ../../vdms_panels/video_encoders/avc_x264.py:256
-#: ../../vdms_panels/video_encoders/hevc_x265.py:264
-#: ../../vdms_panels/video_encoders/mpeg4.py:204
-#: ../../vdms_panels/video_encoders/vp9_webm.py:303
 msgid "It can reduce the file size, but takes longer."
 msgstr "Puede reducir el tamaño del archivo, pero dilatar más."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:264
-#: ../../vdms_panels/video_encoders/av1_svt.py:373
-#: ../../vdms_panels/video_encoders/avc_x264.py:258
-#: ../../vdms_panels/video_encoders/hevc_x265.py:266
-#: ../../vdms_panels/video_encoders/mpeg4.py:206
-#: ../../vdms_panels/video_encoders/vp9_webm.py:305
 msgid "Set minimum bitrate tolerance. Most useful in setting up a CBR encode. It is of little use otherwise. Set to -1 to disable this control."
 msgstr "Tolerancia de bitrate mínimo. Mas util usada con codificación CBR. Es de poca utilidad en otros casos. -1 deshabilita el control."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:268
-#: ../../vdms_panels/video_encoders/av1_svt.py:377
-#: ../../vdms_panels/video_encoders/avc_x264.py:262
-#: ../../vdms_panels/video_encoders/hevc_x265.py:270
-#: ../../vdms_panels/video_encoders/mpeg4.py:210
-#: ../../vdms_panels/video_encoders/vp9_webm.py:309
 msgid "Specifies a maximum tolerance. Requires bufsize to be set. Set to -1 to disable this control."
 msgstr "Especificar tolerancia máxima. Requiere fijar tamaño del buffer. -1 desactiva este control."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:271
-#: ../../vdms_panels/video_encoders/av1_svt.py:380
-#: ../../vdms_panels/video_encoders/avc_x264.py:265
-#: ../../vdms_panels/video_encoders/hevc_x265.py:273
-#: ../../vdms_panels/video_encoders/mpeg4.py:213
-#: ../../vdms_panels/video_encoders/vp9_webm.py:312
 msgid "Set ratecontrol buffer size, which determines the variability of the output bitrate. Set to -1 to disable this control."
 msgstr "Fija control de razón del tamaño de buffer, determina la variabilidad de la frecuencia de bits de salida. -1 desactiva este control."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:275
-#: ../../vdms_panels/video_encoders/av1_svt.py:384
-#: ../../vdms_panels/video_encoders/avc_x264.py:277
-#: ../../vdms_panels/video_encoders/hevc_x265.py:281
-#: ../../vdms_panels/video_encoders/mpeg4.py:231
-#: ../../vdms_panels/video_encoders/vp9_webm.py:316
 msgid "Specifies the target (average) bit rate for the encoder to use. Higher value = higher quality. Set -1 to disable this control."
 msgstr "Especifica la frecuencia de bits (promedio) que usara el codificador. Un valor más alto =  mejor calidad. -1 deshabilita este control."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:279
-#: ../../vdms_panels/video_encoders/av1_svt.py:388
-#: ../../vdms_panels/video_encoders/avc_x264.py:281
-#: ../../vdms_panels/video_encoders/hevc_x265.py:285
-#: ../../vdms_panels/video_encoders/mpeg4.py:235
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:131
-#: ../../vdms_panels/video_encoders/vp9_webm.py:320
 msgid "Video width and video height ratio."
 msgstr "Proporción ancho y alto de video."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:281
-#: ../../vdms_panels/video_encoders/av1_svt.py:390
-#: ../../vdms_panels/video_encoders/avc_x264.py:283
-#: ../../vdms_panels/video_encoders/hevc_x265.py:287
-#: ../../vdms_panels/video_encoders/mpeg4.py:237
-#: ../../vdms_panels/video_encoders/vp9_webm.py:322
 #, fuzzy
 msgid "Frame rate (frames per second). Frames repeat a given number of times per second. In some countries this is 30 for NTSC, other countries (like Italy) use 25 for PAL"
 msgstr "Los cuadros se repiten un dado numero de veces por segundo. En algunos países es 30 para NTSC, en otros  (como Italia) usan 25 para PAL"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:285
 msgid "Quality/Speed ratio modifier. CPU Used sets how efficient the compression will be. Lower values mean slower encoding with better quality, and vice-versa. Valid values are from 0 to 8 inclusive."
 msgstr "Razón Calidad/Velocidad. Fija la eficiencia de la compresión. Valores bajos equivale a una codificación más lenta con mejor calidad, y viceversa. Valores validos incluyen 0 a 8 ."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:290
 msgid "Quality and compression efficiency vs speed trade-off. \"good\" is the default and recommended for most applications; \"realtime\" is recommended for live/fast encoding (live streaming, video conferencing, etc); \"allintra\" for All Intra encoding."
 msgstr "Calidad y compresión del intercambio  eficiencia vs calidad. \"good\" es lo predeterminado y recomendado para muchas aplicaciones;  \"realtime\" recomendado para directos, videoconferencia, etc; «allintra» para la codificación All Intra."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:297
 msgid ""
 "Row Multi-Threading enables row-based multi-threading which maximizes CPU usage.\n"
 "\n"
@@ -3731,7 +2798,6 @@ msgstr ""
 "\n"
 "Activarlo solo es mas rápido si el CPU tiene más hilos que el numero total de cuadros."
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:316
 msgid ""
 "presets 1-3 represent extremely high efficiency, for use when encode time is not important and quality/size of the resulting video file is critical.\n"
 "\n"
@@ -3749,7 +2815,6 @@ msgstr ""
 "\n"
 "Preset 13 es aun más rápido pero no esta dirigido al consumo humano directo --puede usarse por ejemplo para comparaciones por escena de aplicaciones VOD. Solo se debe usar el preset más bajo tolerable."
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:327
 msgid ""
 "Constant rate factor. This parameter governs the quality/size trade-off.\n"
 "\n"
@@ -3767,7 +2832,6 @@ msgstr ""
 "\n"
 " -1 deshabilita el control."
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:334
 msgid ""
 "The \"Film Grain\" parameter allows SVT-AV1 to detect and delete film grain from the source video, and replace it with synthetic grain of the same character, resulting in significant bitrate savings.\n"
 "\n"
@@ -3789,7 +2853,6 @@ msgstr ""
 "\n"
 "Si la fuente de video no tiene grano, se puede desactivar con -1 o usar 0."
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:346
 msgid ""
 "If enabled, the \"Film Grain Denoiser\" option can mitigate the detail removal caused by high \"Film Grain\" values required to preserve the look of very grainy films\n"
 "\n"
@@ -3799,55 +2862,36 @@ msgstr ""
 "\n"
 "Por omisión los cuadros procesados son pasados para ser codificados como imágenes finales, esta caracteristica hara que se usen los cuadros originales. "
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:353
 msgid "Enables encoder optimization to produce faster (less CPU intensive) bit streams to decode, similar to the fastdecode tuning in x264 and x265."
 msgstr "Optimizar codificador para producir un flujo de bits mas rápido (menor uso de CPU) a decodificar, similar al ajuste fastdecode en x264 y x265."
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:362
-#: ../../vdms_panels/video_encoders/avc_x264.py:247
-#: ../../vdms_panels/video_encoders/hevc_x265.py:255
 msgid "Set profile restrictions"
 msgstr "Restricciones de perfil"
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:364
-#: ../../vdms_panels/video_encoders/avc_x264.py:249
-#: ../../vdms_panels/video_encoders/hevc_x265.py:257
 msgid "Specify level for a selected profile"
 msgstr "Especifique nivel del perfil seleccionado"
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:366
-#: ../../vdms_panels/video_encoders/avc_x264.py:251
-#: ../../vdms_panels/video_encoders/hevc_x265.py:259
 msgid "Tune the encoding params"
 msgstr "Afinar parámetros de codificación"
 
-#: ../../vdms_panels/video_encoders/avc_x264.py:245
-#: ../../vdms_panels/video_encoders/hevc_x265.py:253
 msgid "Set the encoding preset (default \"medium\")"
 msgstr "Preset de codificación (por omisión \"medio\")"
 
-#: ../../vdms_panels/video_encoders/avc_x264.py:269
 msgid "specifies the target (average) bit rate for the encoder to use. Higher value = higher quality. Set -1 to disable this control."
 msgstr "especifica la frecuencia de bits (promedio) que usara el codificador. Un valor más alto =  mejor calidad. -1 deshabilita este control."
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:217
 msgid "Variable Bit Rate. From 0-30, with 1 being highest quality/largest filesize and 30 being the lowest quality/smallest filesize. Set to -1 to disable this control."
 msgstr "Flujo Variable de Bits. De 0-30, siendo 1 mayor calidad/mayor tamaño y 30 menor calidad/menor tamaño.  -1 desactiva este control."
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:222
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:133
 msgid "Frames repeat a given number of times per second. In some countries this is 30 for NTSC, other countries (like Italy) use 25 for PAL"
 msgstr "Los cuadros se repiten un dado numero de veces por segundo. En algunos países es 30 para NTSC, en otros  (como Italia) usan 25 para PAL"
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:226
 msgid "The default FourCC stored in an MPEG-4-coded file will be FMP4. If you want a different FourCC, set this option to xvid to force the FourCC xvid to be stored as the video FourCC rather than the default."
 msgstr "El valor FourCC en un video MPEG-4-seria FMP4. Si quiere un valor FourCC diferente, use xvid para forzar FourCC xvid en el video en vez del predeterminado."
 
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:162
 msgid "Copy Video Codec"
 msgstr "Copiar Codec de Video"
 
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:163
 msgid ""
 "This will just copy the video track as is, without any video re-encoding.\n"
 "You will only be able to change output format, select other audio encoders and\n"
@@ -3857,11 +2901,9 @@ msgstr ""
 "Solo podrá cambiar el formato de salida, seleccionar otro codificador de audio y\n"
 "otras pocas opciones."
 
-#: ../../vdms_panels/video_encoders/video_no_enc.py:74
 msgid "Video export disabled"
 msgstr "Exportación de Video desactivada"
 
-#: ../../vdms_panels/video_encoders/video_no_enc.py:75
 msgid ""
 "The Media target you just selected will only allow you to export files as audio tracks.\n"
 "You can then process audio source files only or extract indexed audio streams on\n"
@@ -3871,7 +2913,6 @@ msgstr ""
 "Entonces solo podrá procesar archivos de audio o extraer el audio indicado de\n"
 "los archivos de video."
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:326
 msgid ""
 "Speed sets how efficient the compression will be.\n"
 "\n"
@@ -3893,7 +2934,6 @@ msgstr ""
 "\n"
 "Si Calidad es realtime, los valores de Velocidad son de 0 a 8."
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:335
 msgid ""
 "Time to spend encoding.\n"
 "\n"
@@ -3911,24 +2951,23 @@ msgstr ""
 "\n"
 "\"realtime\" se recomienda para codificaciones en directo/rapidas."
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:341
-msgid "If enabled, adds support for row based multithreading which greatly enhances the number of threads the encoder can utilise. This improves encoding speed significantly on systems that are otherwise underutilised when encoding VP9. Since the amount of additional threads depends on the number of \"tiles\", which itself depends on the video resolution, encoding higher resolution videos will see a larger performance improvement."
-msgstr "Habilitarla, añade multiproceso por renglón que mejora el numero de hilos que el codificador puede usar. Esto mejora significativamente la velocidad de codificado al codificar en VP9, en sistemas que de otra manera están subutilizados. Ya que la cantidad adicional de hilos  depende del numero de \"cuadros\", lo que depende del la resolución del video, codificar videos con altas resoluciones mostrara un gran incremento en el desempeño."
+msgid ""
+"If enabled, adds support for row based multithreading which greatly enhances the number of threads the encoder can utilise. This improves encoding speed significantly on systems that are otherwise underutilised when encoding VP9. Since the amount of additional threads depends on the number of \"tiles\", which itself depends on the video resolution, encoding higher resolution videos will see a "
+"larger performance improvement."
+msgstr ""
+"Habilitarla, añade multiproceso por renglón que mejora el numero de hilos que el codificador puede usar. Esto mejora significativamente la velocidad de codificado al codificar en VP9, en sistemas que de otra manera están subutilizados. Ya que la cantidad adicional de hilos  depende del numero de \"cuadros\", lo que depende del la resolución del video, codificar videos con altas resoluciones "
+"mostrara un gran incremento en el desempeño."
 
-#: ../../vdms_utils/presets_manager_utils.py:46
 #, python-brace-format
 msgid "Supports ({0}) formats only, not ({1})"
 msgstr "Formatos soportados ({0}), no soporta ({1})"
 
-#: ../../vdms_utils/presets_manager_utils.py:49
 msgid "File formats not supported by the selected profile"
 msgstr "Formatos de archivo no soportados por el perfil selecciondo"
 
-#: ../../vdms_utils/presets_manager_utils.py:52
 msgid "Warning"
 msgstr "Advertencia"
 
-#: ../../vdms_utils/presets_manager_utils.py:90
 msgid ""
 "No presets found.\n"
 "\n"
@@ -3938,11 +2977,9 @@ msgstr ""
 "\n"
 "Posible solución: abra el panel del Administrador de Presets, ir a la columna presets y presionar el botón \"Restaurar todo...\""
 
-#: ../../vdms_utils/queue_utils.py:54
 msgid "Import queue file"
 msgstr "Importar archivo de lista"
 
-#: ../../vdms_utils/queue_utils.py:89
 #, python-brace-format
 msgid ""
 "ERROR: invalid data found loading queue file.\n"
@@ -3955,11 +2992,9 @@ msgstr ""
 "\n"
 "No puede contener múltiples valores de `destino`."
 
-#: ../../vdms_utils/queue_utils.py:118
 msgid "Videomass - Add Items to Queue"
 msgstr "Videomass - Añadir Entradas a Lista"
 
-#: ../../vdms_utils/queue_utils.py:119
 msgid ""
 "Multiple items with identical names and destination paths cannot coexist.\n"
 "Please choose one of the following actions:"
@@ -3967,15 +3002,12 @@ msgstr ""
 "Múltiples entradas con nombres y destinos idénticos no pueden coexistir.\n"
 "Elija una de las siguientes acciones:"
 
-#: ../../vdms_utils/queue_utils.py:123
 msgid "Replace occurrences with items from the imported queue."
 msgstr "Reemplace ocurrencias con entradas de la lista importada."
 
-#: ../../vdms_utils/queue_utils.py:124
 msgid "Add only the currently missing items to the queue."
 msgstr "Añadir solo entradas faltantes a la lista."
 
-#: ../../vdms_utils/queue_utils.py:125
 msgid "Remove the current queue and replace it with the imported one."
 msgstr "Eliminar lista actual y reemplazar con la importada."
 
@@ -3987,4 +3019,7 @@ msgstr "Eliminar lista actual y reemplazar con la importada."
 
 #~ msgid "Subtitle Mapping"
 #~ msgstr "Mapeo de Subtitulos"
+
+#~ msgid "Shortest"
+#~ msgstr "MiniPrueba"
 

--- a/videomass/data/locale/es_ES/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/es_ES/LC_MESSAGES/videomass.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Videomass 5.0.18\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-30 11:02+0200\n"
+"POT-Creation-Date: 2025-07-30 15:28+0200\n"
 "PO-Revision-Date: 2024-08-26 17:29-0600\n"
 "Last-Translator: José Alberto Valle Cid j.alberto.vc@gmail.com\n"
 "Language: es_ES\n"
@@ -3010,16 +3010,4 @@ msgstr "Añadir solo entradas faltantes a la lista."
 
 msgid "Remove the current queue and replace it with the imported one."
 msgstr "Eliminar lista actual y reemplazar con la importada."
-
-#~ msgid "Some text boxes are still incomplete"
-#~ msgstr "Algunas cajas de texto están incompletas"
-
-#~ msgid "FFplay"
-#~ msgstr "FFplay"
-
-#~ msgid "Subtitle Mapping"
-#~ msgstr "Mapeo de Subtitulos"
-
-#~ msgid "Shortest"
-#~ msgstr "MiniPrueba"
 

--- a/videomass/data/locale/es_MX/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/es_MX/LC_MESSAGES/videomass.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Videomass 5.0.18\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-30 11:02+0200\n"
+"POT-Creation-Date: 2025-07-30 15:28+0200\n"
 "PO-Revision-Date: 2024-08-26 17:29-0600\n"
 "Last-Translator: José Alberto Valle Cid j.alberto.vc@gmail.com\n"
 "Language: es_MX\n"
@@ -3010,16 +3010,4 @@ msgstr "Añadir solo entradas faltantes a la lista."
 
 msgid "Remove the current queue and replace it with the imported one."
 msgstr "Eliminar lista actual y reemplazar con la importada."
-
-#~ msgid "Some text boxes are still incomplete"
-#~ msgstr "Algunas cajas de texto están incompletas"
-
-#~ msgid "FFplay"
-#~ msgstr "FFplay"
-
-#~ msgid "Subtitle Mapping"
-#~ msgstr "Mapeo de Subtitulos"
-
-#~ msgid "Shortest"
-#~ msgstr "MiniPrueba"
 

--- a/videomass/data/locale/es_MX/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/es_MX/LC_MESSAGES/videomass.po
@@ -1,13 +1,13 @@
-# Spanish translation for Videomass.
-# Copyleft -  2024 Gianluca Pernigotto
-# This file is distributed under the same license as the Videomass package
-# FIRST AUTHOR Gianluca Pernigotto <jeanlucperni@gmail.com>, 2021
+# Spanish (Mexico) translations for Videomass.
+# Copyright (C) 2025 ORGANIZATION
+# This file is distributed under the same license as the Videomass project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Videomass 5.0.18\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-26 15:04+0200\n"
+"POT-Creation-Date: 2025-07-30 11:02+0200\n"
 "PO-Revision-Date: 2024-08-26 17:29-0600\n"
 "Last-Translator: José Alberto Valle Cid j.alberto.vc@gmail.com\n"
 "Language: es_MX\n"
@@ -18,7 +18,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
-#: ../../gui_app.py:196
 #, python-brace-format
 msgid ""
 "Unexpected error while deleting file contents:\n"
@@ -29,162 +28,111 @@ msgstr ""
 "\n"
 "{0}"
 
-#: ../../vdms_dialogs/about_dialog.py:52
 msgid "Cross-platform graphical user interface for FFmpeg\n"
 msgstr ""
 
-#: ../../vdms_dialogs/audioproperties.py:224
 msgid "Videomass supports mono and stereo audio channels. If you are not sure set to \"Auto\" and source values will be copied."
 msgstr "Videomass soporta canales de audio mono y estéreo. Si no esta seguro elija \"Auto\" y se copiaran los valores de la fuente."
 
-#: ../../vdms_dialogs/audioproperties.py:228
 msgid "The audio Rate (or sample-rate) is the sound sampling frequency and is measured in Hertz. The higher the frequency, the more true it will be to the sound source and the more the file will increase in size. For audio CD playback, set a sampling frequency of 44100 kHz. If you are not sure, set to \"Auto\" and source values will be copied."
 msgstr "La Frecuencia de audio (o frecuencia de muestreo) es la frecuencia de toma de muestras del audio y se mide en Hertz. A mayor frecuencia, la fuente de sonido tendrá mayor fidelidad y se incrementara el tamaño del archivo. Para calidad CD , elija una frecuencia de muestreo de 44100 kHz. Si no esta seguro elija \"Auto\" y se copiaran los valores de la fuente."
 
-#: ../../vdms_dialogs/audioproperties.py:237
 msgid "The audio bitrate affects the file compression and thus the quality of listening. The higher the value, the higher the quality."
 msgstr "La frecuencia de bits (bitrate) del audio afecta la compresión y la calidad de audio. Los valores mas altos implican mejor calidad."
 
-#: ../../vdms_dialogs/audioproperties.py:241
 msgid "Bit depth is the number of bits of information in each sample, and it directly corresponds to the resolution of each sample. Bit depth is only meaningful in reference to a PCM digital signal. Non-PCM formats, such as lossy compression formats, do not have associated bit depths."
 msgstr "La profundidad de bites el numero de bits de información en cada muestra, y se corresponde directamente a al resolución de cada muestra. La profundidad de bit solo es relevante para señales digitales PCM. Los formatos No-PCM, como los formatos compresos/con perdidas, no tienen asociados una profundidad de bits."
 
-#: ../../vdms_dialogs/epilogue.py:74 ../../vdms_dialogs/queuedlg.py:120
 msgid "When finished, once the operations have been completed successfully:"
 msgstr "Al finalizar las operaciones con éxito:"
 
-#: ../../vdms_dialogs/epilogue.py:80 ../../vdms_dialogs/queuedlg.py:126
 msgid "Trash the source files"
 msgstr "Desechar archivos fuente"
 
-#: ../../vdms_dialogs/epilogue.py:84 ../../vdms_dialogs/queuedlg.py:130
 msgid "Clear the File List"
 msgstr "Limpia la Lista de Archivos"
 
-#: ../../vdms_dialogs/epilogue.py:91 ../../vdms_dialogs/queuedlg.py:142
-#: ../../vdms_main/main_frame.py:1322
 msgid "Run"
 msgstr "Ejecutar"
 
-#: ../../vdms_dialogs/epilogue.py:97
 msgid "Videomass - Batch Mode"
 msgstr "Videomass - Proceso por lotes"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:47
 msgid "FFmpeg encoders"
 msgstr "Codificadores FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:48
 msgid "supported encoders"
 msgstr "codificadores soportados"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:50
 msgid "FFmpeg decoders"
 msgstr "Decodificadores FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:51
 msgid "supported decoders"
 msgstr "decodificadores soportados"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:77
-#: ../../vdms_panels/av_conversions.py:293
 msgid "Video"
 msgstr "Video"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:87
-#: ../../vdms_panels/av_conversions.py:305
 msgid "Audio"
 msgstr "Audio"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:97
 msgid "Subtitle"
 msgstr "Subtitulo"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:114
-#: ../../vdms_dialogs/ffmpeg_codecs.py:123
-#: ../../vdms_dialogs/ffmpeg_codecs.py:132
-#: ../../vdms_dialogs/ffmpeg_formats.py:112
-#: ../../vdms_dialogs/ffmpeg_formats.py:115
-#: ../../vdms_dialogs/ffmpeg_formats.py:118
 msgid "description"
 msgstr "descripción"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:72
 msgid "Informations"
 msgstr "Informaciones"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:83
 msgid "Flags settings"
 msgstr "Configurar banderas"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:93
 msgid "Flags enabled"
 msgstr "Banderas activas"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:103
 msgid "Flags disabled"
 msgstr "Deshabilitar banderas"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:116
 msgid "FFmpeg configuration"
 msgstr "Configuración de FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:124
 msgid "flags"
 msgstr "banderas"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:125 ../../vdms_dialogs/ffmpeg_conf.py:129
-#: ../../vdms_dialogs/ffmpeg_conf.py:133
 msgid "options"
 msgstr "opciones"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:128 ../../vdms_dialogs/ffmpeg_conf.py:132
 msgid "status"
 msgstr "estado"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:167
 msgid "FFprobe   ...not found !"
 msgstr "¡No se encontró FFprobe !"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:175
 msgid "FFplay   ...not found !"
 msgstr "¡No se encontró FFplay !"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:205
-#: ../../vdms_panels/sequence_to_video.py:706
-#: ../../vdms_panels/video_to_sequence.py:606
 msgid "Enabled"
 msgstr "Habilitado"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:216
-#: ../../vdms_panels/sequence_to_video.py:706
-#: ../../vdms_panels/video_to_sequence.py:610
 msgid "Disabled"
 msgstr "Deshabilitado"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:71
 msgid "Demuxing only"
 msgstr "Solo Desmezclar"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:82
 msgid "Muxing only"
 msgstr "Solo Mezclar"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:93
 msgid "Demuxing/Muxing support"
 msgstr "Soporte Desmezclar/Mezclar"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:104
 msgid "FFmpeg file formats"
 msgstr "Formatos de archivos FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:111
-#: ../../vdms_dialogs/ffmpeg_formats.py:114
-#: ../../vdms_dialogs/ffmpeg_formats.py:117
 msgid "supported formats"
 msgstr "formatos soportados"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:46
 msgid ""
 "Contextual help based on the argument entered in the additional text field.\n"
 "Each argument consists of the type and a type-specific name.\n"
@@ -210,117 +158,84 @@ msgstr ""
 "\n"
 "Algunos ejemplos:"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:68 ../../vdms_dialogs/ffmpeg_help.py:301
-#: ../../vdms_dialogs/ffmpeg_help.py:315
 msgid "Help topic"
 msgstr "Temas de ayuda"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:69
 msgid "List basic options"
 msgstr "Mostrar opciones básicas"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:70
 msgid "List more options"
 msgstr "Mostrar más opciones"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:71
 msgid "List all options (very long)"
 msgstr "Mostrar todas las opciones (muy largo)"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:72
 msgid "Show available devices"
 msgstr "Ver dispositivos disponibles"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:73
 msgid "Show available bit stream filters"
 msgstr "Ver filtros disponibles para flujo de bits"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:74
 msgid "Show available protocols"
 msgstr "Ver protocolos disponibles"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:75
 msgid "Show available filters"
 msgstr "Ver filtros disponibles"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:76
 msgid "Show available pixel formats"
 msgstr "Ver formatos de pixel disponibles"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:77
 msgid "Show available audio sample formats"
 msgstr "Ver formatos disponibles para muestreo de audio"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:78
 msgid "Show available color names"
 msgstr "Ver nombres de color disponibles"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:79
 msgid "List sources of the input device"
 msgstr "Lista fuentes del dispositivo de entrada"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:80
 msgid "List sinks of the output device"
 msgstr "Lista receptores del dispositivo de salida"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:81
 msgid "Show available HW acceleration methods"
 msgstr "Ver métodos de aceleración por HW"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:82
 msgid "Show license"
 msgstr "Mostrar licensia"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:117 ../../vdms_dialogs/filter_scale.py:76
-#: ../../vdms_dialogs/shownormlist.py:98 ../../vdms_dialogs/shownormlist.py:107
-#: ../../vdms_dialogs/shownormlist.py:116 ../../vdms_miniframes/timeline.py:263
-#: ../../vdms_miniframes/timeline.py:283 ../../vdms_panels/concatenate.py:117
-#: ../../vdms_panels/sequence_to_video.py:117
-#: ../../vdms_panels/video_to_sequence.py:81
 msgid "Read me"
 msgstr "Leame"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:123 ../../vdms_main/main_frame.py:534
 msgid "Show configuration"
 msgstr "Mostrar configuración"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:127 ../../vdms_main/main_frame.py:542
 msgid "Encoders"
 msgstr "Codificadores"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:131 ../../vdms_main/main_frame.py:545
 msgid "Decoders"
 msgstr "Decodificadores"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:135 ../../vdms_main/main_frame.py:538
 msgid "Muxers and Demuxers"
 msgstr "Mezcladores y Dezmezcladores"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:165
 msgid "help topic list"
 msgstr "lista de temas de ayuda"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:184
 msgid "Type the argument here and confirm with the enter key on your keyboard"
 msgstr "Teclee aquí el argumento y presione la tecla enter de su teclado"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:192
 msgid "The search function allows you to find entries in the current topic"
 msgstr "La función de búsqueda le permite encontrar entradas del tema actual"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:195
 msgid "Ignore case"
 msgstr "Ignorar mayúsculas"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:196
 msgid "Ignore case distinctions: characters with different case will match."
 msgstr "Ignorar mayúsculas: las letras mayúsculas y minúsculas serán iguales."
 
-#: ../../vdms_dialogs/ffmpeg_help.py:206
 msgid "FFmpeg help topics"
 msgstr "Temas de ayuda de FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:254
 msgid ""
 "This is a multifunctional search tool useful for local help searches\n"
 "on multiple FFmpeg topics and options. The search control, to\n"
@@ -342,8 +257,6 @@ msgstr ""
 "es seguro que su versión de FFmpeg es muy antigua o no tenga configuradas\n"
 "esas características."
 
-#: ../../vdms_dialogs/ffmpeg_help.py:320 ../../vdms_dialogs/ffmpeg_help.py:345
-#: ../../vdms_dialogs/ffmpeg_help.py:371
 msgid ""
 "\n"
 "  ..Nothing available"
@@ -351,7 +264,6 @@ msgstr ""
 "\n"
 "  ..Nada disponible"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:391
 msgid ""
 "\n"
 "  ..Not found"
@@ -359,217 +271,121 @@ msgstr ""
 "\n"
 "...No encontrado"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:91
 msgid "Before"
 msgstr "Antes"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:97
 msgid "After"
 msgstr "Despues"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:103
-#: ../../vdms_dialogs/filter_crop.py:239
 msgid "Search for a specific frame"
 msgstr "Buscar un cuadro especifico"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:117
-#: ../../vdms_dialogs/filter_crop.py:253
 msgid "Load"
 msgstr "Cargar"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:120
 msgid "Color EQ"
 msgstr "Color EQ"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:126
 msgid "Contrast:"
 msgstr "Contraste:"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:134
-#: ../../vdms_dialogs/filter_colorcorrection.py:148
 msgid "-100 to +100, default value 0"
 msgstr "-100 a +100, valor por defecto 0"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:139
 msgid "Brightness:"
 msgstr "Brillo:"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:158
 msgid "Saturation:"
 msgstr "Saturación:"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:166
 msgid "0 to 300, default value 100"
 msgstr "0 a 300, valor por defecto 100"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:170
 msgid "Gamma:"
 msgstr "Gamma:"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:179
 msgid "0 to 100, default value 10"
 msgstr "0 a 100, valor por defecto 10"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:187
-#: ../../vdms_dialogs/filter_crop.py:306
-#: ../../vdms_dialogs/filter_deinterlace.py:209
-#: ../../vdms_dialogs/filter_denoisers.py:110
-#: ../../vdms_dialogs/filter_scale.py:210 ../../vdms_dialogs/filter_stab.py:316
-#: ../../vdms_dialogs/filter_transpose.py:105
-#: ../../vdms_miniframes/timeline.py:262 ../../vdms_miniframes/timeline.py:281
 msgid "Reset"
 msgstr "Reiniciar"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:207
 msgid "Color Correction EQ Tool"
 msgstr "Corrección de EQ Color"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:343
-#: ../../vdms_dialogs/filter_colorcorrection.py:383
-#: ../../vdms_dialogs/filter_colorcorrection.py:390
-#: ../../vdms_dialogs/filter_crop.py:417 ../../vdms_dialogs/filter_scale.py:287
-#: ../../vdms_dialogs/filter_scale.py:394 ../../vdms_dialogs/filter_stab.py:473
-#: ../../vdms_dialogs/filter_stab.py:483 ../../vdms_dialogs/filter_stab.py:494
-#: ../../vdms_dialogs/filter_transpose.py:182
-#: ../../vdms_dialogs/mediainfo.py:245 ../../vdms_dialogs/mediainfo.py:265
-#: ../../vdms_dialogs/mediainfo.py:285 ../../vdms_dialogs/mediainfo.py:305
-#: ../../vdms_dialogs/setting_profiles.py:281
-#: ../../vdms_dialogs/setting_profiles.py:289 ../../vdms_io/checkup.py:45
-#: ../../vdms_io/checkup.py:93 ../../vdms_io/io_tools.py:144
-#: ../../vdms_main/main_frame.py:904 ../../vdms_main/main_frame.py:939
-#: ../../vdms_main/main_frame.py:961 ../../vdms_main/main_frame.py:979
-#: ../../vdms_main/main_frame.py:999
-#: ../../vdms_panels/audio_encoders/acodecs.py:510
-#: ../../vdms_panels/audio_encoders/acodecs.py:800
-#: ../../vdms_panels/concatenate.py:186
-#: ../../vdms_panels/long_processing_task.py:60
-#: ../../vdms_panels/presets_manager.py:426
-#: ../../vdms_panels/presets_manager.py:490
-#: ../../vdms_panels/presets_manager.py:560
-#: ../../vdms_panels/presets_manager.py:599
-#: ../../vdms_panels/presets_manager.py:619
-#: ../../vdms_panels/presets_manager.py:657
-#: ../../vdms_panels/presets_manager.py:701
-#: ../../vdms_panels/presets_manager.py:714
-#: ../../vdms_panels/presets_manager.py:721
-#: ../../vdms_panels/presets_manager.py:756
-#: ../../vdms_panels/presets_manager.py:785
-#: ../../vdms_panels/presets_manager.py:791
-#: ../../vdms_panels/sequence_to_video.py:467
-#: ../../vdms_panels/sequence_to_video.py:473
-#: ../../vdms_panels/sequence_to_video.py:561
-#: ../../vdms_panels/sequence_to_video.py:571
-#: ../../vdms_panels/sequence_to_video.py:588
-#: ../../vdms_panels/sequence_to_video.py:596
-#: ../../vdms_panels/sequence_to_video.py:602
-#: ../../vdms_panels/sequence_to_video.py:643
-#: ../../vdms_panels/sequence_to_video.py:689
-#: ../../vdms_panels/video_to_sequence.py:512
-#: ../../vdms_panels/video_to_sequence.py:583
-#: ../../vdms_threads/ffplay_file.py:43
-#: ../../vdms_utils/presets_manager_utils.py:86
-#: ../../vdms_utils/presets_manager_utils.py:95
-#: ../../vdms_utils/queue_utils.py:68 ../../vdms_utils/queue_utils.py:82
-#: ../../vdms_utils/queue_utils.py:95
 msgid "Videomass - Error!"
 msgstr "Videomass - ¡Error!"
 
-#: ../../vdms_dialogs/filter_crop.py:228 ../../vdms_dialogs/filter_scale.py:109
 #, python-brace-format
 msgid "Source size: {0} x {1} pixels"
 msgstr "Tamaño de la fuente: {0} x {1} pixeles"
 
-#: ../../vdms_dialogs/filter_crop.py:236
 msgid "Crop color"
 msgstr "Color de Recorte"
 
-#: ../../vdms_dialogs/filter_crop.py:256
 msgid "Cropping area selection "
 msgstr "Recortar area seleccionada "
 
-#: ../../vdms_dialogs/filter_crop.py:261 ../../vdms_dialogs/filter_scale.py:121
 msgid "Height"
 msgstr "Altura"
 
-#: ../../vdms_dialogs/filter_crop.py:281
 msgid "Center"
 msgstr "Centro"
 
-#: ../../vdms_dialogs/filter_crop.py:292 ../../vdms_dialogs/filter_scale.py:121
 msgid "Width"
 msgstr "Ancho"
 
-#: ../../vdms_dialogs/filter_crop.py:334
 msgid "Crop Tool"
 msgstr "Herramienta de Recorte"
 
-#: ../../vdms_dialogs/filter_crop.py:335
 msgid "Choose the color to draw the cropping area"
 msgstr "Seleccione el color para dibujar el área de recorte"
 
-#: ../../vdms_dialogs/filter_crop.py:337
 msgid "Crop to width"
 msgstr "Recortar ancho"
 
-#: ../../vdms_dialogs/filter_crop.py:338
 msgid "Move vertically (set to -1 to center the vertical axis)"
 msgstr "Mover verticalmente ( -1 para centrar el eje vertical)"
 
-#: ../../vdms_dialogs/filter_crop.py:340
 msgid "Move horizontally (set to -1 to center the horizontal axis)"
 msgstr "Mover horizontalmente (-1 para centrar el eje horizontal)"
 
-#: ../../vdms_dialogs/filter_crop.py:342
 msgid "Crop to height"
 msgstr "Recortar altura"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:56
 msgid "Advanced Options"
 msgstr "Opciones Avanzadas"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:57
-#: ../../vdms_panels/av_conversions.py:351
 msgid "Deinterlace"
 msgstr "Desentrelazado"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:59
 msgid "Interlace"
 msgstr "Entrelazado"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:63
 msgid "Deinterlaces with w3fdif filter"
 msgstr "Desentrelazar con el filtro w3fdif"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:77
 msgid "Deinterlaces with yadif filter"
 msgstr "Desentrelazar con el filtro yadif"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:101
 msgid "Interlaces with interlace filter"
 msgstr "Entrelazar con el filtro entrelazar"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:118
 msgid "Deinterlacing and Interlacing"
 msgstr "Desenetrelazar y entrelazar"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:144
 msgid "Deinterlace the input video with `w3fdif` filter"
 msgstr "Desentrelazar el video de entrada con el filtro `w3fdif`"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:146
 msgid "Set the interlacing filter coefficients."
 msgstr "Fijar los coeficientes del filtro de entrelazado."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:148
-#: ../../vdms_dialogs/filter_deinterlace.py:158
 msgid "Specify which frames to deinterlace."
 msgstr "Especificar los cuadros a desentrelazar."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:150
 msgid "Deinterlace the input video with `yadif` filter. Using FFmpeg, this is the best and fastest choice"
 msgstr "Desentrelazar el video de entrada con el filtro `yadif` . Utilizar FFmpeg, es la mejor opción y la más rápida"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:153
 msgid ""
 "mode\n"
 "The interlacing mode to adopt."
@@ -577,7 +393,6 @@ msgstr ""
 "modo\n"
 "El modo de entrelazado."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:155
 msgid ""
 "parity\n"
 "The picture field parity assumed for the input interlaced video."
@@ -585,11 +400,9 @@ msgstr ""
 "paridad\n"
 "La paridad del campo imagen asumida por el video entrelazado de entrada."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:160
 msgid "Simple interlacing filter from progressive contents."
 msgstr "Filtro de entrelazado simple proveniente de contenidos progresivos."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:162
 msgid ""
 "scan:\n"
 "determines whether the interlaced frame is taken from the even (tff - default) or odd (bff) lines of the progressive frame."
@@ -597,7 +410,6 @@ msgstr ""
 "scan:\n"
 "determina si el cuadro entrelazado proviene de las lineas pares (tff - predeterminado) o impares (bff) del cuadro progresivo."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:166
 msgid ""
 "lowpass:\n"
 "Enable (default) or disable the vertical lowpass filter to avoid twitter interlacing and reduce moire patterns.\n"
@@ -607,31 +419,24 @@ msgstr ""
 "Habilita (predeterminado) o deshabilita el filtro vertical pasabajos para evitar el entrelazado twitter y reducir  el efecto Moiré.\n"
 "No esta configurado valor predeterminado."
 
-#: ../../vdms_dialogs/filter_denoisers.py:56
 msgid "Denoiser Filters"
 msgstr "Filtros ReduceRuido"
 
-#: ../../vdms_dialogs/filter_denoisers.py:60
 msgid "Enable nlmeans denoiser"
 msgstr "Habilita filtro nlmeans"
 
-#: ../../vdms_dialogs/filter_denoisers.py:73
 msgid "nlmeans options"
 msgstr "opciones de nlmeans"
 
-#: ../../vdms_dialogs/filter_denoisers.py:82
 msgid "Enable hqdn3d denoiser"
 msgstr "Habilitar filtro hqdn3d"
 
-#: ../../vdms_dialogs/filter_denoisers.py:91
 msgid "hqdn3d options"
 msgstr "opciones de hqdn3d"
 
-#: ../../vdms_dialogs/filter_denoisers.py:116
 msgid "Denoiser Tool"
 msgstr "Reduce Ruido"
 
-#: ../../vdms_dialogs/filter_denoisers.py:117
 msgid ""
 "nlmeans:\n"
 "Denoise frames using Non-Local Means algorithm is capable of restoring video sequences, even with strong noise. It is ideal for enhancing the quality of old VHS tapes."
@@ -639,7 +444,6 @@ msgstr ""
 "nlmeans:\n"
 "Mejora los cuadros usando el algoritmo  Medios No-Locales, es capaz de restaurar incluso secuencias de video con fuerte ruido. Es ideal para mejorar la calidad de las antiguas cintas VHS."
 
-#: ../../vdms_dialogs/filter_denoisers.py:122
 msgid ""
 "hqdn3d:\n"
 "This is a high precision/quality 3d denoise filter. It aims to reduce image noise, producing smooth images and making still images really still. It should enhance compressibility."
@@ -647,65 +451,48 @@ msgstr ""
 "hqdn3d:\n"
 "Estes es un filtro reductor de alta precisión/calidad 3d . Su objetivo es reducir el ruido de la imagen, produciendo imágenes suaves y hacer que las imágenes fijas sean realmente fijas. Debe mejorar la compresibilidad."
 
-#: ../../vdms_dialogs/filter_scale.py:81
 msgid "View result"
 msgstr "Ver resultado"
 
-#: ../../vdms_dialogs/filter_scale.py:85
 msgid "New size in pixels"
 msgstr "Nuevo tamaño en pixeles"
 
-#: ../../vdms_dialogs/filter_scale.py:89
 msgid "Width:"
 msgstr "Ancho:"
 
-#: ../../vdms_dialogs/filter_scale.py:99
 msgid "Height:"
 msgstr "Alto:"
 
-#: ../../vdms_dialogs/filter_scale.py:115
 msgid "Constrain proportions (keep aspect ratio)"
 msgstr "Restringir proporciones (mantener relación de aspecto)"
 
-#: ../../vdms_dialogs/filter_scale.py:120
 msgid "Which dimension to adjust?"
 msgstr "¿Que dimensión se ajustara?"
 
-#: ../../vdms_dialogs/filter_scale.py:129
 msgid "Aspect Ratio"
 msgstr "Relación de Aspecto"
 
-#: ../../vdms_dialogs/filter_scale.py:132
 msgid "Setdar filter (display aspect ratio) example 16/9, 4/3 "
 msgstr "Filtro Setdar  (relación de aspecto de pantalla) ejemplo 16/9, 4/3 "
 
-#: ../../vdms_dialogs/filter_scale.py:137
-#: ../../vdms_dialogs/filter_scale.py:171
 msgid "Numerator"
 msgstr "Numerador"
 
-#: ../../vdms_dialogs/filter_scale.py:162
-#: ../../vdms_dialogs/filter_scale.py:196
 msgid "Denominator"
 msgstr "Denominador"
 
-#: ../../vdms_dialogs/filter_scale.py:166
 msgid "Setsar filter (sample aspect ratio) example 1/1"
 msgstr "Filtro Setsar  (relación de aspecto de la muestra) ejemplo 1/1"
 
-#: ../../vdms_dialogs/filter_scale.py:217
 msgid "Resize Tool"
 msgstr "Redimensionar"
 
-#: ../../vdms_dialogs/filter_scale.py:218
 msgid "Scale filter, set to 0 to disable"
 msgstr "Filtro Escala, poner a 0 para deshabilitar"
 
-#: ../../vdms_dialogs/filter_scale.py:221
 msgid "Display Aspect Ratio. Set to 0 to disable"
 msgstr "Relación de Aspecto de Pantalla. Poner a 0 para deshabilitar"
 
-#: ../../vdms_dialogs/filter_scale.py:224
 msgid ""
 "Sample (aka Pixel) Aspect Ratio.\n"
 "Set to 0 to disable"
@@ -713,7 +500,6 @@ msgstr ""
 "Relación de Aspecto de Muestra (Pixel) .\n"
 "Poner a 0 para deshabilitar"
 
-#: ../../vdms_dialogs/filter_scale.py:366
 msgid ""
 "If you want to keep the aspect ratio, select \"Constrain proportions\" below and\n"
 "specify only one dimension, either width or height, and set the other dimension\n"
@@ -723,156 +509,121 @@ msgstr ""
 "especifique sólo una dimensión, ya sea la anchura o la altura, y fije la otra dimensión\n"
 "a -1 o -2 (algunos códecs requieren -2, por lo que deberá hacer algunas pruebas primero)."
 
-#: ../../vdms_dialogs/filter_stab.py:81
 msgid "Enable stabilizer"
 msgstr "Habilitar estabilizador"
 
-#: ../../vdms_dialogs/filter_stab.py:83
 msgid "Create a side-by-side comparison video"
 msgstr "Crear un video de comparación lado a lado"
 
-#: ../../vdms_dialogs/filter_stab.py:88
 msgid "Create a snapshot"
 msgstr "Crear nueva instantanea"
 
-#: ../../vdms_dialogs/filter_stab.py:106
-#: ../../vdms_panels/audio_encoders/acodecs.py:167
 msgid "Preview"
 msgstr "Previsualizar"
 
-#: ../../vdms_dialogs/filter_stab.py:109
 msgid "Duration seconds:"
 msgstr "Duración en segundos:"
 
-#: ../../vdms_dialogs/filter_stab.py:118
 msgid "Video Detect"
 msgstr "Detectar Video"
 
-#: ../../vdms_dialogs/filter_stab.py:176
 msgid "[TRIPOD] Enable tripod mode if checked"
 msgstr "[TRIPOD] Al marcar se habilita el modo tripie"
 
-#: ../../vdms_dialogs/filter_stab.py:183
 msgid "Video transform"
 msgstr "Transformación de video"
 
-#: ../../vdms_dialogs/filter_stab.py:202
 msgid "[OPTALGO] optimization algorithm"
 msgstr "[OPTALGO] algoritmo de optimización"
 
-#: ../../vdms_dialogs/filter_stab.py:224
 msgid "[CROP] Specify how to deal with borders at movement compensation"
 msgstr "[CROP] Especifica como lidiar con los bordes al compensar el movimiento"
 
-#: ../../vdms_dialogs/filter_stab.py:231
 msgid "[INVERT] Invert transforms if checked"
 msgstr "[INVERT] Al marcar, invierte las transformaciones"
 
-#: ../../vdms_dialogs/filter_stab.py:234
 msgid "[RELATIVE] Consider transforms as relative to previous frame if checked, absolute if unchecked"
 msgstr "[RELATIVE] Marcado considera las transformaciones como relativas al cuadro previo, desmarcado como absolutas"
 
-#: ../../vdms_dialogs/filter_stab.py:279
 msgid "Specify type of interpolation"
 msgstr "Especificar tipo de interpolación"
 
-#: ../../vdms_dialogs/filter_stab.py:287
 msgid "[TRIPOD2] virtual tripod mode, equivalent to relative=unchecked:smoothing=0"
 msgstr "[TRIPOD2] modo de tripie virtual, equivalente a relative=desmarcado:smoothing=0"
 
-#: ../../vdms_dialogs/filter_stab.py:294
 msgid "Unsharp filter:"
 msgstr "Filtro desenfoque:"
 
-#: ../../vdms_dialogs/filter_stab.py:323
 msgid "Seek to a position on the video."
 msgstr "Ir a una posición del video."
 
-#: ../../vdms_dialogs/filter_stab.py:325
 msgid "Make a snapshot of the video with the settings made."
 msgstr "Hacer instantánea del video con las configuraciones usadas."
 
-#: ../../vdms_dialogs/filter_stab.py:327
 msgid "Set the snapshot duration from 3 to 15 seconds from the seek position, default is 5 seconds."
 msgstr "Fijar duración de instantánea  de 3 a 15 segundos,  5 es lo predeterminado."
 
-#: ../../vdms_dialogs/filter_stab.py:331
 msgid "Set how shaky the video is and how quick the camera is. A value of 1 means little shakiness, a value of 10 means strong shakiness. Default value is 5."
 msgstr "Fija el grado de temblor del vídeo y la rapidez de la cámara. Un valor de 1 significa poca vibración, un valor de 10 significa mucha vibración. El valor predeterminado es 5."
 
-#: ../../vdms_dialogs/filter_stab.py:335
 msgid "Set the accuracy of the detection process. A value of 1 means low accuracy, a value of 15 means high accuracy. Default value is 15."
 msgstr "Fija la precisión del proceso de detección. Un valor de 1 significa poca precisión, un valor de 15(predeterminado) significa alta precisión."
 
-#: ../../vdms_dialogs/filter_stab.py:339
 msgid "Set stepsize of the search process. The region around minimum is scanned with 1 pixel resolution. Default value is 6."
 msgstr "Fija el paso del proceso de búsqueda. La resolución mínima de la región es de 1 pixel. Valor predeterminado 6."
 
-#: ../../vdms_dialogs/filter_stab.py:343
 msgid "Set minimum contrast. Below this value a local measurement field is discarded. The range is 0-1. Default value is 0.25."
 msgstr "Fija el contraste mínimo. Bajo este valor la medida del campo local es descartada. El rango es 0-1. Valor predeterminado 0.25."
 
-#: ../../vdms_dialogs/filter_stab.py:346
 msgid "Set reference frame number for tripod mode. If enabled, the motion of the frames is compared to a reference frame in the filtered stream, identified by the specified number. The idea is to compensate all movements in a more-or-less static scene and keep the camera view absolutely still. The frames are counted starting from 1."
 msgstr "Fija el numero de cuadro de referencia para el modo tripod. Si se habilita, el movimiento de los cuadros se compara con un cuadro de referencia en el flujo filtrado, identificado por el numero especificado. The idea is to compensate all movements in a more-or-less static scene and keep the camera view absolutely still. The frames are counted starting from 1."
 
-#: ../../vdms_dialogs/filter_stab.py:355
-msgid "Set the number of frames (value*2 + 1) used for lowpass filtering the camera movements. Default value is 15. For example a number of 10 means that 21 frames are used (10 in the past and 10 in the future) to smoothen the motion in the video. A larger value leads to a smoother video, but limits the acceleration of the camera (pan/tilt movements). 0 is a special case where a static camera is simulated."
-msgstr "Fijar el numero de cuadros (valor*2 + 1) usados por pasabajos para filtrar movimientos de cámara. Valor predeterminado 15. Por ejemplo un valor de 10 significa que  se utilizan 21 cuadros (10 en el pasado 10 en el futuro) para suavizar el movimiento en el video. Un valor mayor produce un vídeo más suave, pero limita la aceleración de la cámara (movimientos de giro/inclinación). 0 es un caso especial en el que se simula una cámara estática."
+msgid ""
+"Set the number of frames (value*2 + 1) used for lowpass filtering the camera movements. Default value is 15. For example a number of 10 means that 21 frames are used (10 in the past and 10 in the future) to smoothen the motion in the video. A larger value leads to a smoother video, but limits the acceleration of the camera (pan/tilt movements). 0 is a special case where a static camera is "
+"simulated."
+msgstr ""
+"Fijar el numero de cuadros (valor*2 + 1) usados por pasabajos para filtrar movimientos de cámara. Valor predeterminado 15. Por ejemplo un valor de 10 significa que  se utilizan 21 cuadros (10 en el pasado 10 en el futuro) para suavizar el movimiento en el video. Un valor mayor produce un vídeo más suave, pero limita la aceleración de la cámara (movimientos de giro/inclinación). 0 es un caso "
+"especial en el que se simula una cámara estática."
 
-#: ../../vdms_dialogs/filter_stab.py:363
 msgid "Set the camera path optimization algorithm. Values are: `gauss`: gaussian kernel low-pass filter on camera motion (default), and `avg`: averaging on transformations"
 msgstr "Fija el algoritmo de optimización para la trayectoria de camera. Valores: `gauss`: filtro pasabajos núcleo gaussiano para el movimiento de cámara (predeterminado), y `avg`: promedio de transformaciones"
 
-#: ../../vdms_dialogs/filter_stab.py:367
 msgid "Set maximal angle in radians (degree*PI/180) to rotate frames. Default value is -1, meaning no limit."
 msgstr "Fija angulo máximo en radianes (grados*PI/180) para rotar los cuadros. Valor predeterminado -1, significa sin limites."
 
-#: ../../vdms_dialogs/filter_stab.py:370
 msgid "Specify how to deal with borders that may be visible due to movement compensation. Values are: `keep` keep image information from previous frame (default), `black` fill the border black"
 msgstr "Especifica como lidiar con los bordes visibles al compensar el movimiento. Valores: `mantener` mantener la información de la imagen del cuadro previo (predeterminado), `negro` rellenar lo negro en el borde"
 
-#: ../../vdms_dialogs/filter_stab.py:375
 msgid "Invert transforms if checked. Default is unchecked."
 msgstr "Si se marca Invierte transformaciones. Desmarcado es lo predeterminado."
 
-#: ../../vdms_dialogs/filter_stab.py:377
 msgid "Consider transforms as relative to previous frame if checked, absolute if unchecked. Default is checked."
 msgstr "Marcado considera las transformaciones como relativas al cuadro previo, desmarcado como absolutas. Desmarcado es lo predeterminado."
 
-#: ../../vdms_dialogs/filter_stab.py:380
 msgid "Set percentage to zoom. A positive value will result in a zoom-in effect, a negative value in a zoom-out effect. Default value is 0 (no zoom)."
 msgstr "Fija el porcentaje de aumento. Un valor positivo produce efecto de acercamiento, un valor negativo de alejamiento. Valor predeterminado 0 (sin aumento)."
 
-#: ../../vdms_dialogs/filter_stab.py:384
 msgid "Set optimal zooming to avoid borders. Accepted values are: `0` disabled, `1` optimal static zoom value is determined (only very strong movements will lead to visible borders) (default), `2` optimal adaptive zoom value is determined (no borders will be visible), see zoomspeed. Note that the value given at zoom is added to the one calculated here."
 msgstr "Fija el aumento optimo para evitar bordes. Valores aceptados: `0` desactivado, `1` se determina el nivel de aumento optimo (solo los movimientos muy fuertes producen bordes visibles) (predeterminado), `2` se determina el nivel de aumento optimo adaptativo (no habrá bordes visibles), vea zoomspeed. Note que el valor dado en aumento se añade al calculado aquí."
 
-#: ../../vdms_dialogs/filter_stab.py:391
 msgid "Set percent to zoom maximally each frame (enabled when optzoom is set to 2). Range is from 0 to 5, default value is 0.25."
 msgstr "Fija el porcentaje de aumento máximo en cada cuadro (habilitado cuando optzoom se fija a 2). Rango de 0 to 5, valor predeterminado 0.25."
 
-#: ../../vdms_dialogs/filter_stab.py:395
 msgid "Specify type of interpolation. Available values are: `no` no interpolation, `linear` linear only horizontal, `bilinear` linear in both directions (default), `bicubic` cubic in both directions (slow)"
 msgstr "Especifica tipo de interpolación. Valores disponibles: `no` = sin interpolación, `linear` lineal solo horizontal, `bilinear` lineal en ambas direcciones (predeterminado), `bicubic’`cubica en ambas direcciones (lenta)"
 
-#: ../../vdms_dialogs/filter_stab.py:400
 msgid "Enable virtual tripod mode if checked, which is equivalent to relative=0:smoothing=0. Default is unchecked. Use also tripod option of vidstabdetect."
 msgstr "Habilita el modo de tripie virtual, equivalente a relative=0:smoothing=0. Desmarcado por omisión. Use junto a la opción tripod de vidstabdetect."
 
-#: ../../vdms_dialogs/filter_stab.py:405
 msgid "Sharpen or blur the input video. Note the use of the unsharp filter which is always recommended."
 msgstr "Enfoca o desenfoca el vídeo de entrada.. Se recomienda siempre usar el filtro de desenfoque."
 
-#: ../../vdms_dialogs/filter_stab.py:409
 msgid "Video Stabilizer Tool"
 msgstr "Herramienta Estabilizador de video"
 
-#: ../../vdms_dialogs/filter_stab.py:541 ../../vdms_io/io_tools.py:73
 msgid "Videomass - Loading..."
 msgstr "Videomass - Cargando..."
 
-#: ../../vdms_dialogs/filter_stab.py:542
 msgid ""
 "Please wait,\n"
 "This process will take a few seconds."
@@ -880,135 +631,96 @@ msgstr ""
 "Por favor espere,\n"
 "Este proceso tomar unos segundos."
 
-#: ../../vdms_dialogs/filter_transpose.py:80
-#: ../../vdms_dialogs/filter_transpose.py:293
 msgid "Default position"
 msgstr "Posición predeterminada"
 
-#: ../../vdms_dialogs/filter_transpose.py:86
 msgid "Rotation setting"
 msgstr "Rotación"
 
-#: ../../vdms_dialogs/filter_transpose.py:94
 msgid "90° (left)"
 msgstr "90° (izq)"
 
-#: ../../vdms_dialogs/filter_transpose.py:96
 msgid "90° (right)"
 msgstr "90° (der)"
 
-#: ../../vdms_dialogs/filter_transpose.py:100
 msgid "180°"
 msgstr "180°"
 
-#: ../../vdms_dialogs/filter_transpose.py:115
 msgid "Transpose Tool"
 msgstr "Herramienta Transposición"
 
-#: ../../vdms_dialogs/filter_transpose.py:229
 msgid "Rotate 90 degrees right"
 msgstr "Rotar 90 grados a la derecha"
 
-#: ../../vdms_dialogs/filter_transpose.py:251
 msgid "Rotate 180 degrees"
 msgstr "Rotar 180 grados"
 
-#: ../../vdms_dialogs/filter_transpose.py:272
 msgid "Rotate 90 degrees left"
 msgstr "Rotar 90 grados a la izquierda"
 
-#: ../../vdms_dialogs/mediainfo.py:82
 msgid "Format"
 msgstr "Formato"
 
-#: ../../vdms_dialogs/mediainfo.py:96
 msgid "Video Stream"
 msgstr "Flujo de Video"
 
-#: ../../vdms_dialogs/mediainfo.py:109
 msgid "Audio Streams"
 msgstr "Flujos de Audio"
 
-#: ../../vdms_dialogs/mediainfo.py:122
 msgid "Subtitle Streams"
 msgstr "Flujos de Subtítulos"
 
-#: ../../vdms_dialogs/mediainfo.py:126
 msgid "Copy to clipboard"
 msgstr "Copiar al portapapeles"
 
-#: ../../vdms_dialogs/mediainfo.py:137
 msgid "FILE SELECTION"
 msgstr "SELECCIÓN DE ARCHIVO"
 
-#: ../../vdms_dialogs/mediainfo.py:139 ../../vdms_dialogs/mediainfo.py:142
-#: ../../vdms_dialogs/mediainfo.py:145 ../../vdms_dialogs/mediainfo.py:148
-#: ../../vdms_main/main_frame.py:1318
 msgid "Properties"
 msgstr "Propiedades"
 
-#: ../../vdms_dialogs/mediainfo.py:140 ../../vdms_dialogs/mediainfo.py:143
-#: ../../vdms_dialogs/mediainfo.py:146 ../../vdms_dialogs/mediainfo.py:149
 msgid "Values"
 msgstr "Valores"
 
-#: ../../vdms_dialogs/mediainfo.py:152
 msgid "Streams Properties"
 msgstr "Propiedades de los Flujos"
 
-#: ../../vdms_dialogs/mediainfo.py:244
 msgid "Unable to open the clipboard on Format tab"
 msgstr "Np se puede abrir el portapapeles en la pestaña Formato"
 
-#: ../../vdms_dialogs/mediainfo.py:263
 msgid "Unable to open the clipboard on Video Streams tab"
 msgstr "Np se puede abrir el portapapeles en la pestaña Flujos de Video"
 
-#: ../../vdms_dialogs/mediainfo.py:283
 msgid "Unable to open the clipboard on Audio Streams tab"
 msgstr "Np se puede abrir el portapapeles en la pestaña Flujos de Audio"
 
-#: ../../vdms_dialogs/mediainfo.py:303
 msgid "Unable to open the clipboard on Subtitle Streams tab"
 msgstr "Np se puede abrir el portapapeles en la pestaña Flujos de Subtitulos"
 
-#: ../../vdms_dialogs/preferences.py:90
 msgid "Where do you prefer to save your transcodes?"
 msgstr "¿Donde prefiere guardar sus resultados?"
 
-#: ../../vdms_dialogs/preferences.py:101 ../../vdms_dialogs/preferences.py:128
-#: ../../vdms_dialogs/preferences.py:149 ../../vdms_dialogs/preferences.py:161
-#: ../../vdms_dialogs/preferences.py:173 ../../vdms_panels/filedrop.py:284
 msgid "Change"
 msgstr "Cambiar"
 
-#: ../../vdms_dialogs/preferences.py:103
-#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:602
-#: ../../vdms_panels/presets_manager.py:1050
 msgid "Same destination paths as source files"
 msgstr "Misma carpeta destino que archivos fuente"
 
-#: ../../vdms_dialogs/preferences.py:108
 msgid "Assign optional suffix to destination file names:"
 msgstr "Asignar un sufijo opcional a los archivos de salida:"
 
-#: ../../vdms_dialogs/preferences.py:114
 msgid "File removal preferences"
 msgstr "Preferencias de borrado de archivo"
 
-#: ../../vdms_dialogs/preferences.py:118
 msgid "Trash the source files after successful encoding"
 msgstr "Desechar archivos fuente después de codificación exitosa"
 
-#: ../../vdms_dialogs/preferences.py:131
 msgid "File Preferences"
 msgstr "Preferencias de Archivo"
 
-#: ../../vdms_dialogs/preferences.py:138
 msgid "Location of executables"
 msgstr "Trayectoria de ejecutables"
 
-#: ../../vdms_dialogs/preferences.py:140
 msgid ""
 "FFmpeg can be built by enabling/disabling its options and this depends on your needs.\n"
 "For some use cases it is possible to provide a custom build of FFmpeg where you can specify\n"
@@ -1018,107 +730,81 @@ msgstr ""
 "En algunos caso es posible proporcionar una compilación personalizada de  FFmpeg, la cual puede\n"
 "especificar en esta pestaña."
 
-#: ../../vdms_dialogs/preferences.py:147
 msgid "Enable a custom location to run FFmpeg"
 msgstr "Habilitar FFmpeg en otra trayectoria"
 
-#: ../../vdms_dialogs/preferences.py:159
 msgid "Enable a custom location to run FFprobe"
 msgstr "Habilitar FFprobe en otra trayectoria"
 
-#: ../../vdms_dialogs/preferences.py:171
 msgid "Enable a custom location to run FFplay"
 msgstr "Habilitar FFplay en otra trayectoria"
 
-#: ../../vdms_dialogs/preferences.py:183
 msgid "FFmpeg"
 msgstr "FFmpeg"
 
-#: ../../vdms_dialogs/preferences.py:189
 msgid "Look and Feel (requires application restart)"
 msgstr "Apariencia de la aplicación (requiere reiniciar la aplicación)"
 
-#: ../../vdms_dialogs/preferences.py:194
 msgid "Icon themes"
 msgstr "Temas de iconos"
 
-#: ../../vdms_dialogs/preferences.py:208
 msgid "At the top of window (default)"
 msgstr "Parte superior de la ventana (predeterminado)"
 
-#: ../../vdms_dialogs/preferences.py:209
 msgid "At the bottom of window"
 msgstr "Parte inferior de la ventana"
 
-#: ../../vdms_dialogs/preferences.py:210
 msgid "At the right of window"
 msgstr "A la derecha de la ventana"
 
-#: ../../vdms_dialogs/preferences.py:211
 msgid "At the left of window"
 msgstr "A la izquierda de la ventana"
 
-#: ../../vdms_dialogs/preferences.py:213
 msgid "Place the toolbar"
 msgstr "Situar la barra de herramientas"
 
-#: ../../vdms_dialogs/preferences.py:222
 msgid "Toolbar's icons size:"
 msgstr "Tamaño de iconos:"
 
-#: ../../vdms_dialogs/preferences.py:236
 msgid "Application Language (requires application restart)"
 msgstr "Idioma de la aplicación (requiere reiniciar la aplicación)"
 
-#: ../../vdms_dialogs/preferences.py:248
 msgid "Look and Language"
 msgstr "Apariencia e Idioma"
 
-#: ../../vdms_dialogs/preferences.py:254
 msgid "Upon exiting the application"
 msgstr "Al salir de la aplicación"
 
-#: ../../vdms_dialogs/preferences.py:259
 msgid "Always ask me to confirm"
 msgstr "Siempre pedir confirmación"
 
-#: ../../vdms_dialogs/preferences.py:261
 msgid "Clean the log files"
 msgstr "Limpiar los archivos de registro"
 
-#: ../../vdms_dialogs/preferences.py:264
 msgid "Remove cached files"
 msgstr "Eliminar archivos cache"
 
-#: ../../vdms_dialogs/preferences.py:268
 msgid "On operations completion"
 msgstr "Al completar operación"
 
-#: ../../vdms_dialogs/preferences.py:271
 msgid "These settings will remain active until the application is closed, If necessary, remember to reactivate them."
 msgstr "Estas configuraciones permanecen activas hasta que se cierre la aplicación, De ser necesario recuerde reactivarlas."
 
-#: ../../vdms_dialogs/preferences.py:276
 msgid "Exit the application"
 msgstr "Salir de la aplicación"
 
-#: ../../vdms_dialogs/preferences.py:279
 msgid "Shutdown the system"
 msgstr "Apagar el sistema"
 
-#: ../../vdms_dialogs/preferences.py:283
 msgid "SUDO password:"
 msgstr "contraseña para sudo:"
 
-#: ../../vdms_dialogs/preferences.py:292
 msgid "Exit and Shutdown"
 msgstr "Salir y Apagar"
 
-#: ../../vdms_dialogs/preferences.py:298
 msgid "Specify the character encoding format"
 msgstr "Especificar formato de caracteres"
 
-#: ../../vdms_dialogs/preferences.py:301
 msgid ""
 "Although UTF-8 is the default and most widely used standard encoding format, it is not the only encoding format available.\n"
 "Some file metadata may still contain non-UTF-8 character encodings resulting in the error \"'utf-8' codec can't decode bytes...\".\n"
@@ -1128,31 +814,24 @@ msgstr ""
 "Algunos metadatos aun pueden contener caracteres distintos a los de UTF-8, produciendo el error \"'utf-8' codec can't decode bytes...\".\n"
 "Si sabe el formato de caracteres usado por el archivo, puede intentar especificarlo aquí, ej. ISO 8859-1, ISO 8859-16, etc."
 
-#: ../../vdms_dialogs/preferences.py:311
 msgid "Character encoding:"
 msgstr "Formato de caracteres:"
 
-#: ../../vdms_dialogs/preferences.py:320
 msgid "Default application directories"
 msgstr "Carpetas predeterminadas de la aplicación"
 
-#: ../../vdms_dialogs/preferences.py:324
 msgid "Configuration directory"
 msgstr "Configuración de carpeta"
 
-#: ../../vdms_dialogs/preferences.py:337
 msgid "Cache directory"
 msgstr "Carpeta para Cache"
 
-#: ../../vdms_dialogs/preferences.py:349
 msgid "Log directory"
 msgstr "Carpeta de registros"
 
-#: ../../vdms_dialogs/preferences.py:363
 msgid "Advanced"
 msgstr "Avanzadas"
 
-#: ../../vdms_dialogs/preferences.py:369
 msgid ""
 "The following settings affect output messages and the log messages during transcoding processes.\n"
 "Be careful, by changing these settings some functions of the application may not work correctly,\n"
@@ -1162,121 +841,73 @@ msgstr ""
 "Sea cauteloso, cambiar las configuraciones de algunas funciones de la aplicación puede no funcionar,\n"
 "cámbielas solo si sabe lo que esta haciendo.\n"
 
-#: ../../vdms_dialogs/preferences.py:376
 msgid "Set logging level flags used by FFmpeg"
 msgstr "Fijar opciones de nivel de registro de FFmpeg"
 
-#: ../../vdms_dialogs/preferences.py:383
 msgid "Set logging level flags used by FFplay"
 msgstr "Fijar opciones de nivel de registro de FFplay"
 
-#: ../../vdms_dialogs/preferences.py:391
 msgid "FFmpeg logging levels"
 msgstr "Nivel de registro de FFmpeg"
 
-#: ../../vdms_dialogs/preferences.py:437
 msgid "By assigning an additional suffix you could avoid overwriting files"
 msgstr "Asignar un sufijo adicional evita la reescritura de archivos"
 
-#: ../../vdms_dialogs/preferences.py:440
 msgid "Type sudo password here, only for Unix-like operating systems, not for MS Windows"
 msgstr "Teclee contraseña para sudo, solo para sistemas tipo Unix, no para MS Windows"
 
-#: ../../vdms_dialogs/preferences.py:443
 msgid "Preferences"
 msgstr "Preferencias"
 
-#: ../../vdms_dialogs/preferences.py:596 ../../vdms_dialogs/preferences.py:676
-#: ../../vdms_main/main_frame.py:879 ../../vdms_main/main_frame.py:1060
 msgid "Choose Destination"
 msgstr "Elija Destino"
 
-#: ../../vdms_dialogs/preferences.py:627
 msgid "Enter only alphanumeric characters. You can also use the hyphen (\"-\") and the underscore (\"_\"). Spaces are not allowed."
 msgstr "Teclee solo caracteres alfanuméricos. Puede utilizar el guion (\"-\") y el guion bajo (\"_\"). No se permiten espacios."
 
-#: ../../vdms_dialogs/preferences.py:642
-#: ../../vdms_dialogs/setting_profiles.py:257
-#: ../../vdms_dialogs/setting_profiles.py:264
-#: ../../vdms_dialogs/setting_profiles.py:286
-#: ../../vdms_dialogs/setting_profiles.py:309 ../../vdms_main/main_frame.py:399
-#: ../../vdms_main/main_frame.py:421 ../../vdms_panels/av_conversions.py:605
-#: ../../vdms_panels/av_conversions.py:612
-#: ../../vdms_panels/sequence_to_video.py:352
-#: ../../vdms_panels/video_to_sequence.py:399
 msgid "Videomass - Warning!"
 msgstr "Videomass - ¡Advertencia!"
 
-#: ../../vdms_dialogs/preferences.py:731 ../../vdms_dialogs/preferences.py:771
-#: ../../vdms_dialogs/preferences.py:811 ../../vdms_dialogs/wizard_dlg.py:365
-#: ../../vdms_dialogs/wizard_dlg.py:384 ../../vdms_dialogs/wizard_dlg.py:403
 #, python-brace-format
 msgid "{} location"
 msgstr "Trayectoria de {}"
 
-#: ../../vdms_dialogs/queue_edit.py:36
-#: ../../vdms_dialogs/setting_profiles.py:38
 msgid "One-Pass, Do not start with `ffmpeg -i filename`; do not end with `output-filename`"
 msgstr "Un-Paso, No inicie con `ffmpeg -i archivo`; no termine con `archivo-destino`"
 
-#: ../../vdms_dialogs/queue_edit.py:40
-#: ../../vdms_dialogs/setting_profiles.py:42
 msgid "Two-Pass (optional), Do not start with `ffmpeg -i filename`; do not end with `output-filename`"
 msgstr "Dos-Pasos (opcional), No inicie con `ffmpeg -i archivo`; no termine con `archivo-destino`"
 
-#: ../../vdms_dialogs/queue_edit.py:59
 msgid "Videomass - Edit the selected item in the queue"
 msgstr "Videomass - Editar entrada seleccionada en la lista"
 
-#: ../../vdms_dialogs/queue_edit.py:71
-#: ../../vdms_dialogs/setting_profiles.py:92
 msgid "Pre-input arguments for One-Pass (optional)"
 msgstr "Argumentos Pre-input para Un-paso (opcional)"
 
-#: ../../vdms_dialogs/queue_edit.py:82
-#: ../../vdms_dialogs/setting_profiles.py:151
-#: ../../vdms_panels/presets_manager.py:255
 msgid "FFmpeg arguments for one-pass encoding"
 msgstr "Argumentos de FFmpeg para codificación en un-paso"
 
-#: ../../vdms_dialogs/queue_edit.py:88
-#: ../../vdms_dialogs/setting_profiles.py:158
-#: ../../vdms_panels/presets_manager.py:259
 msgid "Any optional arguments to add before input file on the one-pass encoding, e.g required names of some hardware accelerations like -hwaccel to use with CUDA."
 msgstr "Cualquier argumento adicional previo al archivo de entrada para la codificación un-paso, ej. nombres de aceleradores de hardware como -hwaccel para usar con CUDA."
 
-#: ../../vdms_dialogs/queue_edit.py:102
-#: ../../vdms_dialogs/setting_profiles.py:98
 msgid "Pre-input arguments for Two-Pass (optional)"
 msgstr "Argumentos Pre-input para Dos-pasos (opcional)"
 
-#: ../../vdms_dialogs/queue_edit.py:113
-#: ../../vdms_dialogs/setting_profiles.py:152
-#: ../../vdms_panels/presets_manager.py:257
 msgid "FFmpeg arguments for two-pass encoding"
 msgstr "Argumentos de FFmpeg para codificación en dos-pasoa"
 
-#: ../../vdms_dialogs/queue_edit.py:120
-#: ../../vdms_dialogs/setting_profiles.py:162
-#: ../../vdms_panels/presets_manager.py:263
 msgid "Any optional arguments to add before input file on the two-pass encoding, e.g required names of some hardware accelerations like -hwaccel to use with CUDA."
 msgstr "Cualquier argumento adicional previo al archivo de entrada para la codificación dos-pasos, ej. nombres de aceleradores de hardware como -hwaccel para usar con CUDA."
 
-#: ../../vdms_dialogs/queuedlg.py:65 ../../vdms_main/main_frame.py:508
-#: ../../vdms_panels/presets_manager.py:189
-#: ../../vdms_panels/video_to_sequence.py:171
 msgid "Edit"
 msgstr "Editar"
 
-#: ../../vdms_dialogs/queuedlg.py:68
 msgid "Remove"
 msgstr "Eliminar"
 
-#: ../../vdms_dialogs/queuedlg.py:71
 msgid "Remove all"
 msgstr "Eliminar todo"
 
-#: ../../vdms_dialogs/queuedlg.py:74
 msgid ""
 "Export\n"
 "queue file"
@@ -1284,7 +915,6 @@ msgstr ""
 "Exportar\n"
 "lista de archivos"
 
-#: ../../vdms_dialogs/queuedlg.py:77
 msgid ""
 "Import\n"
 "queue file"
@@ -1292,30 +922,22 @@ msgstr ""
 "Importar\n"
 "archivo de lista"
 
-#: ../../vdms_dialogs/queuedlg.py:85 ../../vdms_panels/filedrop.py:273
 #, fuzzy
 msgid "Destination file name"
 msgstr "Archivo de Salida"
 
-#: ../../vdms_dialogs/queuedlg.py:137
 msgid "Remove all items in the queue"
 msgstr "Eliminar todas las entradas de la lista"
 
-#: ../../vdms_dialogs/queuedlg.py:151
 msgid "Videomass - Queue"
 msgstr "Videomass - Lista"
 
-#: ../../vdms_dialogs/queuedlg.py:228
 msgid "Export queue file"
 msgstr "Exportar archivo de lista"
 
-#: ../../vdms_dialogs/queuedlg.py:296 ../../vdms_panels/av_conversions.py:1192
-#: ../../vdms_panels/presets_manager.py:1044
-#: ../../vdms_panels/video_to_sequence.py:600
 msgid "Same as source"
 msgstr "Igual que la fuente"
 
-#: ../../vdms_dialogs/queuedlg.py:301
 msgid ""
 "Source\n"
 "File destination\n"
@@ -1333,81 +955,60 @@ msgstr ""
 "Segmento de Inicio\n"
 "Duración de Clip"
 
-#: ../../vdms_dialogs/renamer.py:76
 msgid "# will be replaced by ascending numbers starting with:"
 msgstr "# Se reemplazara con números incrementales desde:"
 
-#: ../../vdms_dialogs/set_timestamp.py:87
 msgid "Font Size"
 msgstr "Tamaño de Letra"
 
-#: ../../vdms_dialogs/set_timestamp.py:111
 msgid "Font Color"
 msgstr "Color de Letra"
 
-#: ../../vdms_dialogs/set_timestamp.py:121
 msgid "Shadow Color"
 msgstr "Color de Sombra"
 
-#: ../../vdms_dialogs/set_timestamp.py:132
 msgid "Show text box"
 msgstr "Mostrar caja de texto"
 
-#: ../../vdms_dialogs/set_timestamp.py:136
 msgid "Box Color"
 msgstr "Color de la Caja"
 
-#: ../../vdms_dialogs/set_timestamp.py:156
 msgid "The timestamp size does not auto-adjust to the video size, you have to set the size here"
 msgstr "El tamaño de la estampa de tiempo no se auto ajusta al tamaño de video, configure aquí el tamaño"
 
-#: ../../vdms_dialogs/set_timestamp.py:160 ../../vdms_main/main_frame.py:559
 msgid "Timestamp settings"
 msgstr "Configurar Estampa de tiempo"
 
-#: ../../vdms_dialogs/setting_profiles.py:46
 msgid "Supported Formats list (optional). Do not include the `.`"
 msgstr "Lista de formatos soportados (opcional). No incluya el `.`"
 
-#: ../../vdms_dialogs/setting_profiles.py:47
 msgid "Output Format. Empty to copy format and codec. Do not include the `.`"
 msgstr "Formato de Salida. Vacio, copia el formato y codec. No incluya el `.`"
 
-#: ../../vdms_dialogs/setting_profiles.py:70
 msgid "Profile Name"
 msgstr "Nombre de Perfil"
 
-#: ../../vdms_dialogs/setting_profiles.py:74
-#: ../../vdms_panels/presets_manager.py:404
 msgid "Description"
 msgstr "Descripción"
 
-#: ../../vdms_dialogs/setting_profiles.py:149
 msgid "A short profile name"
 msgstr "Un nombre corto de perfil"
 
-#: ../../vdms_dialogs/setting_profiles.py:150
 msgid "A long description of the profile"
 msgstr "Una descripción amplia del perfil"
 
-#: ../../vdms_dialogs/setting_profiles.py:153
 msgid "One or more comma-separated format names compatible with this profile"
 msgstr "Uno o más nombres de formato compatibles con este perfil, separados por comas"
 
-#: ../../vdms_dialogs/setting_profiles.py:155
 msgid "Output format extension. Leave empty to copy codec and format"
 msgstr "Extensión del formato de salida. Deje vació para copiar codec y formato"
 
-#: ../../vdms_dialogs/setting_profiles.py:256
 msgid "Incomplete profile assignments"
 msgstr "Asignaciones de perfil incompletas"
 
-#: ../../vdms_dialogs/setting_profiles.py:263
 msgid "Formats must be comma-separated"
 msgstr "Debe separar con coma los formatos"
 
-#: ../../vdms_dialogs/setting_profiles.py:279
-#: ../../vdms_utils/queue_utils.py:80
 #, python-brace-format
 msgid ""
 "ERROR: Keys mismatched for requested data.\n"
@@ -1416,105 +1017,69 @@ msgstr ""
 "ERROR: No coinciden llaves para datos requeridos.\n"
 "Archivo invalido: «{0}»"
 
-#: ../../vdms_dialogs/setting_profiles.py:285
-#: ../../vdms_dialogs/setting_profiles.py:308
 msgid "Profile already stored with same name"
 msgstr "Ya existe perfil con ese nombre"
 
-#: ../../vdms_dialogs/setting_profiles.py:293
 msgid "Profile stored successfully!"
 msgstr "¡Perfil guardado exitosamente!"
 
-#: ../../vdms_dialogs/setting_profiles.py:311
 msgid "Profile change successful!"
 msgstr "¡Cambio de Perfil exitosol!"
 
-#: ../../vdms_dialogs/showlogs.py:80
 msgid "Log file list"
 msgstr "Lista de archivos de registro"
 
-#: ../../vdms_dialogs/showlogs.py:82 ../../vdms_dialogs/showlogs.py:116
 msgid "Log messages"
 msgstr "Registro de mensajes"
 
-#: ../../vdms_dialogs/showlogs.py:105
 msgid "Refresh log messages"
 msgstr "Refrescar mensajes de registro"
 
-#: ../../vdms_dialogs/showlogs.py:107
 msgid "Clear log messages"
 msgstr "Limpiar mensajes de registro"
 
-#: ../../vdms_dialogs/showlogs.py:160
 msgid "Select a log file"
 msgstr "Seleccionar archivo de registro"
 
-#: ../../vdms_dialogs/showlogs.py:167
 msgid "Are you sure you want to clear the selected log file?"
 msgstr "¿Seguro desea limpiar el archivo de registro?"
 
-#: ../../vdms_dialogs/showlogs.py:168 ../../vdms_dialogs/wizard_dlg.py:251
-#: ../../vdms_io/checkup.py:68 ../../vdms_main/main_frame.py:205
-#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1685
-#: ../../vdms_panels/presets_manager.py:349
-#: ../../vdms_panels/presets_manager.py:550
-#: ../../vdms_panels/presets_manager.py:590
-#: ../../vdms_panels/presets_manager.py:649
-#: ../../vdms_panels/presets_manager.py:684
-#: ../../vdms_panels/presets_manager.py:749
-#: ../../vdms_panels/presets_manager.py:775
-#: ../../vdms_panels/presets_manager.py:874
-#: ../../vdms_panels/presets_manager.py:904
 msgid "Please confirm"
 msgstr "Por favor Confirme"
 
-#: ../../vdms_dialogs/shownormlist.py:83
 msgid "File name"
 msgstr "Nombre de archivo"
 
-#: ../../vdms_dialogs/shownormlist.py:84
 msgid "Max volume dBFS"
 msgstr "Volumen máximo dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:85
 msgid "Mean volume dBFS"
 msgstr "Volumen promedio dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:86
 msgid "Offset dBFS"
 msgstr "Desplazamiento dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:87
 msgid "Result dBFS"
 msgstr "Resultado dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:92
 msgid "Post-normalization references:"
 msgstr "Referencias post-normalización:"
 
-#: ../../vdms_dialogs/shownormlist.py:102
 msgid "=  Clipped peaks"
 msgstr "=  Picos recortados"
 
-#: ../../vdms_dialogs/shownormlist.py:111
 msgid "=  No changes"
 msgstr "=  Sin cambios"
 
-#: ../../vdms_dialogs/shownormlist.py:121
 msgid "=  Below max peak"
 msgstr "=  Pico inferior máximo"
 
-#: ../../vdms_dialogs/shownormlist.py:166
-#: ../../vdms_panels/audio_encoders/acodecs.py:841
 msgid "RMS-based volume statistics"
 msgstr "Estadísticas de volumen basadas en RMS"
 
-#: ../../vdms_dialogs/shownormlist.py:191
-#: ../../vdms_panels/audio_encoders/acodecs.py:839
 msgid "PEAK-based volume statistics"
 msgstr "Estadísticas de volumen basadas en Picos"
 
-#: ../../vdms_dialogs/shownormlist.py:216
 msgid ""
 "...It means the resulting audio will be clipped,\n"
 "because its volume is higher than the maximum 0 db\n"
@@ -1526,7 +1091,6 @@ msgstr ""
 "de 0 db. Esto provoca perdida de datos y el audio \n"
 "podría sonar distorsionado."
 
-#: ../../vdms_dialogs/shownormlist.py:242
 msgid ""
 "...It means the resulting audio will not change,\n"
 "because it's equal to the source."
@@ -1534,7 +1098,6 @@ msgstr ""
 "...Significa que el audio resultante no tendrá\n"
 "cambios y sera igual al de la fuente."
 
-#: ../../vdms_dialogs/shownormlist.py:266
 msgid ""
 "...It means an audio signal will be produced with\n"
 "a lower volume than the source."
@@ -1542,15 +1105,12 @@ msgstr ""
 "...Significa que la señal de audio se producirá\n"
 "con un volumen menor al original."
 
-#: ../../vdms_dialogs/videomass_check_version.py:63
 msgid "Get Latest Version"
 msgstr "Obtenga la Ultima Version"
 
-#: ../../vdms_dialogs/videomass_check_version.py:67
 msgid "Checking for newer version"
 msgstr "Comprobando versión más reciente"
 
-#: ../../vdms_dialogs/videomass_check_version.py:95
 msgid ""
 "\n"
 "\n"
@@ -1560,7 +1120,6 @@ msgstr ""
 "\n"
 "Las nuevas versiones corrigen fallos y añaden características."
 
-#: ../../vdms_dialogs/videomass_check_version.py:96
 #, python-brace-format
 msgid ""
 "\n"
@@ -1573,7 +1132,6 @@ msgstr ""
 "Videomass versión. {0}\n"
 "\n"
 
-#: ../../vdms_dialogs/while_playing.py:37
 msgid ""
 "q, ESC\n"
 "f\n"
@@ -1615,65 +1173,51 @@ msgstr ""
 "click botón derecho\n"
 "doble click botón izquierdo"
 
-#: ../../vdms_dialogs/while_playing.py:92
 msgid "Shortcut keys while playing with FFplay"
 msgstr "Atajos del teclado al reproducir con FFplay"
 
-#: ../../vdms_dialogs/widget_utils.py:120 ../../vdms_main/main_frame.py:1326
 msgid "Stop"
 msgstr "Parar"
 
-#: ../../vdms_dialogs/wizard_dlg.py:63
 msgid "Please take a moment to set up the application"
 msgstr "Por favor configure la aplicación"
 
-#: ../../vdms_dialogs/wizard_dlg.py:64
 msgid "Click the \"Next\" button to get started"
 msgstr "Presione el botón \"Siguiente\" para iniciar"
 
-#: ../../vdms_dialogs/wizard_dlg.py:79
 msgid "Welcome to the Videomass Wizard!"
 msgstr "¡Bienvenido al asistente de Videomass!"
 
-#: ../../vdms_dialogs/wizard_dlg.py:123
 msgid "Videomass is an application based on FFmpeg\n"
 msgstr "Videomass es una aplicación basada en FFmpeg\n"
 
-#: ../../vdms_dialogs/wizard_dlg.py:125
 msgid "If FFmpeg is not on your computer, this application will be unusable"
 msgstr "Si FFmpeg no esta en su equipo, esta aplicación es inútil"
 
-#: ../../vdms_dialogs/wizard_dlg.py:128
 msgid ""
 "If you have already installed FFmpeg on your operating system,\n"
 "click the \"Auto-detection\" button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:131
 msgid ""
 "If you want to use a version of FFmpeg located on your filesystem\n"
 "but not installed on your operating system,\n"
 "click the \"Locate\" button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:162
 msgid "Auto-detection"
 msgstr "Auto-detectar"
 
-#: ../../vdms_dialogs/wizard_dlg.py:164
 msgid "Locate"
 msgstr "Localizar"
 
-#: ../../vdms_dialogs/wizard_dlg.py:214
 msgid "Click the \"Next\" button"
 msgstr "Presione el botón \"Siguiente\""
 
-#: ../../vdms_dialogs/wizard_dlg.py:235
 #, python-brace-format
 msgid "'{}' is not installed on your computer. Install it or indicate another location by clicking the 'Locate' button."
 msgstr "'{}' no esta instalado en su equipo. Instalelo o indique su ubicación presionando el botón 'Localizar'."
 
-#: ../../vdms_dialogs/wizard_dlg.py:249
 msgid ""
 "Videomass already seems to include FFmpeg.\n"
 "\n"
@@ -1683,11 +1227,9 @@ msgstr ""
 "\n"
 "¿Desea utilizarlo?"
 
-#: ../../vdms_dialogs/wizard_dlg.py:275
 msgid "Locating FFmpeg executables\n"
 msgstr "Localizando ejecutables de FFmpeg\n"
 
-#: ../../vdms_dialogs/wizard_dlg.py:277
 msgid ""
 "\"ffmpeg\", \"ffprobe\" and \"ffplay\" are required. Complete all\n"
 "the text boxes below by clicking on the respective buttons."
@@ -1695,40 +1237,30 @@ msgstr ""
 "Se requiere \"ffmpeg\", \"ffprobe\" y \"ffplay\". Complete todas\n"
 "las cajas de texto presionando en los botones respectivos."
 
-#: ../../vdms_dialogs/wizard_dlg.py:437
 msgid "Wizard completed successfully!\n"
 msgstr "¡Asistente completado con éxito!\n"
 
-#: ../../vdms_dialogs/wizard_dlg.py:438
 msgid "Remember that you can always change these settings later, through the Preferences dialog."
 msgstr "Recuerde que puede cambiar estas configuraciones posteriormente, mediante el dialogo Preferencias."
 
-#: ../../vdms_dialogs/wizard_dlg.py:440
 msgid "Thank You!"
 msgstr "¡Gracias!"
 
-#: ../../vdms_dialogs/wizard_dlg.py:441
 msgid "To exit click the \"Finish\" button"
 msgstr "Para salir presione el botón \"Finalizar\""
 
-#: ../../vdms_dialogs/wizard_dlg.py:527
 msgid "< Previous"
 msgstr "< Anterior"
 
-#: ../../vdms_dialogs/wizard_dlg.py:530 ../../vdms_dialogs/wizard_dlg.py:613
 msgid "Next >"
 msgstr "Siguiente >"
 
-#: ../../vdms_dialogs/wizard_dlg.py:535
 msgid "Videomass Wizard"
 msgstr "Asistente de Videomass"
 
-#: ../../vdms_dialogs/wizard_dlg.py:563 ../../vdms_dialogs/wizard_dlg.py:586
-#: ../../vdms_dialogs/wizard_dlg.py:591
 msgid "Finish"
 msgstr "Finalizar"
 
-#: ../../vdms_io/checkup.py:44 ../../vdms_io/checkup.py:92
 #, python-brace-format
 msgid ""
 "Output folder does not exist:\n"
@@ -1739,32 +1271,25 @@ msgstr ""
 "\n"
 "\"{}\"\n"
 
-#: ../../vdms_io/checkup.py:65
 msgid "Files already exist, do you want to overwrite them?"
 msgstr "Ya existe archivo, ¿quiere sobreecribirlo?"
 
-#: ../../vdms_io/checkup.py:67
 msgid "Already exist"
 msgstr "Ya existe"
 
-#: ../../vdms_io/checkup.py:81
 msgid "Not found"
 msgstr "No encontrado"
 
-#: ../../vdms_io/checkup.py:82 ../../vdms_panels/filedrop.py:196
 msgid "Error list"
 msgstr "Lista de Error"
 
-#: ../../vdms_io/checkup.py:83
 msgid "File(s) not found"
 msgstr "Archivo(s) no encontrado(s)"
 
-#: ../../vdms_io/io_tools.py:56
 #, python-format
 msgid "File does not exist or is invalid:  %s"
 msgstr "Archivo no existe o invalido:  %s"
 
-#: ../../vdms_io/io_tools.py:74
 msgid ""
 "Wait....\n"
 "Audio peak analysis."
@@ -1772,16 +1297,12 @@ msgstr ""
 "Espere....\n"
 "Analizando Picos de Audio."
 
-#: ../../vdms_io/io_tools.py:179
 msgid "Videomass - Downloading..."
 msgstr "Videomass - Descargando..."
 
-#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1409
-#: ../../vdms_main/main_frame.py:1441
 msgid "Ready"
 msgstr "Listo"
 
-#: ../../vdms_main/main_frame.py:203
 msgid ""
 "Not all items in the queue were completed.\n"
 "\n"
@@ -1791,343 +1312,256 @@ msgstr ""
 "\n"
 "¿Desea mantenerlas en la lista?"
 
-#: ../../vdms_main/main_frame.py:224
 #, python-brace-format
 msgid "Queue ({0})"
 msgstr "Lista ({0})"
 
-#: ../../vdms_main/main_frame.py:229 ../../vdms_main/main_frame.py:1334
 msgid "Queue"
 msgstr "Lista"
 
-#: ../../vdms_main/main_frame.py:396 ../../vdms_main/main_frame.py:418
 msgid "There are still active windows with running processes, make sure you finish your work before exit."
 msgstr "Aun hay ventanas activas con procesos ejecutándose, asegúrese de finalizar su trabajo antes de salir."
 
-#: ../../vdms_main/main_frame.py:403
 msgid "Are you sure you want to exit the application?"
 msgstr "¿Seguro que desea salir?"
 
-#: ../../vdms_main/main_frame.py:405
 msgid "Exit"
 msgstr "Salir"
 
-#: ../../vdms_main/main_frame.py:463
 msgid "Import files\tCtrl+O"
 msgstr "Importar archivos\tCtrl+O"
 
-#: ../../vdms_main/main_frame.py:466
 msgid "Open destination folder of encodings\tCtrl+D"
 msgstr "Carpeta destino para codificaciones\tCtrl+D"
 
-#: ../../vdms_main/main_frame.py:469
 msgid "Load queue file"
 msgstr "Cargar archivo de Lista"
 
-#: ../../vdms_main/main_frame.py:470
 msgid "Load a previously exported queue file"
 msgstr "Cargar archivo de Lista previamente exportado"
 
-#: ../../vdms_main/main_frame.py:473
 msgid "Open trash"
 msgstr "Abrir Papelera"
 
-#: ../../vdms_main/main_frame.py:474
 msgid "Open the Videomass trash folder"
 msgstr "Abre carpeta de la papelera de Videomass"
 
-#: ../../vdms_main/main_frame.py:476
 msgid "Empty trash"
 msgstr "Vaciar papelera"
 
-#: ../../vdms_main/main_frame.py:477
 msgid "Delete all files in the Videomass trash folder"
 msgstr "Borrar todo de la papelera de Videomass"
 
-#: ../../vdms_main/main_frame.py:480
 msgid "Exit\tCtrl+Q"
 msgstr "Salir\tCtrl+Q"
 
-#: ../../vdms_main/main_frame.py:481
 msgid "Completely exit the application"
 msgstr "Salir de la aplicación"
 
-#: ../../vdms_main/main_frame.py:482
 msgid "File"
 msgstr "Archivo"
 
-#: ../../vdms_main/main_frame.py:486 ../../vdms_panels/filedrop.py:340
-#: ../../vdms_panels/filedrop.py:381
 msgid "Rename selected file\tCtrl+R"
 msgstr "Renombrar archivo seleccionado\tCtrl+R"
 
-#: ../../vdms_main/main_frame.py:487
 msgid "Rename the destination of the selected file"
 msgstr "Renombra destino de archivo seleccionado"
 
-#: ../../vdms_main/main_frame.py:490 ../../vdms_panels/filedrop.py:341
-#: ../../vdms_panels/filedrop.py:384
 #, fuzzy
 msgid "Batch rename files\tCtrl+B"
 msgstr "Renombrado en lote\tCtrl+B"
 
-#: ../../vdms_main/main_frame.py:491
 msgid "Numerically renames the destination of all items in the list"
 msgstr "Ennumerar el destino de todas las entradas de la lista"
 
-#: ../../vdms_main/main_frame.py:496 ../../vdms_panels/filedrop.py:343
-#: ../../vdms_panels/filedrop.py:388
 msgid "Remove selected entry\tDEL"
 msgstr "Quitar entrada seleccionada\tDEL"
 
-#: ../../vdms_main/main_frame.py:497
 msgid "Remove the selected file from the list"
 msgstr "Eliminar archivo seleccionado de la lista"
 
-#: ../../vdms_main/main_frame.py:500 ../../vdms_panels/filedrop.py:344
-#: ../../vdms_panels/filedrop.py:391
 msgid "Clear list\tShift+DEL"
 msgstr "Vaciar lista\tShift+DEL"
 
-#: ../../vdms_main/main_frame.py:501
 msgid "Clear the file list"
 msgstr "Limpiar la lista de archivos"
 
-#: ../../vdms_main/main_frame.py:506
 msgid "Preferences\tCtrl+P"
 msgstr "Preferencias\tCtrl+P"
 
-#: ../../vdms_main/main_frame.py:507
 msgid "Application preferences"
 msgstr "Preferencias de la aplicación"
 
-#: ../../vdms_main/main_frame.py:512
 msgid "Find FFmpeg topics"
 msgstr "Encontrar temas sobre FFmpeg"
 
-#: ../../vdms_main/main_frame.py:513
 msgid "A useful tool to search for FFmpeg help topics and options"
 msgstr "Una herramienta util para buscar temas de la ayuda de FFmpeg"
 
-#: ../../vdms_main/main_frame.py:518
 msgid "Check for preset updates"
 msgstr "Buscar nuevos presets"
 
-#: ../../vdms_main/main_frame.py:519
 #, python-brace-format
 msgid "Check for new presets updates from {0}"
 msgstr "Buscar nuevos presets en {0}"
 
-#: ../../vdms_main/main_frame.py:521
 msgid "Get latest presets"
 msgstr "Obtener los últimos preset"
 
-#: ../../vdms_main/main_frame.py:522
 #, python-brace-format
 msgid "Get the latest presets from {0}"
 msgstr "Obtener los últimos preset desde {0}"
 
-#: ../../vdms_main/main_frame.py:525
 msgid "Work notes\tCtrl+N"
 msgstr "Notas de trabajo\tCtrl+N"
 
-#: ../../vdms_main/main_frame.py:526
 msgid "Read and write useful notes and reminders."
 msgstr "Lea y escriba recordatorios y notas."
 
-#: ../../vdms_main/main_frame.py:528
 msgid "Tools"
 msgstr "Herramientas"
 
-#: ../../vdms_main/main_frame.py:535
 msgid "Show FFmpeg's built-in configuration capabilities"
 msgstr "Mostrar capacidades de  configuración integradas en FFmpeg"
 
-#: ../../vdms_main/main_frame.py:539
 msgid "Muxers and demuxers available on your version of FFmpeg"
 msgstr "Mezcladores y Desmezcladores disponibles en el FFmpeg utilizado"
 
-#: ../../vdms_main/main_frame.py:543
 msgid "Encoders available on your version of FFmpeg"
 msgstr "Muestra los codificadores disponibles en FFmpeg"
 
-#: ../../vdms_main/main_frame.py:546
 msgid "Decoders available on your version of FFmpeg"
 msgstr "Muestra los decodificadores disponibles en FFmpeg"
 
-#: ../../vdms_main/main_frame.py:550
 msgid "Enable timestamps on playback"
 msgstr "Mostrar marcas de tiempo al reproducir"
 
-#: ../../vdms_main/main_frame.py:551
 msgid "Displays timestamp when playing media with FFplay"
 msgstr "Mostrar marcas de tiempo al reproducir con FFplay"
 
-#: ../../vdms_main/main_frame.py:554
 msgid "Auto-exit after playback"
 msgstr "Salir al terminar reproducción"
 
-#: ../../vdms_main/main_frame.py:555
 msgid "If checked, the FFplay window will auto-close when playback is complete"
 msgstr "Al activar, la ventana de FFplay se cerrara al finalizar la reproducción"
 
-#: ../../vdms_main/main_frame.py:559
 msgid "Customize the timestamp style"
 msgstr "Personalizar Estampa de tiempo"
 
-#: ../../vdms_main/main_frame.py:562
 msgid "While playing..."
 msgstr "Durante reproducción..."
 
-#: ../../vdms_main/main_frame.py:563
 msgid "Show useful shortcut keys when playing or previewing using FFplay"
 msgstr "Mostrar atajos de teclado al reproducir o previsualizar con FFplay"
 
-#: ../../vdms_main/main_frame.py:567
 msgid "Show timeline editor\tCtrl+T"
 msgstr "Editor de linea de tiempo\tCtrl+T"
 
-#: ../../vdms_main/main_frame.py:568
 msgid "Set duration or trim slices of time to remove unwanted parts from your files"
 msgstr "Fijar lduración o recortar pedazos de tiempo, eliminar partes no deseadas de archivos"
 
-#: ../../vdms_main/main_frame.py:572
 msgid "View"
 msgstr "Ver"
 
-#: ../../vdms_main/main_frame.py:579
 msgid "Home panel\tCtrl+Shift+H"
 msgstr "Panel principal\tCtrl+Shift+H"
 
-#: ../../vdms_main/main_frame.py:580
 msgid "Go to the «Home» panel"
 msgstr "Ir al panel «Principal»"
 
-#: ../../vdms_main/main_frame.py:583
 msgid "Presets Manager\tCtrl+Shift+P"
 msgstr "Administrador de Presets\tCtrl+Shift+P"
 
-#: ../../vdms_main/main_frame.py:584
 msgid "Go to the «Presets Manager» panel"
 msgstr "Ir al panel «Administrador de Presets»"
 
-#: ../../vdms_main/main_frame.py:586
 msgid "A/V Conversions\tCtrl+Shift+V"
 msgstr "Conversiones A/V \tCtrl+Shift+V"
 
-#: ../../vdms_main/main_frame.py:587
 msgid "Go to the «A/V Conversions» panel"
 msgstr "Ir al panel «Conversiones A/V»"
 
-#: ../../vdms_main/main_frame.py:589
 msgid "Concatenate Demuxer\tCtrl+Shift+D"
 msgstr "Encadenar Dezmezclador\tCtrl+Shift+D"
 
-#: ../../vdms_main/main_frame.py:590
 msgid "Go to the «Concatenate Demuxer» panel"
 msgstr "Ir al panel «Encadenar Desmezcladores»"
 
-#: ../../vdms_main/main_frame.py:593
 msgid "Still Image Maker\tCtrl+Shift+I"
 msgstr "Creador de Imágenes Fijas\tCtrl+Shift+I"
 
-#: ../../vdms_main/main_frame.py:594
 msgid "Go to the «Still Image Maker» panel"
 msgstr "Ir al panel «Productor de Imágenes Fijas»"
 
-#: ../../vdms_main/main_frame.py:596
 msgid "From Movie to Pictures\tCtrl+Shift+S"
 msgstr "De Película a Imágenes\tCtrl+Shift+S"
 
-#: ../../vdms_main/main_frame.py:597
 msgid "Go to the «From Movie to Pictures» panel"
 msgstr "Ir al panel «De Película a Imágenes»"
 
-#: ../../vdms_main/main_frame.py:600
 msgid "Output monitor\tCtrl+Shift+O"
 msgstr "Monitor de Salida\tCtrl+Shift+O"
 
-#: ../../vdms_main/main_frame.py:601
 msgid "Keeps track of the output for debugging errors"
 msgstr "Mantener rastro de la salida para depuración de errores"
 
-#: ../../vdms_main/main_frame.py:603
 msgid "Go"
 msgstr "Ir a"
 
-#: ../../vdms_main/main_frame.py:607
 msgid "User guide"
 msgstr "Guía de usuario"
 
-#: ../../vdms_main/main_frame.py:611
 msgid "System version"
 msgstr "Versión del Sistema"
 
-#: ../../vdms_main/main_frame.py:612
 msgid "Get version about your operating system, version of Python and wxPython."
 msgstr "Obteniendo versiones de su sistema, Python y wxPython."
 
-#: ../../vdms_main/main_frame.py:616
 msgid "Show log files\tCtrl+L"
 msgstr "Mostrar Registros\tCtrl+L"
 
-#: ../../vdms_main/main_frame.py:617
 msgid "Viewing log messages"
 msgstr "Ver mensajes de registro"
 
-#: ../../vdms_main/main_frame.py:620
 msgid "Issue tracker"
 msgstr "Seguimiento de fallos"
 
-#: ../../vdms_main/main_frame.py:624
 msgid "Contribute to the project"
 msgstr "Contribuir al proyecto"
 
-#: ../../vdms_main/main_frame.py:627
 msgid "Sponsor this project"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:628
 msgid "Become a developer supporter"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:629
 msgid "Donate"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:630
 msgid "Donate to the app developer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:634
 msgid "Other projects by the developer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:650
 msgid "About Videomass"
 msgstr "Sobre Videomass"
 
-#: ../../vdms_main/main_frame.py:651
 msgid "Check for newer version"
 msgstr "Comprobanr versión más reciente"
 
-#: ../../vdms_main/main_frame.py:652
 msgid "Check for the latest Videomass version"
 msgstr "Comprobar ultima versión de Videomass"
 
-#: ../../vdms_main/main_frame.py:654
 msgid "Help"
 msgstr "Ayuda"
 
-#: ../../vdms_main/main_frame.py:729
 msgid "Import files"
 msgstr "Importar archivos"
 
-#: ../../vdms_main/main_frame.py:752
 msgid "No default folder has been set for the destination of the encodings. The current setting is \"Same destination paths as source files\"."
 msgstr "No se fijo carpeta destino para las conversiones. La configuración actual es \"Misma carpeta que archivos fuente\"."
 
-#: ../../vdms_main/main_frame.py:784 ../../vdms_main/main_frame.py:809
 #, python-brace-format
 msgid ""
 "'{}':\n"
@@ -2136,11 +1570,9 @@ msgstr ""
 "'{}':\n"
 "No existe archivo o carpeta"
 
-#: ../../vdms_main/main_frame.py:797
 msgid "Are you sure to empty trash folder?"
 msgstr "¿Seguro que desea vaciar la papelera?"
 
-#: ../../vdms_main/main_frame.py:805
 #, python-brace-format
 msgid ""
 "'{}':\n"
@@ -2149,17 +1581,14 @@ msgstr ""
 "'{}':\n"
 "No hay archivos a borrar."
 
-#: ../../vdms_main/main_frame.py:862
 #, python-brace-format
 msgid "Installed release v{0}. A new presets release is available {1}"
 msgstr "Versión instalada v{0}. Nueva versión de presets disponible {1}"
 
-#: ../../vdms_main/main_frame.py:866
 #, python-brace-format
 msgid "Installed release v{0}. No new updates found."
 msgstr "Versión instalada v{0}. No se encontró actualizaciones."
 
-#: ../../vdms_main/main_frame.py:896
 msgid ""
 "Wait....\n"
 "The archive is being downloaded"
@@ -2167,16 +1596,13 @@ msgstr ""
 "Espere....\n"
 "El archivo esta siendo descargado"
 
-#: ../../vdms_main/main_frame.py:908
 #, python-brace-format
 msgid "Successfully downloaded to \"{0}\""
 msgstr "Descargado exitosamente en \"{0}\""
 
-#: ../../vdms_main/main_frame.py:1120
 msgid "Some changes require restarting the application."
 msgstr "Algunos cambios requieren reiniciar aplicación."
 
-#: ../../vdms_main/main_frame.py:1126
 #, python-brace-format
 msgid ""
 "{0}\n"
@@ -2187,116 +1613,85 @@ msgstr ""
 "\n"
 "¿Quiere reiniciar aplicación ahora?"
 
-#: ../../vdms_main/main_frame.py:1128
 msgid "Restart Videomass?"
 msgstr "¿Reiniciar Videomass?"
 
-#: ../../vdms_main/main_frame.py:1207
 #, python-brace-format
 msgid "A new release is available - v.{0}\n"
 msgstr "Una nueva versión esta disponible . {0}\n"
 
-#: ../../vdms_main/main_frame.py:1210
 msgid "You are using a development version that has not yet been released!\n"
 msgstr "¡Esta utilizando una versión de desarrollo!\n"
 
-#: ../../vdms_main/main_frame.py:1213
 msgid "Congratulation! You are already using the latest version.\n"
 msgstr "¡Felicitaciones! Ya esta utilizando la ultima versión versión.\n"
 
-#: ../../vdms_main/main_frame.py:1301
 msgid "Previous panel"
 msgstr "Panel anterior"
 
-#: ../../vdms_main/main_frame.py:1302
 msgid "Back"
 msgstr "Regresar"
 
-#: ../../vdms_main/main_frame.py:1305
 msgid "Next panel"
 msgstr "Siguiente panel"
 
-#: ../../vdms_main/main_frame.py:1306
 msgid "Next"
 msgstr "Siguiente"
 
-#: ../../vdms_main/main_frame.py:1309
 msgid "Home panel"
 msgstr "Panel Principal"
 
-#: ../../vdms_main/main_frame.py:1310
 msgid "Home"
 msgstr "Principal"
 
-#: ../../vdms_main/main_frame.py:1313
 msgid "Play the selected imput file"
 msgstr "Reproducir archivo de entrada seleccionado"
 
-#: ../../vdms_main/main_frame.py:1314
 msgid "Play"
 msgstr "Reproducir"
 
-#: ../../vdms_main/main_frame.py:1317
 msgid "Get informative data about imported media streams"
 msgstr "Obtiene información de flujos Multimedia importados"
 
-#: ../../vdms_main/main_frame.py:1321
 msgid "Start batch processing"
 msgstr "Comenzar proceso por lote"
 
-#: ../../vdms_main/main_frame.py:1325
 msgid "Stops current process"
 msgstr "Detener proceso actual"
 
-#: ../../vdms_main/main_frame.py:1329
 msgid "Add an item to Queue"
 msgstr "Añadir entrada a la Lista"
 
-#: ../../vdms_main/main_frame.py:1330
 msgid "Add to Queue"
 msgstr "Añadir a la Lista"
 
-#: ../../vdms_main/main_frame.py:1333
 msgid "Show queue"
 msgstr "Mostrar lista"
 
-#: ../../vdms_main/main_frame.py:1408 ../../vdms_panels/presets_manager.py:569
 msgid "Videomass"
 msgstr "Videomass"
 
-#: ../../vdms_main/main_frame.py:1442
 msgid "Videomass - File List"
 msgstr "Videomass - Lista de Archivos"
 
-#: ../../vdms_main/main_frame.py:1459
 msgid "Videomass - AV Conversions"
 msgstr "Videomass - Conversiones AV"
 
-#: ../../vdms_main/main_frame.py:1488
 msgid "Videomass - Presets Manager"
 msgstr "Videomass - Administrador de Presets"
 
-#: ../../vdms_main/main_frame.py:1518
 msgid "Videomass - Concatenate Demuxer"
 msgstr "Videomass - Encadenar Dezmezcladores"
 
-#: ../../vdms_main/main_frame.py:1547
 msgid "Videomass - From Movie to Pictures"
 msgstr "Videomass -De Película a Imágenes"
 
-#: ../../vdms_main/main_frame.py:1576
 msgid "Videomass - Still Image Maker"
 msgstr "Videomass -Productor de Imágenes Fijas"
 
-#: ../../vdms_main/main_frame.py:1660 ../../vdms_panels/av_conversions.py:577
-#: ../../vdms_panels/filedrop.py:500 ../../vdms_panels/filedrop.py:616
-#: ../../vdms_panels/sequence_to_video.py:322
-#: ../../vdms_panels/video_to_sequence.py:369
-#: ../../vdms_panels/video_to_sequence.py:501
 msgid "Have to select an item in the file list first"
 msgstr "Primero elija un archivo en la lista"
 
-#: ../../vdms_main/main_frame.py:1682
 msgid ""
 "An item with the same destination file already exists.\n"
 "\n"
@@ -2306,84 +1701,63 @@ msgstr ""
 "\n"
 "¿Desea reemplazarlo añadiendo la entrada a la lista?"
 
-#: ../../vdms_main/main_frame.py:1703
 msgid "Videomass - FFmpeg Message Monitoring"
 msgstr "Videomass - Monitor de mensajes de FFmpeg"
 
-#: ../../vdms_main/main_frame.py:1828
 #, python-brace-format
 msgid "The system will turn off in {0} seconds"
 msgstr "El sistema se apagara en {0} segundos"
 
-#: ../../vdms_main/main_frame.py:1829
 msgid "Videomass - Shutdown!"
 msgstr "Videomass - ¡Apagando!"
 
-#: ../../vdms_main/main_frame.py:1836
 msgid "Error while shutting down. Please see file log for details."
 msgstr "Error al apagar. Vea el archivo de registro para detalles."
 
-#: ../../vdms_main/main_frame.py:1848
 #, python-brace-format
 msgid "Exiting the application in {0} seconds"
 msgstr "La aplicación se cerrara en {0} segundos"
 
-#: ../../vdms_main/main_frame.py:1849
 msgid "Videomass - Exiting!"
 msgstr "Videomass - ¡Saliendo!"
 
-#: ../../vdms_miniframes/timeline.py:46
 msgid "Start point adjustment"
 msgstr "Punto de ajuste inicial"
 
-#: ../../vdms_miniframes/timeline.py:48
 msgid "End point adjustment"
 msgstr "Ajuste de punto final"
 
-#: ../../vdms_miniframes/timeline.py:105
 msgid "Hours"
 msgstr "Horas"
 
-#: ../../vdms_miniframes/timeline.py:106
 msgid "Minutes"
 msgstr "Minutos"
 
-#: ../../vdms_miniframes/timeline.py:107
 msgid "Seconds"
 msgstr "Segundos"
 
-#: ../../vdms_miniframes/timeline.py:108
 msgid "Milliseconds"
 msgstr "Milisegundos"
 
-#: ../../vdms_miniframes/timeline.py:189 ../../vdms_miniframes/timeline.py:312
 msgid "No source duration:"
 msgstr "Sin duraci´on de la fuente:"
 
-#: ../../vdms_miniframes/timeline.py:208 ../../vdms_miniframes/timeline.py:298
-#: ../../vdms_miniframes/timeline.py:333 ../../vdms_miniframes/timeline.py:338
-#: ../../vdms_miniframes/timeline.py:441
 #, python-brace-format
 msgid "{0} {1}  |  Segment Duration: {2}"
 msgstr "{0} {1}  |  Duración de Segmento: {2}"
 
-#: ../../vdms_miniframes/timeline.py:260 ../../vdms_miniframes/timeline.py:277
 msgid "End adjustment"
 msgstr "Ajuste de final"
 
-#: ../../vdms_miniframes/timeline.py:261 ../../vdms_miniframes/timeline.py:279
 msgid "Start adjustment"
 msgstr "Iniciar ajuste"
 
-#: ../../vdms_miniframes/timeline.py:320
 msgid "Source duration:"
 msgstr "Duración de fuente:"
 
-#: ../../vdms_miniframes/timeline.py:387
 msgid "WARNING: Invalid selection, out of range."
 msgstr "ADVERTENCIA: Selección invalida, fuera de rango."
 
-#: ../../vdms_miniframes/timeline.py:461
 msgid ""
 "Start by dragging the bottom left handle,\n"
 "or right-click for options."
@@ -2392,15 +1766,12 @@ msgstr ""
 "\n"
 "o presione con el botón derecho para ver las opciones."
 
-#: ../../vdms_miniframes/timeline.py:497
 msgid "Start"
 msgstr "Iniciar"
 
-#: ../../vdms_miniframes/timeline.py:498
 msgid "End"
 msgstr "Fin"
 
-#: ../../vdms_miniframes/timeline.py:548
 msgid ""
 "The timeline editor is a tool that allows you to trim slices of time on selected imported media (see File List panel).\n"
 "\n"
@@ -2422,39 +1793,30 @@ msgstr ""
 "\n"
 "Los valores \"Inicio\"/\"Fin\" siempre refieren al valor inicial de la linea de tiempo: 00:00:00.000. Para información sobre la duración del segmento y advertencias vea los mensajes en la barra de estado."
 
-#: ../../vdms_miniframes/timeline.py:565
 msgid "Timeline Editor Usage"
 msgstr "Uso del Editor de Linea de Tiempo"
 
-#: ../../vdms_panels/av_conversions.py:153
 msgid "Media:"
 msgstr "Medio:"
 
-#: ../../vdms_panels/av_conversions.py:169
 msgid "Container:"
 msgstr "Contenedor:"
 
-#: ../../vdms_panels/av_conversions.py:180
 msgid "Save profile"
 msgstr "Guardar perfil"
 
-#: ../../vdms_panels/av_conversions.py:183
 msgid "Target"
 msgstr "Destino"
 
-#: ../../vdms_panels/av_conversions.py:316
 msgid "Miscellaneous"
 msgstr "Misceláneos"
 
-#: ../../vdms_panels/av_conversions.py:323
 msgid "Save as a new profile of the Presets Manager."
 msgstr "Guardar nuevo perfil del Administrador de Presets."
 
-#: ../../vdms_panels/av_conversions.py:325
 msgid "Available video encoders. \"Copy\" means that the video stream will not be re-encoded and will allow you (depending on the encoder) to change the container, audio codec and a few other parameters."
 msgstr "Codificadores de video disponibles. \"Copiar\" indica que el flujo de video no sera recodificado y permite (según el codificador) cambiar el contenedor, codificador de audio y algunos otros parámetros."
 
-#: ../../vdms_panels/av_conversions.py:330
 msgid ""
 "Container format. It is usually represented by the file extension (output format).\n"
 "\n"
@@ -2468,7 +1830,6 @@ msgstr ""
 "\n"
 "If the media target is set to \"Audio\", you can extract only the audio streams from videos, or simply convert audio source files."
 
-#: ../../vdms_panels/av_conversions.py:338
 msgid ""
 "Set output files target: \"Video\" to save output files as video files; \"Audio\" to save files using an audio encoder and format.\n"
 "\n"
@@ -2478,46 +1839,34 @@ msgstr ""
 "\n"
 "Note que al usar \"Audio\" como destino, aun podrá trabajar sobre los archivos video originales pero solo podrá extraer los flujos de  audio, convertirlos y aplicarles filtros como el de normalización."
 
-#: ../../vdms_panels/av_conversions.py:346
 msgid "Preview video filters"
 msgstr "Previsualizar filtros de video"
 
-#: ../../vdms_panels/av_conversions.py:347
 msgid "Disable active filters"
 msgstr "Desactivar filtros activos"
 
-#: ../../vdms_panels/av_conversions.py:348
-#: ../../vdms_panels/sequence_to_video.py:156
-#: ../../vdms_panels/video_to_sequence.py:113
 msgid "Resize"
 msgstr "Redimencionar"
 
-#: ../../vdms_panels/av_conversions.py:349
 msgid "Crop"
 msgstr "Recortar"
 
-#: ../../vdms_panels/av_conversions.py:350
 msgid "Transpose"
 msgstr "Transponer"
 
-#: ../../vdms_panels/av_conversions.py:352
 #, fuzzy
 msgid "Denoise"
 msgstr "ReduceRuido"
 
-#: ../../vdms_panels/av_conversions.py:353
 msgid "Stabilize"
 msgstr "Estabilizar"
 
-#: ../../vdms_panels/av_conversions.py:354
 msgid "Equalize"
 msgstr "Equalizar"
 
-#: ../../vdms_panels/av_conversions.py:517
 msgid "Unable to preview Video Stabilizer filter"
 msgstr "No se puede previsualizar el filtro Estabilizador de Video"
 
-#: ../../vdms_panels/av_conversions.py:602
 msgid ""
 "Unsupported file:\n"
 "Missing decoder or library? Check FFmpeg configuration."
@@ -2525,22 +1874,15 @@ msgstr ""
 "Archivo no soportado:\n"
 "¿Falta decodificador o librería? Revise la configuración de FFmpeg."
 
-#: ../../vdms_panels/av_conversions.py:611
-#: ../../vdms_panels/sequence_to_video.py:351
-#: ../../vdms_panels/video_to_sequence.py:398
 msgid "The file is not a frame or a video file"
 msgstr "El archivo no es un cuadro o archivo de video"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:434
-#: ../../vdms_panels/av_conversions.py:861
 msgid "Undetected volume values! Click the \"Volume detect\" button to analyze audio volume data."
 msgstr "¡No se detectaron valores de volumen! Presione el botón \"Detectar Volumen\" para analizar los datos del audio."
 
-#: ../../vdms_panels/av_conversions.py:1186
 msgid "Off"
 msgstr "Apagado"
 
-#: ../../vdms_panels/av_conversions.py:1203
 msgid ""
 "Batch processing items\n"
 "Destination\n"
@@ -2566,109 +1908,81 @@ msgstr ""
 "Segmento inicial\n"
 "Duración de Clip"
 
-#: ../../vdms_panels/av_conversions.py:1246
-#: ../../vdms_panels/presets_manager.py:814
 #, python-brace-format
 msgid "Write profile on «{0}»"
 msgstr "Escribir perfil en «{0}»"
 
-#: ../../vdms_panels/av_conversions.py:1266
-#: ../../vdms_panels/presets_manager.py:513
 msgid "Enter name for new preset"
 msgstr "Intorduzca nombre del nuevo preset"
 
-#: ../../vdms_panels/av_conversions.py:1276
-#: ../../vdms_panels/presets_manager.py:524
 msgid "Invalid file name, make sure to provide a valid name including the «.json» extension"
 msgstr "Nombre de archivo invalido, asegúrese de proporcionar un nombre valido incluyendo la extensión «.json»"
 
-#: ../../vdms_panels/av_conversions.py:1284
 #, python-brace-format
 msgid "Cannot save current data in file «{}»."
 msgstr "No se puede guardar la información actual en '{}'."
 
-#: ../../vdms_panels/av_conversions.py:1289
 msgid "Open Videomass preset"
 msgstr "Abrir preset de Videomass"
 
-#: ../../vdms_panels/av_conversions.py:1307
 msgid "Videomass - Save new profile"
 msgstr "Videomass - Guardar nuevo perfil"
 
-#: ../../vdms_panels/av_conversions.py:1308
 msgid "Where do you want to save this profile?"
 msgstr "¿Desea guardar el perfil?"
 
-#: ../../vdms_panels/av_conversions.py:1309
 msgid "Save the profile to a new preset"
 msgstr "Guardar perfil en nuevo preset"
 
-#: ../../vdms_panels/av_conversions.py:1310
 msgid "Save the profile to an existing preset"
 msgstr "Guardar perfil en preset existente"
 
-#: ../../vdms_panels/choose_topic.py:69
 msgid "Welcome to Videomass"
 msgstr "Bienvenido a Videomass"
 
-#: ../../vdms_panels/choose_topic.py:71
 #, python-brace-format
 msgid "Version {}"
 msgstr "Versión {}"
 
-#: ../../vdms_panels/choose_topic.py:82
 msgid "Presets Manager"
 msgstr "Administrador de Presets"
 
-#: ../../vdms_panels/choose_topic.py:85
 msgid "AV-Conversions"
 msgstr "Conversiones-AV"
 
-#: ../../vdms_panels/choose_topic.py:88
 msgid "Concatenate media files"
 msgstr "Encadenar archivos de medios"
 
-#: ../../vdms_panels/choose_topic.py:91
 msgid "Still Image Maker"
 msgstr "Productor de Imágenes Fijas"
 
-#: ../../vdms_panels/choose_topic.py:94
 msgid "From Movie to Pictures"
 msgstr "De Película a Imágenes"
 
-#: ../../vdms_panels/choose_topic.py:123
 msgid "Create, edit and use quickly your favorite FFmpeg presets and profiles with full formats support and codecs."
 msgstr "Crear, editar y usar rápidamente sus presets y perfiles favoritos de FFmpeg con un completo soporte de formatos y codecs."
 
-#: ../../vdms_panels/choose_topic.py:127
 msgid "A set of useful tools for audio and video conversions. Save your profiles and reuse them with Presets Manager."
 msgstr "Un conjunto de herramientas útiles para conversiones de audio y video. Guarde sus perfiles y reutilicelos con el Administrador de Presets."
 
-#: ../../vdms_panels/choose_topic.py:131
 msgid "Concatenate multiple media files based on import order without re-encoding"
 msgstr "Encadenar múltiples archivos de medios en base a su orden de importación sin recodificar"
 
-#: ../../vdms_panels/choose_topic.py:134
 msgid "Create video from a sequence of images, based on import order, with the ability to add an audio file."
 msgstr "Crear video a partir de una secuencia de imágenes, ordenadas según se importan, con la posibilidad de añadir un archivo de audio file."
 
-#: ../../vdms_panels/choose_topic.py:137
 msgid "Extract images (frames) from your movies in JPG, PNG, BMP, GIF formats."
 msgstr "Extraer cuadros desde películas  a imágenes  en formatos JPG, PNG, BMP, GIF ."
 
-#: ../../vdms_panels/concatenate.py:47
 msgid "At least two files are required to perform concatenation."
 msgstr "Se requieren al menos dos archivos para realizar la encadenación."
 
-#: ../../vdms_panels/concatenate.py:63
 msgid "Invalid data found"
 msgstr "Información invalida"
 
-#: ../../vdms_panels/concatenate.py:68
 msgid "The files do not have the same \"codec_types\", same \"sample_rate\" or same \"width\" or \"height\". Unable to proceed."
 msgstr "Los archivos no tienen los mismos \"codec\", \"frec. muestreo\" o \"ancho\" o \"altura\". No se puede proceder."
 
-#: ../../vdms_panels/concatenate.py:84
 msgid ""
 "\n"
 "- The concatenation function is performed only with Audio files or only with Video files.\n"
@@ -2696,17 +2010,12 @@ msgstr ""
 "\n"
 "- Los archivo de Audio deben tener los mismos formatos, codecs y frecuencia de muestreo."
 
-#: ../../vdms_panels/concatenate.py:125
 msgid "Videomass Documentation:"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:136
-#: ../../vdms_panels/sequence_to_video.py:212
-#: ../../vdms_panels/video_to_sequence.py:181
 msgid "Official FFmpeg documentation:"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:253
 msgid ""
 "Items to concatenate\n"
 "File destination\n"
@@ -2720,254 +2029,192 @@ msgstr ""
 "Tipo de salida multimedia\n"
 "Duración"
 
-#: ../../vdms_panels/filedrop.py:45
 msgid "File has illegal characters like:"
 msgstr "Archivo con caracteres ilegales:"
 
-#: ../../vdms_panels/filedrop.py:46
 msgid "Invalid character found in path name: (\")"
 msgstr "Carácter invalido en la trayectoria: (\")"
 
-#: ../../vdms_panels/filedrop.py:47
 msgid "Directories are not allowed, just add files, please."
 msgstr "No se permiten Carpetas, por favor solo añada archivos."
 
-#: ../../vdms_panels/filedrop.py:48
 msgid "File without format extension: please give an appropriate extension to the file name, example '.mkv', '.avi', '.mp3', etc."
 msgstr "Archivo sin extensión de formato: ponga una extensión apropiada al archivo, ejemplo '.mkv', '.avi','.mp3', etc."
 
-#: ../../vdms_panels/filedrop.py:84
 #, python-brace-format
 msgid "Name has illegal characters like: {0}"
 msgstr "Nombre con caracteres invalidos: {0}"
 
-#: ../../vdms_panels/filedrop.py:85
 msgid "Name already in use:"
 msgstr "El nombre ya esta en uso:"
 
-#: ../../vdms_panels/filedrop.py:185
 msgid "Duplicate file, it has already been added to the list."
 msgstr "El archivo ya esta en la lista."
 
-#: ../../vdms_panels/filedrop.py:197
 msgid "Rejected files"
 msgstr "Archivos Rechazados"
 
-#: ../../vdms_panels/filedrop.py:269
 msgid "Source file"
 msgstr "Archivo fuente"
 
-#: ../../vdms_panels/filedrop.py:270
 msgid "Duration"
 msgstr "Duración"
 
-#: ../../vdms_panels/filedrop.py:271
 msgid "Media type"
 msgstr "Tipo de Medio"
 
-#: ../../vdms_panels/filedrop.py:272
 msgid "Size"
 msgstr "Tamaño"
 
-#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:405
 msgid "Drag one or more files below"
 msgstr "Arrastre uno o más archivos abajo"
 
-#: ../../vdms_panels/filedrop.py:282
 msgid "Save to:"
 msgstr "Guardar a:"
 
-#: ../../vdms_panels/filedrop.py:306
 msgid "Set a new destination folder for encodings"
 msgstr "Carpeta destino para codificaciones"
 
-#: ../../vdms_panels/filedrop.py:308
 msgid "Encodings destination folder"
 msgstr "Carpeta destino para codificaciones"
 
-#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:394
 msgid "Play file"
 msgstr "Reproducir archivo"
 
-#: ../../vdms_panels/filedrop.py:408
 msgid "Drag two or more Audio/Video files below"
 msgstr "Arrastre dos o más archivos Audio/Video abajo"
 
-#: ../../vdms_panels/filedrop.py:412
 #, fuzzy
 msgid "Drag one or more Image files below"
 msgstr "Arrastre uno o más archivos abajo"
 
-#: ../../vdms_panels/filedrop.py:415
 msgid "Drag one or more Video files below"
 msgstr "Arrastre uno o más archivos Video abajo"
 
-#: ../../vdms_panels/filedrop.py:623
 msgid "Rename the file destination"
 msgstr "Renombra archivo destino"
 
-#: ../../vdms_panels/filedrop.py:624
 msgid "Rename the selected file to:"
 msgstr "Renombrar archivo seleccionado a:"
 
-#: ../../vdms_panels/filedrop.py:638 ../../vdms_panels/filedrop.py:648
-#: ../../vdms_panels/filedrop.py:679
 msgid "Add Files"
 msgstr "Añadir Archivos"
 
-#: ../../vdms_panels/filedrop.py:655
 msgid "Rename in batch"
 msgstr "Renombrar por lote"
 
-#: ../../vdms_panels/filedrop.py:656
 #, python-brace-format
 msgid "Rename the {0} items to:"
 msgstr "Renombrar {0} objetos a:"
 
-#: ../../vdms_panels/filedrop.py:658
 msgid "New Name #"
 msgstr "Nombre Nuevo #"
 
-#: ../../vdms_panels/long_processing_task.py:114
 msgid "Sorry, all task failed !"
 msgstr "¡Ha fallado la tarea !"
 
-#: ../../vdms_panels/long_processing_task.py:115
 msgid "The process was stopped due to a fatal error."
 msgstr "Proceso detenido debido a error fatal."
 
-#: ../../vdms_panels/long_processing_task.py:116
 msgid "Interrupted Process !"
 msgstr "¡Proceso Interrumpido !"
 
-#: ../../vdms_panels/long_processing_task.py:117
 msgid "Successfully completed !"
 msgstr "¡Completado exitosamente !"
 
-#: ../../vdms_panels/long_processing_task.py:118
 msgid "Not everything was successful."
 msgstr "No todo fue exitoso."
 
-#: ../../vdms_panels/long_processing_task.py:148
 msgid "Encoding Status"
 msgstr "Estado de codificación"
 
-#: ../../vdms_panels/long_processing_task.py:152
 msgid "Current Log"
 msgstr "Registro"
 
-#: ../../vdms_panels/long_processing_task.py:354
 msgid "Fatal Error !"
 msgstr "¡Error Fatal !"
 
-#: ../../vdms_panels/long_processing_task.py:363
 msgid "Get your files at the destination you specified"
 msgstr "Guarde sus archivos en el destino especificado"
 
-#: ../../vdms_panels/long_processing_task.py:377
 msgid "For more details please read the Current Log."
 msgstr "Para mas detalles vea el Registro."
 
-#: ../../vdms_panels/long_processing_task.py:380
 msgid "...Finished"
 msgstr "...Completado"
 
-#: ../../vdms_panels/long_processing_task.py:399
 msgid "Please wait... interruption in progress"
 msgstr "Por favor espere.. Abortando"
 
-#: ../../vdms_panels/long_processing_task.py:402
 msgid "...Interrupted"
 msgstr "...Interrumpido"
 
-#: ../../vdms_panels/presets_manager.py:166
 msgid "Presets"
 msgstr "Presets"
 
-#: ../../vdms_panels/presets_manager.py:180
 msgid "Write"
 msgstr "Escribir"
 
-#: ../../vdms_panels/presets_manager.py:184
 msgid "Delete"
 msgstr "Borrar"
 
-#: ../../vdms_panels/presets_manager.py:194
 msgid "Duplicate"
 msgstr "Duplicado"
 
-#: ../../vdms_panels/presets_manager.py:199
 msgid "Profiles"
 msgstr "Perfiles"
 
-#: ../../vdms_panels/presets_manager.py:206
 msgid "One-Pass Encoding"
 msgstr "Codificación en Un-Paso"
 
-#: ../../vdms_panels/presets_manager.py:218
 msgid "Two-Pass Encoding"
 msgstr "Codificación en Dos-Pasos"
 
-#: ../../vdms_panels/presets_manager.py:232
 msgid "Choose a preset and view its profiles"
 msgstr "Elija un preset y vea sus perfiles"
 
-#: ../../vdms_panels/presets_manager.py:233
 #, fuzzy
 msgid "Write a new profile and save it in the selected preset"
 msgstr "Crear un nuevo perfil y guardarlo en el preset seleccionado"
 
-#: ../../vdms_panels/presets_manager.py:235
 msgid "Delete the selected profile"
 msgstr "Borrar perfil seleccionado"
 
-#: ../../vdms_panels/presets_manager.py:236
 msgid "Edit the selected profile"
 msgstr "Editar perfil seleccionado"
 
-#: ../../vdms_panels/presets_manager.py:237
 msgid "Duplicate the selected profile"
 msgstr "Duplicar perfil seleccionado"
 
-#: ../../vdms_panels/presets_manager.py:238
 #, fuzzy
 msgid "Create new preset"
 msgstr "Crear nuevo preset"
 
-#: ../../vdms_panels/presets_manager.py:240
 msgid "Remove selected preset"
 msgstr "Quitar preset seleccionado"
 
-#: ../../vdms_panels/presets_manager.py:242
 msgid "Backup selected preset"
 msgstr "Respaldar preset seleccionado"
 
-#: ../../vdms_panels/presets_manager.py:244
 msgid "Backup the presets folder"
 msgstr "Respaldar carpeta de presets"
 
-#: ../../vdms_panels/presets_manager.py:246
 msgid "Restore a preset"
 msgstr "Restablecer un preset"
 
-#: ../../vdms_panels/presets_manager.py:248
 msgid "Restore a presets folder"
 msgstr "Restablecer carpeta de presets"
 
-#: ../../vdms_panels/presets_manager.py:250
 msgid "Resets the selected preset to default values"
 msgstr "Restablecer preset seleccionado"
 
-#: ../../vdms_panels/presets_manager.py:252
 msgid "Reset all presets to default values"
 msgstr "Restablecer todos los presets"
 
-#: ../../vdms_panels/presets_manager.py:254
 #, fuzzy
 msgid "Refresh the presets list"
 msgstr "Actualizar lista de presets"
 
-#: ../../vdms_panels/presets_manager.py:338
 #, python-brace-format
 msgid ""
 "Outdated presets version found: v{1}\n"
@@ -2990,28 +2237,22 @@ msgstr ""
 "\n"
 "¿Desea actualizar?"
 
-#: ../../vdms_panels/presets_manager.py:403
 msgid "Name"
 msgstr "Nombre"
 
-#: ../../vdms_panels/presets_manager.py:405
 msgid "Output Format"
 msgstr "Formato de Salida"
 
-#: ../../vdms_panels/presets_manager.py:406
 msgid "Supported Format List"
 msgstr "Lista de formatos soportados"
 
-#: ../../vdms_panels/presets_manager.py:531
 #, python-brace-format
 msgid "Cannot save current data in file '{}'."
 msgstr "No se puede guardar la información actual en '{}'."
 
-#: ../../vdms_panels/presets_manager.py:535
 msgid "You just successfully created a new preset!"
 msgstr "¡Preset creado exitosamente!"
 
-#: ../../vdms_panels/presets_manager.py:547
 #, python-brace-format
 msgid ""
 "Are you sure you want to remove \"{}\" preset?\n"
@@ -3022,7 +2263,6 @@ msgstr ""
 "\n"
 "Se moverá a la carpeta \"Removals\" dentro de la carpeta de presets."
 
-#: ../../vdms_panels/presets_manager.py:558
 #, python-brace-format
 msgid ""
 "{}\n"
@@ -3033,30 +2273,22 @@ msgstr ""
 "\n"
 "Fallo al eliminar, no se puede continuar.."
 
-#: ../../vdms_panels/presets_manager.py:568
 #, python-brace-format
 msgid "The preset \"{0}\" was successfully removed"
 msgstr "El preset \"{0}\" se elimino con exito"
 
-#: ../../vdms_panels/presets_manager.py:583
-#: ../../vdms_panels/presets_manager.py:612
 msgid "Open a destination folder"
 msgstr "Abrir carpeta destino"
 
-#: ../../vdms_panels/presets_manager.py:588
 msgid "A file with this name already exists, do you want to overwrite it?"
 msgstr "Ya existe archivo con ese nombres, ¿quiere sobreecribirlo?"
 
-#: ../../vdms_panels/presets_manager.py:602
-#: ../../vdms_panels/presets_manager.py:622
 msgid "Backup completed successfully"
 msgstr "¡Respaldo completado con éxito!"
 
-#: ../../vdms_panels/presets_manager.py:631
 msgid "Open the preset you want to restore"
 msgstr "Abra el preset a restaurar"
 
-#: ../../vdms_panels/presets_manager.py:645
 msgid ""
 "This preset already exists and is about to be updated. Don't worry, it will keep all your saved profiles.\n"
 "\n"
@@ -3066,11 +2298,9 @@ msgstr ""
 "\n"
 "¿Desea continuar?"
 
-#: ../../vdms_panels/presets_manager.py:663
 msgid "Restore successful"
 msgstr "¡Restauración exitosa!"
 
-#: ../../vdms_panels/presets_manager.py:681
 msgid ""
 "This will update the presets database. Don't worry, it will keep all your saved profiles.\n"
 "\n"
@@ -3080,19 +2310,15 @@ msgstr ""
 "\n"
 "¿Desea continuar?"
 
-#: ../../vdms_panels/presets_manager.py:689
 msgid "Open the presets folder to restore"
 msgstr "Abrir carpeta de presets a restaurar"
 
-#: ../../vdms_panels/presets_manager.py:725
 msgid "The presets database has been successfully updated"
 msgstr "Base de datos de presets actualizada con exito"
 
-#: ../../vdms_panels/presets_manager.py:740
 msgid "The selected preset is not part of Videomass's default presets."
 msgstr "Preset seleccionado no es parte de Videomass."
 
-#: ../../vdms_panels/presets_manager.py:745
 msgid ""
 "Be careful! The selected preset will be overwritten with the default one. Your profiles may be deleted!\n"
 "\n"
@@ -3102,12 +2328,9 @@ msgstr ""
 "\n"
 "¿Desea continuar?"
 
-#: ../../vdms_panels/presets_manager.py:760
-#: ../../vdms_panels/presets_manager.py:794
 msgid "Successful recovery"
 msgstr "Recuperación exitosa"
 
-#: ../../vdms_panels/presets_manager.py:769
 msgid ""
 "Be careful! This action will restore all presets to default ones. Your profiles may be deleted!\n"
 "\n"
@@ -3121,20 +2344,16 @@ msgstr ""
 "\n"
 "¿Desea continuar?"
 
-#: ../../vdms_panels/presets_manager.py:833
 #, python-brace-format
 msgid "Edit profile on «{0}»"
 msgstr "Editar perfil en «{0}»"
 
-#: ../../vdms_panels/presets_manager.py:872
 msgid "Are you sure you want to delete the selected profile? It will no longer be possible to recover it."
 msgstr "¿Seguro que desea borrar el perfil seleccionado? No sera posible recuperarlo."
 
-#: ../../vdms_panels/presets_manager.py:891
 msgid "First select a profile in the list"
 msgstr "Primero elija un perfil en la lista"
 
-#: ../../vdms_panels/presets_manager.py:899
 msgid ""
 "The selected profile command has been changed manually.\n"
 "Do you want to apply it during the conversion process?"
@@ -3142,11 +2361,9 @@ msgstr ""
 "El comando del perfil seleccionado se cambio manualmente.\n"
 "¿Desea aplicarlo durante el proceso de conversión?"
 
-#: ../../vdms_panels/presets_manager.py:909
 msgid "Don't show this dialog again"
 msgstr "No mostrar nuevamente este dialogo"
 
-#: ../../vdms_panels/presets_manager.py:1054
 msgid ""
 "Batch processing items\n"
 "Destination\n"
@@ -3166,12 +2383,10 @@ msgstr ""
 "Inicio de segmento\n"
 "Duración de Clip"
 
-#: ../../vdms_panels/sequence_to_video.py:54
 #, fuzzy
 msgid "Images need to be resized, please use Resize function."
 msgstr "Las Imágenes deben redimencionarse, por favor use la función Redimensionar."
 
-#: ../../vdms_panels/sequence_to_video.py:73
 msgid ""
 "\n"
 "1. Import one or more image files such as JPG, PNG and BMP formats, then select one.\n"
@@ -3202,11 +2417,9 @@ msgstr ""
 "El video producido tendrá el nombre del archivo seleccionado en el panel 'Lista de Archivos' , \n"
 "y sera guardado en una carpeta llamada 'Still_Images' con un digito progresivo, en la trayectoria especificada."
 
-#: ../../vdms_panels/sequence_to_video.py:129
 msgid "Enable a single still image"
 msgstr "Habilitar solo una imagen fija"
 
-#: ../../vdms_panels/sequence_to_video.py:162
 msgid ""
 "Force original aspect ratio using\n"
 "padding rather than stretching"
@@ -3214,28 +2427,21 @@ msgstr ""
 "Forzar la relación de aspecto original usando\n"
 "rellenar en lugar de estirar"
 
-#: ../../vdms_panels/sequence_to_video.py:170
 msgid "Include audio file"
 msgstr "Incluir archivo de audio"
 
-#: ../../vdms_panels/sequence_to_video.py:173
 msgid "Play the video until audio track finishes"
 msgstr "Reproducir video hasta que la pista de audio finalice"
 
-#: ../../vdms_panels/sequence_to_video.py:180
-#: ../../vdms_panels/sequence_to_video.py:439
 msgid "Open audio file"
 msgstr "Abrir archivo de audio"
 
-#: ../../vdms_panels/sequence_to_video.py:199
 msgid "Additional arguments"
 msgstr "Argumentos Adicionales"
 
-#: ../../vdms_panels/sequence_to_video.py:454
 msgid "Open Audio File"
 msgstr "Abrir Archivo de Audio"
 
-#: ../../vdms_panels/sequence_to_video.py:466
 #, python-brace-format
 msgid ""
 "Invalid file: '{}'\n"
@@ -3246,7 +2452,6 @@ msgstr ""
 "\n"
 "{}"
 
-#: ../../vdms_panels/sequence_to_video.py:471
 #, python-brace-format
 msgid ""
 "Invalid file: '{}'\n"
@@ -3257,21 +2462,14 @@ msgstr ""
 "\n"
 "No parece un archivo de audio."
 
-#: ../../vdms_panels/sequence_to_video.py:560
-#: ../../vdms_panels/sequence_to_video.py:587
-#: ../../vdms_panels/video_to_sequence.py:511
 #, python-brace-format
 msgid "Invalid file: '{}'"
 msgstr "Archivo invalido: \"{}\""
 
-#: ../../vdms_panels/sequence_to_video.py:570
-#: ../../vdms_panels/sequence_to_video.py:595
 #, python-brace-format
 msgid "Unsupported format '{}'"
 msgstr "Formato no soportado '{}'"
 
-#: ../../vdms_panels/sequence_to_video.py:576
-#: ../../vdms_panels/sequence_to_video.py:600
 #, python-brace-format
 msgid ""
 "File does not exist:\n"
@@ -3282,15 +2480,9 @@ msgstr ""
 "\n"
 "\"{}\"\n"
 
-#: ../../vdms_panels/sequence_to_video.py:577
 msgid "ERROR"
 msgstr "ERROR"
 
-#: ../../vdms_panels/sequence_to_video.py:707
-msgid "Shortest"
-msgstr "MiniPrueba"
-
-#: ../../vdms_panels/sequence_to_video.py:715
 msgid ""
 "Items to concatenate\n"
 "Output filename\n"
@@ -3318,7 +2510,6 @@ msgstr ""
 "Duración de Imagen Fija\n"
 "Duración total de Video"
 
-#: ../../vdms_panels/video_to_sequence.py:50
 msgid ""
 "\n"
 "1. Import one or more video files, then select one.\n"
@@ -3348,51 +2539,39 @@ msgstr ""
 "Las imágenes producidas serán guardadas en una carpeta llamada 'Movie_to_Pictures'\n"
 "con un digito progresivo, en la trayectoria especificada."
 
-#: ../../vdms_panels/video_to_sequence.py:86
 msgid "Create thumbnails"
 msgstr "Crear miniaturas"
 
-#: ../../vdms_panels/video_to_sequence.py:87
 msgid "Create tiled mosaics"
 msgstr "Crear mosaicos"
 
-#: ../../vdms_panels/video_to_sequence.py:88
 msgid "Create animated GIF"
 msgstr "Crear GIF animado"
 
-#: ../../vdms_panels/video_to_sequence.py:90
 msgid "Options"
 msgstr "Opciones"
 
-#: ../../vdms_panels/video_to_sequence.py:119
 msgid "Output format:"
 msgstr "Formato de Salida:"
 
-#: ../../vdms_panels/video_to_sequence.py:131
 msgid "Rows:"
 msgstr "Renglones:"
 
-#: ../../vdms_panels/video_to_sequence.py:141
 msgid "Columns:"
 msgstr "Columnas:"
 
-#: ../../vdms_panels/video_to_sequence.py:205
 msgid "Other unofficial resources:"
 msgstr "Otros recursos no oficiales:"
 
-#: ../../vdms_panels/video_to_sequence.py:229
 msgid "Set FPS control from 0.1 to 30.0 fps. The higher this value, the more images will be extracted."
 msgstr "Fijar el control de FPS, desde 0.1 hasta 30.0 fps. Entre más alto el valor se extraen más imágenes."
 
-#: ../../vdms_panels/video_to_sequence.py:232
 msgid "Spaces around the mosaic tiles. From 0 to 32 pixels"
 msgstr "Espacio entre mosaicos. Desde 0 hasta 32 pixels"
 
-#: ../../vdms_panels/video_to_sequence.py:234
 msgid "Spaces around the mosaic borders. From 0 to 32 pixels"
 msgstr "Espacio entre bordes de mosaicos. Desde 0 hasta 32 pixels"
 
-#: ../../vdms_panels/video_to_sequence.py:626
 msgid ""
 "Selected File\n"
 "Output Format\n"
@@ -3420,51 +2599,39 @@ msgstr ""
 "Inicio de segmento\n"
 "Duración"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:118
 msgid "Audio encoder settings, mapping and filters"
 msgstr "Configuración de codificador de Audio, mapeo y filtros"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:128
 msgid "Audio Encoder"
 msgstr "Codificador de Audio"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:137
 msgid "Settings"
 msgstr "Configuraciones"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:148
 msgid "Index Selection:"
 msgstr "Selecciòn de Indice:"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:157
 msgid "Map:"
 msgstr "Mapear:"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:180
 msgid "Normalization"
 msgstr "Normalización"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:191
 msgid "Volume detect"
 msgstr "Detectar Volumen"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:195
 msgid "Volume Statistics"
 msgstr "Estadísticas de Volumen"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:199
 msgid "Target level:"
 msgstr "Nivel Objetivo:"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:264
 msgid "Gets maximum volume and average volume data in dBFS, then calculates the offset amount for audio normalization."
 msgstr "Obtiene el volumen máximo y promedio en dBFs, y calcula el desplazamiento para normalizar el audio."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:267
 msgid "Limiter for the maximum peak level or the mean level (when switch to RMS) in dBFS. From -99.0 to +0.0; default for PEAK level is -1.0; default for RMS is -20.0"
 msgstr "Limita por máximo nivel de pico o por nivel promedio (cuando se usa RMS) en dBFS. Desde -99 a +0.0; predeterminado para nivel de pico es -1.0; para RMS es 20.0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:271
 msgid ""
 "Normally on a video with correctly indexed streams and having one or more audio streams, the first audio stream should be indexed at \"1\", the second at \"2\" and so on (the video stream on the other hand is always indexed at \"0\"). In this case it is recommended to select the desired stream by setting a specific index, e.g \"1\" for for the first available audio stream.\n"
 "\n"
@@ -3474,7 +2641,6 @@ msgstr ""
 "\n"
 "Ponga este control en \"Auto\" si la fuente es una pista de audio ."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:280
 msgid ""
 "\"Auto\" keeps all audio streams and processes only the one selected by the \"Index Selection\" control.\n"
 "\n"
@@ -3488,28 +2654,22 @@ msgstr ""
 "\n"
 "\"Solo el Indice\" procesa solo el flujo de audio seleccionado en el control \"Selección de Indice\" y elimina el resto"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:288
 msgid "Integrated Loudness Target in LUFS. From -70.0 to -5.0, default is -16.0"
 msgstr "Intensidad Destino Integrada en LUFS. Desde -70.0 a -5.0, predeterminado -16.0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:291
 msgid "Maximum True Peak in dBTP. From -1.5 to +0.0, default is -2.0"
 msgstr "Pico Máximo Real en dBTP. Desde -9.0 a +0.0, predeterminado -2.0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:294
 #, fuzzy
 msgid "Loudness Range Target in LUFS. From +1.0 to +20.0, default is +11.0"
 msgstr "Rango de Intensidad Destino en LUFS. Desde +1.0 a +20.0, predeterminado +7.0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:297
 msgid "Play the audio stream selected in the \"Index Selection\" control. Using this function you can test the result of audio normalization."
 msgstr "Reproducir el flujo de audio seleccionado en la \"Selección de Indice\". Con esta función puede probar el resultado de normalizar el audio."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:503
 msgid "Selected index does not exist or does not contain any audio streams"
 msgstr "El indice seleccionado no existe o no contiene flujos de audio"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:508
 #, python-brace-format
 msgid ""
 "ERROR: Missing audio stream:\n"
@@ -3518,15 +2678,12 @@ msgstr ""
 "ERROR: Falta flujo de audio:\n"
 "\"{}\""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:726
 msgid "PEAK level normalization, which will produce a maximum peak level equal to the set target level."
 msgstr "Normalización de nivel de pico, produce un nivel de pico máximo igual al configurado."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:729
 msgid "RMS-based normalization, which according to mean volume calculates the amount of gain to reach same average power signal."
 msgstr "Normalización RMS, se calcula la ganancia de acuerdo al volumen medio para lograr la misma potencia promedio de señal."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:733
 msgid ""
 "Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements the EBU R128 algorithm.\n"
 "Ideal for live normalization. It produces worse results than the High-quality two-pass Loudnorm normalization, but is faster."
@@ -3534,7 +2691,6 @@ msgstr ""
 "Normalización de intensidad. Se Normaliza la intensidad percibida utilizando el filtro \"​loudnorm\", el cual implementa el algoritmo EBU R128.\n"
 "Ideal par normalización en vivo. Produce peores resultados que la normalización de intensidad en dos pasos de Alta calidad, pero es mas rápida."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:740
 msgid ""
 "High-quality two-pass Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements\n"
 "the EBU R128 algorithm. Ideal for postprocessing."
@@ -3542,23 +2698,18 @@ msgstr ""
 "Normalización de intensidad Alta calidad en dos pasos. Se Normaliza la intensidad percibida utilizando el filtro \"​loudnorm\", el cual\n"
 "implementa el algoritmo EBU R128. Ideal para postprocesado."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:789
 msgid "You need to import at least one file"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:63
 msgid "Subtitle Mapping:"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:77
 msgid "Copy Chapters"
 msgstr "Copiar capítulos"
 
-#: ../../vdms_panels/miscellaneous/miscell.py:79
 msgid "Copy Metadata"
 msgstr "Copiar metadatos"
 
-#: ../../vdms_panels/miscellaneous/miscell.py:85
 msgid ""
 "Select \"All\" to include any source file subtitles in the output video.\n"
 "\n"
@@ -3572,152 +2723,68 @@ msgstr ""
 "\n"
 "Se ignora esta opción sil la salida es archivo de audio."
 
-#: ../../vdms_panels/miscellaneous/miscell.py:90
 msgid "Copy the chapter markers as is from source file. This option is automatically ignored for output audio files."
 msgstr "Copiar las marcas de capítulos desde la fuente. Se ignora esta opción sil la salida es archivo de audio."
 
-#: ../../vdms_panels/miscellaneous/miscell.py:93
 msgid "Copy all incoming metadata from source file, such as audio/video tags, titles, unique marks, and so on."
 msgstr "Copiar todos los metadatos desde la fuente, cosas como etiquetas de audio/video, títulos, marcas únicas, etc."
 
-#: ../../vdms_panels/miscellaneous/miscell.py:108
 #, fuzzy
 msgid "Additional options"
 msgstr "Argumentos Adicionales"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:89
-#: ../../vdms_panels/video_encoders/av1_svt.py:120
-#: ../../vdms_panels/video_encoders/avc_x264.py:90
-#: ../../vdms_panels/video_encoders/hevc_x265.py:98
-#: ../../vdms_panels/video_encoders/mpeg4.py:71
-#: ../../vdms_panels/video_encoders/vp9_webm.py:131
 #, fuzzy
 msgid "Reload"
 msgstr "Recargar"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:101
-#: ../../vdms_panels/video_encoders/av1_svt.py:129
-#: ../../vdms_panels/video_encoders/avc_x264.py:101
-#: ../../vdms_panels/video_encoders/hevc_x265.py:109
-#: ../../vdms_panels/video_encoders/mpeg4.py:82
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:97
-#: ../../vdms_panels/video_encoders/vp9_webm.py:141
 #, fuzzy
 msgid "Optimize for Web"
 msgstr "Para uso en Web"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:247
-#: ../../vdms_panels/video_encoders/av1_svt.py:313
-#: ../../vdms_panels/video_encoders/avc_x264.py:242
-#: ../../vdms_panels/video_encoders/hevc_x265.py:250
-#: ../../vdms_panels/video_encoders/mpeg4.py:198
-#: ../../vdms_panels/video_encoders/vp9_webm.py:288
 msgid "Reloads the selected video encoder settings. Changes will be discarded."
 msgstr "Recargar configuración del codificador de video. Se descartaran los cambios."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:250
-#: ../../vdms_panels/video_encoders/avc_x264.py:273
-#: ../../vdms_panels/video_encoders/hevc_x265.py:277
-#: ../../vdms_panels/video_encoders/vp9_webm.py:291
 #, fuzzy
 msgid "Constant rate factor. Lower values correspond to higher quality and greater file size. Set to -1 to disable this control."
 msgstr "Factor de frecuencia Constante. Valores mas bajos = mejor calidad y mayor tamaño de archivo. -1 deshabilita este control."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:254
-#: ../../vdms_panels/video_encoders/av1_svt.py:357
-#: ../../vdms_panels/video_encoders/vp9_webm.py:295
 msgid "Number of tile rows to use, default changes per resolution"
 msgstr "Renglones a usar, el predeterminado cambia según resolución"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:256
-#: ../../vdms_panels/video_encoders/av1_svt.py:359
-#: ../../vdms_panels/video_encoders/vp9_webm.py:297
 msgid "Number of tile columns to use, default changes per resolution"
 msgstr "Columnas a usar, el predeterminado cambia según resolución"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:259
-#: ../../vdms_panels/video_encoders/av1_svt.py:368
-#: ../../vdms_panels/video_encoders/avc_x264.py:253
-#: ../../vdms_panels/video_encoders/hevc_x265.py:261
-#: ../../vdms_panels/video_encoders/mpeg4.py:201
-#: ../../vdms_panels/video_encoders/vp9_webm.py:300
 msgid "Set the Group Of Picture (GOP). Set to -1 to disable this control."
 msgstr "Tamaño del grupo de imágenes (GOP). -1 para desactiva este control."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:262
-#: ../../vdms_panels/video_encoders/av1_svt.py:371
-#: ../../vdms_panels/video_encoders/avc_x264.py:256
-#: ../../vdms_panels/video_encoders/hevc_x265.py:264
-#: ../../vdms_panels/video_encoders/mpeg4.py:204
-#: ../../vdms_panels/video_encoders/vp9_webm.py:303
 msgid "It can reduce the file size, but takes longer."
 msgstr "Puede reducir el tamaño del archivo, pero dilatar más."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:264
-#: ../../vdms_panels/video_encoders/av1_svt.py:373
-#: ../../vdms_panels/video_encoders/avc_x264.py:258
-#: ../../vdms_panels/video_encoders/hevc_x265.py:266
-#: ../../vdms_panels/video_encoders/mpeg4.py:206
-#: ../../vdms_panels/video_encoders/vp9_webm.py:305
 msgid "Set minimum bitrate tolerance. Most useful in setting up a CBR encode. It is of little use otherwise. Set to -1 to disable this control."
 msgstr "Tolerancia de bitrate mínimo. Mas util usada con codificación CBR. Es de poca utilidad en otros casos. -1 deshabilita el control."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:268
-#: ../../vdms_panels/video_encoders/av1_svt.py:377
-#: ../../vdms_panels/video_encoders/avc_x264.py:262
-#: ../../vdms_panels/video_encoders/hevc_x265.py:270
-#: ../../vdms_panels/video_encoders/mpeg4.py:210
-#: ../../vdms_panels/video_encoders/vp9_webm.py:309
 msgid "Specifies a maximum tolerance. Requires bufsize to be set. Set to -1 to disable this control."
 msgstr "Especificar tolerancia máxima. Requiere fijar tamaño del buffer. -1 desactiva este control."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:271
-#: ../../vdms_panels/video_encoders/av1_svt.py:380
-#: ../../vdms_panels/video_encoders/avc_x264.py:265
-#: ../../vdms_panels/video_encoders/hevc_x265.py:273
-#: ../../vdms_panels/video_encoders/mpeg4.py:213
-#: ../../vdms_panels/video_encoders/vp9_webm.py:312
 msgid "Set ratecontrol buffer size, which determines the variability of the output bitrate. Set to -1 to disable this control."
 msgstr "Fija control de razón del tamaño de buffer, determina la variabilidad de la frecuencia de bits de salida. -1 desactiva este control."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:275
-#: ../../vdms_panels/video_encoders/av1_svt.py:384
-#: ../../vdms_panels/video_encoders/avc_x264.py:277
-#: ../../vdms_panels/video_encoders/hevc_x265.py:281
-#: ../../vdms_panels/video_encoders/mpeg4.py:231
-#: ../../vdms_panels/video_encoders/vp9_webm.py:316
 msgid "Specifies the target (average) bit rate for the encoder to use. Higher value = higher quality. Set -1 to disable this control."
 msgstr "Especifica la frecuencia de bits (promedio) que usara el codificador. Un valor más alto =  mejor calidad. -1 deshabilita este control."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:279
-#: ../../vdms_panels/video_encoders/av1_svt.py:388
-#: ../../vdms_panels/video_encoders/avc_x264.py:281
-#: ../../vdms_panels/video_encoders/hevc_x265.py:285
-#: ../../vdms_panels/video_encoders/mpeg4.py:235
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:131
-#: ../../vdms_panels/video_encoders/vp9_webm.py:320
 msgid "Video width and video height ratio."
 msgstr "Proporción ancho y alto de video."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:281
-#: ../../vdms_panels/video_encoders/av1_svt.py:390
-#: ../../vdms_panels/video_encoders/avc_x264.py:283
-#: ../../vdms_panels/video_encoders/hevc_x265.py:287
-#: ../../vdms_panels/video_encoders/mpeg4.py:237
-#: ../../vdms_panels/video_encoders/vp9_webm.py:322
 #, fuzzy
 msgid "Frame rate (frames per second). Frames repeat a given number of times per second. In some countries this is 30 for NTSC, other countries (like Italy) use 25 for PAL"
 msgstr "Los cuadros se repiten un dado numero de veces por segundo. En algunos países es 30 para NTSC, en otros  (como Italia) usan 25 para PAL"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:285
 msgid "Quality/Speed ratio modifier. CPU Used sets how efficient the compression will be. Lower values mean slower encoding with better quality, and vice-versa. Valid values are from 0 to 8 inclusive."
 msgstr "Razón Calidad/Velocidad. Fija la eficiencia de la compresión. Valores bajos equivale a una codificación más lenta con mejor calidad, y viceversa. Valores validos incluyen 0 a 8 ."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:290
 msgid "Quality and compression efficiency vs speed trade-off. \"good\" is the default and recommended for most applications; \"realtime\" is recommended for live/fast encoding (live streaming, video conferencing, etc); \"allintra\" for All Intra encoding."
 msgstr "Calidad y compresión del intercambio  eficiencia vs calidad. \"good\" es lo predeterminado y recomendado para muchas aplicaciones;  \"realtime\" recomendado para directos, videoconferencia, etc; «allintra» para la codificación All Intra."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:297
 msgid ""
 "Row Multi-Threading enables row-based multi-threading which maximizes CPU usage.\n"
 "\n"
@@ -3731,7 +2798,6 @@ msgstr ""
 "\n"
 "Activarlo solo es mas rápido si el CPU tiene más hilos que el numero total de cuadros."
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:316
 msgid ""
 "presets 1-3 represent extremely high efficiency, for use when encode time is not important and quality/size of the resulting video file is critical.\n"
 "\n"
@@ -3749,7 +2815,6 @@ msgstr ""
 "\n"
 "Preset 13 es aun más rápido pero no esta dirigido al consumo humano directo --puede usarse por ejemplo para comparaciones por escena de aplicaciones VOD. Solo se debe usar el preset más bajo tolerable."
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:327
 msgid ""
 "Constant rate factor. This parameter governs the quality/size trade-off.\n"
 "\n"
@@ -3767,7 +2832,6 @@ msgstr ""
 "\n"
 " -1 deshabilita el control."
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:334
 msgid ""
 "The \"Film Grain\" parameter allows SVT-AV1 to detect and delete film grain from the source video, and replace it with synthetic grain of the same character, resulting in significant bitrate savings.\n"
 "\n"
@@ -3789,7 +2853,6 @@ msgstr ""
 "\n"
 "Si la fuente de video no tiene grano, se puede desactivar con -1 o usar 0."
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:346
 msgid ""
 "If enabled, the \"Film Grain Denoiser\" option can mitigate the detail removal caused by high \"Film Grain\" values required to preserve the look of very grainy films\n"
 "\n"
@@ -3799,55 +2862,36 @@ msgstr ""
 "\n"
 "Por omisión los cuadros procesados son pasados para ser codificados como imágenes finales, esta caracteristica hara que se usen los cuadros originales. "
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:353
 msgid "Enables encoder optimization to produce faster (less CPU intensive) bit streams to decode, similar to the fastdecode tuning in x264 and x265."
 msgstr "Optimizar codificador para producir un flujo de bits mas rápido (menor uso de CPU) a decodificar, similar al ajuste fastdecode en x264 y x265."
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:362
-#: ../../vdms_panels/video_encoders/avc_x264.py:247
-#: ../../vdms_panels/video_encoders/hevc_x265.py:255
 msgid "Set profile restrictions"
 msgstr "Restricciones de perfil"
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:364
-#: ../../vdms_panels/video_encoders/avc_x264.py:249
-#: ../../vdms_panels/video_encoders/hevc_x265.py:257
 msgid "Specify level for a selected profile"
 msgstr "Especifique nivel del perfil seleccionado"
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:366
-#: ../../vdms_panels/video_encoders/avc_x264.py:251
-#: ../../vdms_panels/video_encoders/hevc_x265.py:259
 msgid "Tune the encoding params"
 msgstr "Afinar parámetros de codificación"
 
-#: ../../vdms_panels/video_encoders/avc_x264.py:245
-#: ../../vdms_panels/video_encoders/hevc_x265.py:253
 msgid "Set the encoding preset (default \"medium\")"
 msgstr "Preset de codificación (por omisión \"medio\")"
 
-#: ../../vdms_panels/video_encoders/avc_x264.py:269
 msgid "specifies the target (average) bit rate for the encoder to use. Higher value = higher quality. Set -1 to disable this control."
 msgstr "especifica la frecuencia de bits (promedio) que usara el codificador. Un valor más alto =  mejor calidad. -1 deshabilita este control."
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:217
 msgid "Variable Bit Rate. From 0-30, with 1 being highest quality/largest filesize and 30 being the lowest quality/smallest filesize. Set to -1 to disable this control."
 msgstr "Flujo Variable de Bits. De 0-30, siendo 1 mayor calidad/mayor tamaño y 30 menor calidad/menor tamaño.  -1 desactiva este control."
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:222
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:133
 msgid "Frames repeat a given number of times per second. In some countries this is 30 for NTSC, other countries (like Italy) use 25 for PAL"
 msgstr "Los cuadros se repiten un dado numero de veces por segundo. En algunos países es 30 para NTSC, en otros  (como Italia) usan 25 para PAL"
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:226
 msgid "The default FourCC stored in an MPEG-4-coded file will be FMP4. If you want a different FourCC, set this option to xvid to force the FourCC xvid to be stored as the video FourCC rather than the default."
 msgstr "El valor FourCC en un video MPEG-4-seria FMP4. Si quiere un valor FourCC diferente, use xvid para forzar FourCC xvid en el video en vez del predeterminado."
 
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:162
 msgid "Copy Video Codec"
 msgstr "Copiar Codec de Video"
 
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:163
 msgid ""
 "This will just copy the video track as is, without any video re-encoding.\n"
 "You will only be able to change output format, select other audio encoders and\n"
@@ -3857,11 +2901,9 @@ msgstr ""
 "Solo podrá cambiar el formato de salida, seleccionar otro codificador de audio y\n"
 "otras pocas opciones."
 
-#: ../../vdms_panels/video_encoders/video_no_enc.py:74
 msgid "Video export disabled"
 msgstr "Exportación de Video desactivada"
 
-#: ../../vdms_panels/video_encoders/video_no_enc.py:75
 msgid ""
 "The Media target you just selected will only allow you to export files as audio tracks.\n"
 "You can then process audio source files only or extract indexed audio streams on\n"
@@ -3871,7 +2913,6 @@ msgstr ""
 "Entonces solo podrá procesar archivos de audio o extraer el audio indicado de\n"
 "los archivos de video."
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:326
 msgid ""
 "Speed sets how efficient the compression will be.\n"
 "\n"
@@ -3893,7 +2934,6 @@ msgstr ""
 "\n"
 "Si Calidad es realtime, los valores de Velocidad son de 0 a 8."
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:335
 msgid ""
 "Time to spend encoding.\n"
 "\n"
@@ -3911,24 +2951,23 @@ msgstr ""
 "\n"
 "\"realtime\" se recomienda para codificaciones en directo/rapidas."
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:341
-msgid "If enabled, adds support for row based multithreading which greatly enhances the number of threads the encoder can utilise. This improves encoding speed significantly on systems that are otherwise underutilised when encoding VP9. Since the amount of additional threads depends on the number of \"tiles\", which itself depends on the video resolution, encoding higher resolution videos will see a larger performance improvement."
-msgstr "Habilitarla, añade multiproceso por renglón que mejora el numero de hilos que el codificador puede usar. Esto mejora significativamente la velocidad de codificado al codificar en VP9, en sistemas que de otra manera están subutilizados. Ya que la cantidad adicional de hilos  depende del numero de \"cuadros\", lo que depende del la resolución del video, codificar videos con altas resoluciones mostrara un gran incremento en el desempeño."
+msgid ""
+"If enabled, adds support for row based multithreading which greatly enhances the number of threads the encoder can utilise. This improves encoding speed significantly on systems that are otherwise underutilised when encoding VP9. Since the amount of additional threads depends on the number of \"tiles\", which itself depends on the video resolution, encoding higher resolution videos will see a "
+"larger performance improvement."
+msgstr ""
+"Habilitarla, añade multiproceso por renglón que mejora el numero de hilos que el codificador puede usar. Esto mejora significativamente la velocidad de codificado al codificar en VP9, en sistemas que de otra manera están subutilizados. Ya que la cantidad adicional de hilos  depende del numero de \"cuadros\", lo que depende del la resolución del video, codificar videos con altas resoluciones "
+"mostrara un gran incremento en el desempeño."
 
-#: ../../vdms_utils/presets_manager_utils.py:46
 #, python-brace-format
 msgid "Supports ({0}) formats only, not ({1})"
 msgstr "Formatos soportados ({0}), no soporta ({1})"
 
-#: ../../vdms_utils/presets_manager_utils.py:49
 msgid "File formats not supported by the selected profile"
 msgstr "Formatos de archivo no soportados por el perfil selecciondo"
 
-#: ../../vdms_utils/presets_manager_utils.py:52
 msgid "Warning"
 msgstr "Advertencia"
 
-#: ../../vdms_utils/presets_manager_utils.py:90
 msgid ""
 "No presets found.\n"
 "\n"
@@ -3938,11 +2977,9 @@ msgstr ""
 "\n"
 "Posible solución: abra el panel del Administrador de Presets, ir a la columna presets y presionar el botón \"Restaurar todo...\""
 
-#: ../../vdms_utils/queue_utils.py:54
 msgid "Import queue file"
 msgstr "Importar archivo de lista"
 
-#: ../../vdms_utils/queue_utils.py:89
 #, python-brace-format
 msgid ""
 "ERROR: invalid data found loading queue file.\n"
@@ -3955,11 +2992,9 @@ msgstr ""
 "\n"
 "No puede contener múltiples valores de `destino`."
 
-#: ../../vdms_utils/queue_utils.py:118
 msgid "Videomass - Add Items to Queue"
 msgstr "Videomass - Añadir Entradas a Lista"
 
-#: ../../vdms_utils/queue_utils.py:119
 msgid ""
 "Multiple items with identical names and destination paths cannot coexist.\n"
 "Please choose one of the following actions:"
@@ -3967,15 +3002,12 @@ msgstr ""
 "Múltiples entradas con nombres y destinos idénticos no pueden coexistir.\n"
 "Elija una de las siguientes acciones:"
 
-#: ../../vdms_utils/queue_utils.py:123
 msgid "Replace occurrences with items from the imported queue."
 msgstr "Reemplace ocurrencias con entradas de la lista importada."
 
-#: ../../vdms_utils/queue_utils.py:124
 msgid "Add only the currently missing items to the queue."
 msgstr "Añadir solo entradas faltantes a la lista."
 
-#: ../../vdms_utils/queue_utils.py:125
 msgid "Remove the current queue and replace it with the imported one."
 msgstr "Eliminar lista actual y reemplazar con la importada."
 
@@ -3987,4 +3019,7 @@ msgstr "Eliminar lista actual y reemplazar con la importada."
 
 #~ msgid "Subtitle Mapping"
 #~ msgstr "Mapeo de Subtitulos"
+
+#~ msgid "Shortest"
+#~ msgstr "MiniPrueba"
 

--- a/videomass/data/locale/fr_FR/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/fr_FR/LC_MESSAGES/videomass.po
@@ -1,13 +1,13 @@
-# French translation for Videomass.
-# Copyleft -  2024 Gianluca Pernigotto
-# This file is distributed under the same license as the Videomass package
-# FIRST AUTHOR <philiaug@live.fr>, 2022.
+# French (France) translations for Videomass.
+# Copyright (C) 2025 ORGANIZATION
+# This file is distributed under the same license as the Videomass project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Videomass 5.0.14\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-26 15:04+0200\n"
+"POT-Creation-Date: 2025-07-30 11:02+0200\n"
 "PO-Revision-Date: 2024-08-18 00:59+0200\n"
 "Last-Translator: Phil Aug <philiaug@live.fr>\n"
 "Language: fr_FR\n"
@@ -18,7 +18,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
-#: ../../gui_app.py:196
 #, python-brace-format
 msgid ""
 "Unexpected error while deleting file contents:\n"
@@ -29,162 +28,113 @@ msgstr ""
 "\n"
 "{0}"
 
-#: ../../vdms_dialogs/about_dialog.py:52
 msgid "Cross-platform graphical user interface for FFmpeg\n"
 msgstr ""
 
-#: ../../vdms_dialogs/audioproperties.py:224
 msgid "Videomass supports mono and stereo audio channels. If you are not sure set to \"Auto\" and source values will be copied."
 msgstr "Videomass supporte les canaux mono et stéréo. Si vous n'êtes pas sûr choisissez \"Auto\" et les valeurs d'origine seront dupliquées.."
 
-#: ../../vdms_dialogs/audioproperties.py:228
 msgid "The audio Rate (or sample-rate) is the sound sampling frequency and is measured in Hertz. The higher the frequency, the more true it will be to the sound source and the more the file will increase in size. For audio CD playback, set a sampling frequency of 44100 kHz. If you are not sure, set to \"Auto\" and source values will be copied."
-msgstr "Le débit audio (ou fréquence d'échantillonnage) est la fréquence d'échantillonnage du son, elle est calculée en Hertz.Plus la fréquence est élevée, plus elle se rapproche de la source originale du son et plus le fichier augmente en taille.Pour la lecture de CD audio, définissez une fréquence d'échantillonnage de 44100 kHz.Si vous n'êtes pas sûr, réglez sur \"Auto\" et les valeurs sources seront dupliquées.."
+msgstr ""
+"Le débit audio (ou fréquence d'échantillonnage) est la fréquence d'échantillonnage du son, elle est calculée en Hertz.Plus la fréquence est élevée, plus elle se rapproche de la source originale du son et plus le fichier augmente en taille.Pour la lecture de CD audio, définissez une fréquence d'échantillonnage de 44100 kHz.Si vous n'êtes pas sûr, réglez sur \"Auto\" et les valeurs sources seront"
+" dupliquées.."
 
-#: ../../vdms_dialogs/audioproperties.py:237
 msgid "The audio bitrate affects the file compression and thus the quality of listening. The higher the value, the higher the quality."
 msgstr "Le débit audio (bitrate) affecte la compression du fichier et donc la qualité de l'écoute.Plus la valeur est élevée, meilleure est la qualité."
 
-#: ../../vdms_dialogs/audioproperties.py:241
 msgid "Bit depth is the number of bits of information in each sample, and it directly corresponds to the resolution of each sample. Bit depth is only meaningful in reference to a PCM digital signal. Non-PCM formats, such as lossy compression formats, do not have associated bit depths."
 msgstr "La profondeur du bit est le nombre d'informations inclus dans chaque échantillon, elle correspond directement à la résolution de chaque échantillon.La profondeur du bit est uniquement significative en référence à un signal numérique PCM.Les formats non PCM, tels que les formats de compression avec perte, n'ont pas de profondeur de bits associée."
 
-#: ../../vdms_dialogs/epilogue.py:74 ../../vdms_dialogs/queuedlg.py:120
 msgid "When finished, once the operations have been completed successfully:"
 msgstr "Une fois les opérations terminées et effectuées avec succès :"
 
-#: ../../vdms_dialogs/epilogue.py:80 ../../vdms_dialogs/queuedlg.py:126
 msgid "Trash the source files"
 msgstr "Supprimer les Fichiers sources"
 
-#: ../../vdms_dialogs/epilogue.py:84 ../../vdms_dialogs/queuedlg.py:130
 msgid "Clear the File List"
 msgstr "Effacer la liste des fichiers"
 
-#: ../../vdms_dialogs/epilogue.py:91 ../../vdms_dialogs/queuedlg.py:142
-#: ../../vdms_main/main_frame.py:1322
 msgid "Run"
 msgstr "Lancer"
 
-#: ../../vdms_dialogs/epilogue.py:97
 msgid "Videomass - Batch Mode"
 msgstr "Videomass - Batch Mode"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:47
 msgid "FFmpeg encoders"
 msgstr "Encodeurs FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:48
 msgid "supported encoders"
 msgstr "encodeurs supportés"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:50
 msgid "FFmpeg decoders"
 msgstr "Décodeurs FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:51
 msgid "supported decoders"
 msgstr "décodeurs supportés"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:77
-#: ../../vdms_panels/av_conversions.py:293
 msgid "Video"
 msgstr "Vidéo"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:87
-#: ../../vdms_panels/av_conversions.py:305
 msgid "Audio"
 msgstr "Audio"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:97
 msgid "Subtitle"
 msgstr "Sous-Titres"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:114
-#: ../../vdms_dialogs/ffmpeg_codecs.py:123
-#: ../../vdms_dialogs/ffmpeg_codecs.py:132
-#: ../../vdms_dialogs/ffmpeg_formats.py:112
-#: ../../vdms_dialogs/ffmpeg_formats.py:115
-#: ../../vdms_dialogs/ffmpeg_formats.py:118
 msgid "description"
 msgstr "description"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:72
 msgid "Informations"
 msgstr "Informations"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:83
 msgid "Flags settings"
 msgstr "Réglages des drapeaux"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:93
 msgid "Flags enabled"
 msgstr "Drapeaux activés"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:103
 msgid "Flags disabled"
 msgstr "Drapeaux désactivés"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:116
 msgid "FFmpeg configuration"
 msgstr "Configuration FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:124
 msgid "flags"
 msgstr "drapeaux"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:125 ../../vdms_dialogs/ffmpeg_conf.py:129
-#: ../../vdms_dialogs/ffmpeg_conf.py:133
 msgid "options"
 msgstr "options"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:128 ../../vdms_dialogs/ffmpeg_conf.py:132
 msgid "status"
 msgstr "statut"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:167
 msgid "FFprobe   ...not found !"
 msgstr "FFprobe   ...introuvable!"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:175
 msgid "FFplay   ...not found !"
 msgstr "FFplay   ...introuvable !"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:205
-#: ../../vdms_panels/sequence_to_video.py:706
-#: ../../vdms_panels/video_to_sequence.py:606
 msgid "Enabled"
 msgstr "Activé"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:216
-#: ../../vdms_panels/sequence_to_video.py:706
-#: ../../vdms_panels/video_to_sequence.py:610
 msgid "Disabled"
 msgstr "Désactivé"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:71
 msgid "Demuxing only"
 msgstr "Démultiplexage uniquement"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:82
 msgid "Muxing only"
 msgstr "Multiplexage uniquement"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:93
 msgid "Demuxing/Muxing support"
 msgstr "Prise en charge du Démultiplexage/Multiplexage"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:104
 msgid "FFmpeg file formats"
 msgstr "Formats de fichier FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:111
-#: ../../vdms_dialogs/ffmpeg_formats.py:114
-#: ../../vdms_dialogs/ffmpeg_formats.py:117
 msgid "supported formats"
 msgstr "formats supportés"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:46
 msgid ""
 "Contextual help based on the argument entered in the additional text field.\n"
 "Each argument consists of the type and a type-specific name.\n"
@@ -210,117 +160,84 @@ msgstr ""
 "\n"
 "Exemples:"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:68 ../../vdms_dialogs/ffmpeg_help.py:301
-#: ../../vdms_dialogs/ffmpeg_help.py:315
 msgid "Help topic"
 msgstr "Rubrique Aide"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:69
 msgid "List basic options"
 msgstr "Options de base"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:70
 msgid "List more options"
 msgstr "Plus d'options"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:71
 msgid "List all options (very long)"
 msgstr "Toutes les options (très long)"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:72
 msgid "Show available devices"
 msgstr "Périphériques disponibles"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:73
 msgid "Show available bit stream filters"
 msgstr "Afficher  les filtres  bit stream"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:74
 msgid "Show available protocols"
 msgstr "Afficher les protocoles disponibles"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:75
 msgid "Show available filters"
 msgstr "Afficher les filtres disponibles"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:76
 msgid "Show available pixel formats"
 msgstr "Afficher les formats de pixel disponibles"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:77
 msgid "Show available audio sample formats"
 msgstr "Afficher les formats d'échantillon audio disponibles"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:78
 msgid "Show available color names"
 msgstr "Afficher les noms de couleurs disponibles"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:79
 msgid "List sources of the input device"
 msgstr "Sources du périphérique d'entrée"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:80
 msgid "List sinks of the output device"
 msgstr "Liste les récepteurs du périphérique de sortie"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:81
 msgid "Show available HW acceleration methods"
 msgstr "Afficher les méthodes d'accélération HW disponibles"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:82
 msgid "Show license"
 msgstr "Afficher la licence"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:117 ../../vdms_dialogs/filter_scale.py:76
-#: ../../vdms_dialogs/shownormlist.py:98 ../../vdms_dialogs/shownormlist.py:107
-#: ../../vdms_dialogs/shownormlist.py:116 ../../vdms_miniframes/timeline.py:263
-#: ../../vdms_miniframes/timeline.py:283 ../../vdms_panels/concatenate.py:117
-#: ../../vdms_panels/sequence_to_video.py:117
-#: ../../vdms_panels/video_to_sequence.py:81
 msgid "Read me"
 msgstr "Lisez moi"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:123 ../../vdms_main/main_frame.py:534
 msgid "Show configuration"
 msgstr "Afficher la configuration"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:127 ../../vdms_main/main_frame.py:542
 msgid "Encoders"
 msgstr "Encodeurs"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:131 ../../vdms_main/main_frame.py:545
 msgid "Decoders"
 msgstr "Décodeurs"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:135 ../../vdms_main/main_frame.py:538
 msgid "Muxers and Demuxers"
 msgstr "Multiplexeurs et Démultiplexeurs"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:165
 msgid "help topic list"
 msgstr "liste des rubriques d'aide"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:184
 msgid "Type the argument here and confirm with the enter key on your keyboard"
 msgstr "Taper l'argument ici et confirmer avec Entrée au clavier"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:192
 msgid "The search function allows you to find entries in the current topic"
 msgstr "La fonction de recherche permet de trouver des entrées sur le sujet actuel"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:195
 msgid "Ignore case"
 msgstr "Ignorer la casse"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:196
 msgid "Ignore case distinctions: characters with different case will match."
 msgstr "Ignorer les distinctions; aucune distinction entre les caractères de casse différente ."
 
-#: ../../vdms_dialogs/ffmpeg_help.py:206
 msgid "FFmpeg help topics"
 msgstr "Aide  FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:254
 msgid ""
 "This is a multifunctional search tool useful for local help searches\n"
 "on multiple FFmpeg topics and options. The search control, to\n"
@@ -342,8 +259,6 @@ msgstr ""
 "c'est que votre version FFmpeg est trop ancienne ou mal configurée\n"
 "avec ces mêmes fonctionnalités."
 
-#: ../../vdms_dialogs/ffmpeg_help.py:320 ../../vdms_dialogs/ffmpeg_help.py:345
-#: ../../vdms_dialogs/ffmpeg_help.py:371
 msgid ""
 "\n"
 "  ..Nothing available"
@@ -351,7 +266,6 @@ msgstr ""
 "\n"
 "  ..Non disponible"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:391
 msgid ""
 "\n"
 "  ..Not found"
@@ -359,217 +273,121 @@ msgstr ""
 "\n"
 "  ..Introuvable"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:91
 msgid "Before"
 msgstr "Avant"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:97
 msgid "After"
 msgstr "Après"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:103
-#: ../../vdms_dialogs/filter_crop.py:239
 msgid "Search for a specific frame"
 msgstr "Chercher une trame spécifique"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:117
-#: ../../vdms_dialogs/filter_crop.py:253
 msgid "Load"
 msgstr "Charger"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:120
 msgid "Color EQ"
 msgstr "Couleur EQ"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:126
 msgid "Contrast:"
 msgstr "Contraste:"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:134
-#: ../../vdms_dialogs/filter_colorcorrection.py:148
 msgid "-100 to +100, default value 0"
 msgstr "-100 à +100, par défaut 0"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:139
 msgid "Brightness:"
 msgstr "Brillance:"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:158
 msgid "Saturation:"
 msgstr "Saturation:"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:166
 msgid "0 to 300, default value 100"
 msgstr "0 à 300, par défaut 100"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:170
 msgid "Gamma:"
 msgstr "Gamma:"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:179
 msgid "0 to 100, default value 10"
 msgstr "0 à 100, valeur par défaut 10"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:187
-#: ../../vdms_dialogs/filter_crop.py:306
-#: ../../vdms_dialogs/filter_deinterlace.py:209
-#: ../../vdms_dialogs/filter_denoisers.py:110
-#: ../../vdms_dialogs/filter_scale.py:210 ../../vdms_dialogs/filter_stab.py:316
-#: ../../vdms_dialogs/filter_transpose.py:105
-#: ../../vdms_miniframes/timeline.py:262 ../../vdms_miniframes/timeline.py:281
 msgid "Reset"
 msgstr "Réinitialiser"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:207
 msgid "Color Correction EQ Tool"
 msgstr "Correction Couleur EQ Tool"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:343
-#: ../../vdms_dialogs/filter_colorcorrection.py:383
-#: ../../vdms_dialogs/filter_colorcorrection.py:390
-#: ../../vdms_dialogs/filter_crop.py:417 ../../vdms_dialogs/filter_scale.py:287
-#: ../../vdms_dialogs/filter_scale.py:394 ../../vdms_dialogs/filter_stab.py:473
-#: ../../vdms_dialogs/filter_stab.py:483 ../../vdms_dialogs/filter_stab.py:494
-#: ../../vdms_dialogs/filter_transpose.py:182
-#: ../../vdms_dialogs/mediainfo.py:245 ../../vdms_dialogs/mediainfo.py:265
-#: ../../vdms_dialogs/mediainfo.py:285 ../../vdms_dialogs/mediainfo.py:305
-#: ../../vdms_dialogs/setting_profiles.py:281
-#: ../../vdms_dialogs/setting_profiles.py:289 ../../vdms_io/checkup.py:45
-#: ../../vdms_io/checkup.py:93 ../../vdms_io/io_tools.py:144
-#: ../../vdms_main/main_frame.py:904 ../../vdms_main/main_frame.py:939
-#: ../../vdms_main/main_frame.py:961 ../../vdms_main/main_frame.py:979
-#: ../../vdms_main/main_frame.py:999
-#: ../../vdms_panels/audio_encoders/acodecs.py:510
-#: ../../vdms_panels/audio_encoders/acodecs.py:800
-#: ../../vdms_panels/concatenate.py:186
-#: ../../vdms_panels/long_processing_task.py:60
-#: ../../vdms_panels/presets_manager.py:426
-#: ../../vdms_panels/presets_manager.py:490
-#: ../../vdms_panels/presets_manager.py:560
-#: ../../vdms_panels/presets_manager.py:599
-#: ../../vdms_panels/presets_manager.py:619
-#: ../../vdms_panels/presets_manager.py:657
-#: ../../vdms_panels/presets_manager.py:701
-#: ../../vdms_panels/presets_manager.py:714
-#: ../../vdms_panels/presets_manager.py:721
-#: ../../vdms_panels/presets_manager.py:756
-#: ../../vdms_panels/presets_manager.py:785
-#: ../../vdms_panels/presets_manager.py:791
-#: ../../vdms_panels/sequence_to_video.py:467
-#: ../../vdms_panels/sequence_to_video.py:473
-#: ../../vdms_panels/sequence_to_video.py:561
-#: ../../vdms_panels/sequence_to_video.py:571
-#: ../../vdms_panels/sequence_to_video.py:588
-#: ../../vdms_panels/sequence_to_video.py:596
-#: ../../vdms_panels/sequence_to_video.py:602
-#: ../../vdms_panels/sequence_to_video.py:643
-#: ../../vdms_panels/sequence_to_video.py:689
-#: ../../vdms_panels/video_to_sequence.py:512
-#: ../../vdms_panels/video_to_sequence.py:583
-#: ../../vdms_threads/ffplay_file.py:43
-#: ../../vdms_utils/presets_manager_utils.py:86
-#: ../../vdms_utils/presets_manager_utils.py:95
-#: ../../vdms_utils/queue_utils.py:68 ../../vdms_utils/queue_utils.py:82
-#: ../../vdms_utils/queue_utils.py:95
 msgid "Videomass - Error!"
 msgstr "Videomass - Erreur!"
 
-#: ../../vdms_dialogs/filter_crop.py:228 ../../vdms_dialogs/filter_scale.py:109
 #, python-brace-format
 msgid "Source size: {0} x {1} pixels"
 msgstr "Taille originale: {0} x {1} pixels"
 
-#: ../../vdms_dialogs/filter_crop.py:236
 msgid "Crop color"
 msgstr "Rognage Couleur"
 
-#: ../../vdms_dialogs/filter_crop.py:256
 msgid "Cropping area selection "
 msgstr "Sélection de la zone de rognage "
 
-#: ../../vdms_dialogs/filter_crop.py:261 ../../vdms_dialogs/filter_scale.py:121
 msgid "Height"
 msgstr "Hauteur"
 
-#: ../../vdms_dialogs/filter_crop.py:281
 msgid "Center"
 msgstr "Centre"
 
-#: ../../vdms_dialogs/filter_crop.py:292 ../../vdms_dialogs/filter_scale.py:121
 msgid "Width"
 msgstr "Largeur"
 
-#: ../../vdms_dialogs/filter_crop.py:334
 msgid "Crop Tool"
 msgstr "Outil Rognage"
 
-#: ../../vdms_dialogs/filter_crop.py:335
 msgid "Choose the color to draw the cropping area"
 msgstr "Couleur de la zone de rognage"
 
-#: ../../vdms_dialogs/filter_crop.py:337
 msgid "Crop to width"
 msgstr "Rogner sur la largeur"
 
-#: ../../vdms_dialogs/filter_crop.py:338
 msgid "Move vertically (set to -1 to center the vertical axis)"
 msgstr "Déplacement vertical  (réglé sur -1 pour centrer l'axe vertical)"
 
-#: ../../vdms_dialogs/filter_crop.py:340
 msgid "Move horizontally (set to -1 to center the horizontal axis)"
 msgstr "Déplacement horizontal (réglé sur -1 pour centrer l'axe horizontal)"
 
-#: ../../vdms_dialogs/filter_crop.py:342
 msgid "Crop to height"
 msgstr "Rogner sur la hauteur"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:56
 msgid "Advanced Options"
 msgstr "Options Avancées"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:57
-#: ../../vdms_panels/av_conversions.py:351
 msgid "Deinterlace"
 msgstr "Désentrelacer"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:59
 msgid "Interlace"
 msgstr "Entrelacer"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:63
 msgid "Deinterlaces with w3fdif filter"
 msgstr "Désentrelacer avec le filtre w3fdif"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:77
 msgid "Deinterlaces with yadif filter"
 msgstr "Désentrelacer avec le filtre yadif"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:101
 msgid "Interlaces with interlace filter"
 msgstr "Entrelacer avec filtre entrelacer"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:118
 msgid "Deinterlacing and Interlacing"
 msgstr "Désentrelacement  et entrelacement"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:144
 msgid "Deinterlace the input video with `w3fdif` filter"
 msgstr "Désentrelacer la vidéo d'entrée avec le filtre `w3fdif`"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:146
 msgid "Set the interlacing filter coefficients."
 msgstr "Définir  les coefficients du filtre entrelacement."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:148
-#: ../../vdms_dialogs/filter_deinterlace.py:158
 msgid "Specify which frames to deinterlace."
 msgstr "Spécifier les trames à désentrelacer."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:150
 msgid "Deinterlace the input video with `yadif` filter. Using FFmpeg, this is the best and fastest choice"
 msgstr "Désentrelace la vidéo d'entrée avec le filtre `yadif.FFmpeg constitue le meilleur choix et le plus rapide"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:153
 msgid ""
 "mode\n"
 "The interlacing mode to adopt."
@@ -577,7 +395,6 @@ msgstr ""
 "mode\n"
 "Mode d'entrelacement à adopter."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:155
 msgid ""
 "parity\n"
 "The picture field parity assumed for the input interlaced video."
@@ -585,11 +402,9 @@ msgstr ""
 "parité\n"
 "Parité de champ d'image supposée pour la vidéo entrelacée en entrée."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:160
 msgid "Simple interlacing filter from progressive contents."
 msgstr "Filtre simple d'entrelacement à partir d'un contenu progressif."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:162
 msgid ""
 "scan:\n"
 "determines whether the interlaced frame is taken from the even (tff - default) or odd (bff) lines of the progressive frame."
@@ -597,7 +412,6 @@ msgstr ""
 "scan:\n"
 "Détermine si la trame entrelacée est prélevée sur les lignes paires (tff - par défaut) ou impaires (BFF) de la trame progressive."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:166
 msgid ""
 "lowpass:\n"
 "Enable (default) or disable the vertical lowpass filter to avoid twitter interlacing and reduce moire patterns.\n"
@@ -607,31 +421,24 @@ msgstr ""
 "Active (défaut) ou désactive le filtre vertical de passe basse pour éviter un entrelacement twitter et réduire les motifs de moirage.\n"
 "Pas de réglage par défaut."
 
-#: ../../vdms_dialogs/filter_denoisers.py:56
 msgid "Denoiser Filters"
 msgstr "Filtres  Débruitage"
 
-#: ../../vdms_dialogs/filter_denoisers.py:60
 msgid "Enable nlmeans denoiser"
 msgstr "Active le débruitage nlmeans"
 
-#: ../../vdms_dialogs/filter_denoisers.py:73
 msgid "nlmeans options"
 msgstr "options nlmeans"
 
-#: ../../vdms_dialogs/filter_denoisers.py:82
 msgid "Enable hqdn3d denoiser"
 msgstr "Activer le débruitage hqdn3d"
 
-#: ../../vdms_dialogs/filter_denoisers.py:91
 msgid "hqdn3d options"
 msgstr "options hqdn3d"
 
-#: ../../vdms_dialogs/filter_denoisers.py:116
 msgid "Denoiser Tool"
 msgstr "Outil Débruitage"
 
-#: ../../vdms_dialogs/filter_denoisers.py:117
 msgid ""
 "nlmeans:\n"
 "Denoise frames using Non-Local Means algorithm is capable of restoring video sequences, even with strong noise. It is ideal for enhancing the quality of old VHS tapes."
@@ -639,7 +446,6 @@ msgstr ""
 "nlmeans:\n"
 "Les trames de débruitage utilisant l'algorithme Non-Local-Means sont capables de restaurer des séquences vidéo, même avec un bruit fort.C'est idéal pour améliorer la qualité d'anciennes bandes VHS."
 
-#: ../../vdms_dialogs/filter_denoisers.py:122
 msgid ""
 "hqdn3d:\n"
 "This is a high precision/quality 3d denoise filter. It aims to reduce image noise, producing smooth images and making still images really still. It should enhance compressibility."
@@ -647,65 +453,48 @@ msgstr ""
 "hqdn3d:\n"
 "Est un filtre de débruitage 3D de haute précision / qualité.Il vise à réduire le bruit de l'image, à produire des images plus lissées et à rendre  réellement les images fixes .Il  améliore  potentiellement la compressibilité."
 
-#: ../../vdms_dialogs/filter_scale.py:81
 msgid "View result"
 msgstr "Afficher le résultat"
 
-#: ../../vdms_dialogs/filter_scale.py:85
 msgid "New size in pixels"
 msgstr "Nouvelle taille en pixels"
 
-#: ../../vdms_dialogs/filter_scale.py:89
 msgid "Width:"
 msgstr "Largeur:"
 
-#: ../../vdms_dialogs/filter_scale.py:99
 msgid "Height:"
 msgstr "Hauteur:"
 
-#: ../../vdms_dialogs/filter_scale.py:115
 msgid "Constrain proportions (keep aspect ratio)"
 msgstr "Conserver les proportions (conserve le même rapport de proportions)"
 
-#: ../../vdms_dialogs/filter_scale.py:120
 msgid "Which dimension to adjust?"
 msgstr "Quelle dimension voulez-vous modifier?"
 
-#: ../../vdms_dialogs/filter_scale.py:129
 msgid "Aspect Ratio"
 msgstr "Rapport de Proportions"
 
-#: ../../vdms_dialogs/filter_scale.py:132
 msgid "Setdar filter (display aspect ratio) example 16/9, 4/3 "
 msgstr "Filtre Setdar (affiche les proportions) 16/9, 4/3 "
 
-#: ../../vdms_dialogs/filter_scale.py:137
-#: ../../vdms_dialogs/filter_scale.py:171
 msgid "Numerator"
 msgstr "Numérateur"
 
-#: ../../vdms_dialogs/filter_scale.py:162
-#: ../../vdms_dialogs/filter_scale.py:196
 msgid "Denominator"
 msgstr "Dénominateur"
 
-#: ../../vdms_dialogs/filter_scale.py:166
 msgid "Setsar filter (sample aspect ratio) example 1/1"
 msgstr "Fltre Setsar (rapport d'aspect normal) exemple 1/1"
 
-#: ../../vdms_dialogs/filter_scale.py:217
 msgid "Resize Tool"
 msgstr "Outil Redimensionnement"
 
-#: ../../vdms_dialogs/filter_scale.py:218
 msgid "Scale filter, set to 0 to disable"
 msgstr "Filtre mise à l'échelle, mettre sur 0 pour désactiver"
 
-#: ../../vdms_dialogs/filter_scale.py:221
 msgid "Display Aspect Ratio. Set to 0 to disable"
 msgstr "Affiche le rapport hauteur/largeur. Mettre sur 0 pour désactiver"
 
-#: ../../vdms_dialogs/filter_scale.py:224
 msgid ""
 "Sample (aka Pixel) Aspect Ratio.\n"
 "Set to 0 to disable"
@@ -713,7 +502,6 @@ msgstr ""
 "Sample (aka Pixel) Aspect Proportionnel.\n"
 "Mettre sur 0 pour désactiver"
 
-#: ../../vdms_dialogs/filter_scale.py:366
 msgid ""
 "If you want to keep the aspect ratio, select \"Constrain proportions\" below and\n"
 "specify only one dimension, either width or height, and set the other dimension\n"
@@ -723,156 +511,123 @@ msgstr ""
 "spécifiez une seule dimension, largeur ou hauteur, puis définir l'autre dimension\n"
 "à -1 ou -2 (certains codecs nécessitent -2, faire des tests au préalable)."
 
-#: ../../vdms_dialogs/filter_stab.py:81
 msgid "Enable stabilizer"
 msgstr "Activer le stabilisateur"
 
-#: ../../vdms_dialogs/filter_stab.py:83
 msgid "Create a side-by-side comparison video"
 msgstr "Comparer côte-à-côte les vidéos"
 
-#: ../../vdms_dialogs/filter_stab.py:88
 msgid "Create a snapshot"
 msgstr "Créer un  snapshot"
 
-#: ../../vdms_dialogs/filter_stab.py:106
-#: ../../vdms_panels/audio_encoders/acodecs.py:167
 msgid "Preview"
 msgstr "Aperçu"
 
-#: ../../vdms_dialogs/filter_stab.py:109
 msgid "Duration seconds:"
 msgstr "Durée en secondes:"
 
-#: ../../vdms_dialogs/filter_stab.py:118
 msgid "Video Detect"
 msgstr "Détection Vidéo"
 
-#: ../../vdms_dialogs/filter_stab.py:176
 msgid "[TRIPOD] Enable tripod mode if checked"
 msgstr "[TRÉPIED] Active le mode trépied si coché"
 
-#: ../../vdms_dialogs/filter_stab.py:183
 msgid "Video transform"
 msgstr "Transformation Video"
 
-#: ../../vdms_dialogs/filter_stab.py:202
 msgid "[OPTALGO] optimization algorithm"
 msgstr "[OPTALGO] algorithme d'optimisation"
 
-#: ../../vdms_dialogs/filter_stab.py:224
 msgid "[CROP] Specify how to deal with borders at movement compensation"
 msgstr "[ROGNAGE]  Spécifie comment gérer les bordures lors de la compensation de mouvement"
 
-#: ../../vdms_dialogs/filter_stab.py:231
 msgid "[INVERT] Invert transforms if checked"
 msgstr "[INVERSE]  transforme en inversé si coché"
 
-#: ../../vdms_dialogs/filter_stab.py:234
 msgid "[RELATIVE] Consider transforms as relative to previous frame if checked, absolute if unchecked"
 msgstr "[RELATIF] Considère les transformations comme relatives par rapport à la trame précédente si coché, absolues si décoché"
 
-#: ../../vdms_dialogs/filter_stab.py:279
 msgid "Specify type of interpolation"
 msgstr "Définir le type d'interpolation"
 
-#: ../../vdms_dialogs/filter_stab.py:287
 msgid "[TRIPOD2] virtual tripod mode, equivalent to relative=unchecked:smoothing=0"
 msgstr "[TRÉPIED] Mode de trépied virtuel, équivalent à relatif = lissage:désactivé = 0"
 
-#: ../../vdms_dialogs/filter_stab.py:294
 msgid "Unsharp filter:"
 msgstr "Filtre Adoucir:"
 
-#: ../../vdms_dialogs/filter_stab.py:323
 msgid "Seek to a position on the video."
 msgstr "Cherchez une position sur la vidéo."
 
-#: ../../vdms_dialogs/filter_stab.py:325
 msgid "Make a snapshot of the video with the settings made."
 msgstr "Faites un snapshot de la vidéo avec les paramètres définis."
 
-#: ../../vdms_dialogs/filter_stab.py:327
 msgid "Set the snapshot duration from 3 to 15 seconds from the seek position, default is 5 seconds."
 msgstr "Définir la durée du snapshot de 3 à 15 secondes à partir de la position de recherche, la durée par défaut est de 5 secondes."
 
-#: ../../vdms_dialogs/filter_stab.py:331
 msgid "Set how shaky the video is and how quick the camera is. A value of 1 means little shakiness, a value of 10 means strong shakiness. Default value is 5."
 msgstr "Evalue à quel point la vidéo est tremblante et la vitesse de la caméra .Une valeur de 1 signifie peu de tremblement, une valeur de 10 signifie un fort tremblement.La valeur par défaut est 5."
 
-#: ../../vdms_dialogs/filter_stab.py:335
 msgid "Set the accuracy of the detection process. A value of 1 means low accuracy, a value of 15 means high accuracy. Default value is 15."
 msgstr "Définit la précision du processus de détection.Une valeur de 1 signifie une faible précision, une valeur de 15 signifie une précision élevée.La valeur par défaut est 15."
 
-#: ../../vdms_dialogs/filter_stab.py:339
 msgid "Set stepsize of the search process. The region around minimum is scanned with 1 pixel resolution. Default value is 6."
 msgstr "Définit la valeur du processus de recherche.La zone autour du minimum est scannée avec une résolution de 1 pixel.La valeur par défaut est 6."
 
-#: ../../vdms_dialogs/filter_stab.py:343
 msgid "Set minimum contrast. Below this value a local measurement field is discarded. The range is 0-1. Default value is 0.25."
 msgstr "Définit le contraste minimum.En dessous de cette valeur, un champ de mesure local est écarté.La plage est de 0-1.La valeur par défaut est de 0,25."
 
-#: ../../vdms_dialogs/filter_stab.py:346
 msgid "Set reference frame number for tripod mode. If enabled, the motion of the frames is compared to a reference frame in the filtered stream, identified by the specified number. The idea is to compensate all movements in a more-or-less static scene and keep the camera view absolutely still. The frames are counted starting from 1."
 msgstr "Définit un nombre de trames de référence pour le mode trépied.Si activé, le mouvement des trames est comparé à une trame de référence dans le flux filtré, identifié par le numéro spécifié.L'idée est de compenser tous les mouvements par rapport à une scène plus ou moins statique et de reproduire l'immobilité de la caméra . Les trames sont comptées à partir de 1."
 
-#: ../../vdms_dialogs/filter_stab.py:355
-msgid "Set the number of frames (value*2 + 1) used for lowpass filtering the camera movements. Default value is 15. For example a number of 10 means that 21 frames are used (10 in the past and 10 in the future) to smoothen the motion in the video. A larger value leads to a smoother video, but limits the acceleration of the camera (pan/tilt movements). 0 is a special case where a static camera is simulated."
-msgstr "Définit  le nombre de trames (valeur * 2 + 1) utilisé pour un filtrage en lowpass des mouvements de la caméra.La valeur par défaut est de 15. Par exemple, un nombre de 10 signifie que 21 images seront utilisées (10 avant et 10 après) pour fluidifier le mouvement de la vidéo.Une valeur plus grande rend la vidéo plus fluide, mais limite l'accélération de la caméra (mouvements Pan / Tilt).0 est un cas particulier où une caméra statique est simulée."
+msgid ""
+"Set the number of frames (value*2 + 1) used for lowpass filtering the camera movements. Default value is 15. For example a number of 10 means that 21 frames are used (10 in the past and 10 in the future) to smoothen the motion in the video. A larger value leads to a smoother video, but limits the acceleration of the camera (pan/tilt movements). 0 is a special case where a static camera is "
+"simulated."
+msgstr ""
+"Définit  le nombre de trames (valeur * 2 + 1) utilisé pour un filtrage en lowpass des mouvements de la caméra.La valeur par défaut est de 15. Par exemple, un nombre de 10 signifie que 21 images seront utilisées (10 avant et 10 après) pour fluidifier le mouvement de la vidéo.Une valeur plus grande rend la vidéo plus fluide, mais limite l'accélération de la caméra (mouvements Pan / Tilt).0 est un"
+" cas particulier où une caméra statique est simulée."
 
-#: ../../vdms_dialogs/filter_stab.py:363
 msgid "Set the camera path optimization algorithm. Values are: `gauss`: gaussian kernel low-pass filter on camera motion (default), and `avg`: averaging on transformations"
 msgstr "Définit l'algorithme d'optimisation du chemin de la caméra.Les valeurs sont: filtre «gauss»: gaussian kernel low-pass pour le mouvement de la caméra (par défaut) et `avg»: valeurs moyennes des transformations"
 
-#: ../../vdms_dialogs/filter_stab.py:367
 msgid "Set maximal angle in radians (degree*PI/180) to rotate frames. Default value is -1, meaning no limit."
 msgstr "Règle l'angle de rayon maximal (degré * PI / 180) pour faire pivoter les trames.La valeur par défaut est -1, ce qui signifie aucune limite."
 
-#: ../../vdms_dialogs/filter_stab.py:370
 msgid "Specify how to deal with borders that may be visible due to movement compensation. Values are: `keep` keep image information from previous frame (default), `black` fill the border black"
 msgstr "Spécifie comment gérer les bordures qui peuvent être visibles en raison de la compensation de mouvement.Les valeurs sont: `conserver 'conserver les informations de l'image du cadre précédent (par défaut),` Noir' remplit la bordure de couleur noire"
 
-#: ../../vdms_dialogs/filter_stab.py:375
 msgid "Invert transforms if checked. Default is unchecked."
 msgstr "Inverse les changements si coché.Valeur désactivée par défaut ."
 
-#: ../../vdms_dialogs/filter_stab.py:377
 msgid "Consider transforms as relative to previous frame if checked, absolute if unchecked. Default is checked."
 msgstr "Considère les changements comme relatifs par rapport à la trame précédente si activé, absolu si désactivé. Cette option est activée par défaut."
 
-#: ../../vdms_dialogs/filter_stab.py:380
 msgid "Set percentage to zoom. A positive value will result in a zoom-in effect, a negative value in a zoom-out effect. Default value is 0 (no zoom)."
 msgstr "Définit le pourcentage du zoom.Une valeur positive se traduit par un effet de zoom avant, une valeur négative par un effet de zoom arrière.La valeur par défaut est 0 (pas de zoom)."
 
-#: ../../vdms_dialogs/filter_stab.py:384
 msgid "Set optimal zooming to avoid borders. Accepted values are: `0` disabled, `1` optimal static zoom value is determined (only very strong movements will lead to visible borders) (default), `2` optimal adaptive zoom value is determined (no borders will be visible), see zoomspeed. Note that the value given at zoom is added to the one calculated here."
-msgstr "Définit une valeur de zoom optimale pour éviter l'ajout de bordures noires. Les valeurs acceptées sont: \"0\" désactivé, la valeur de zoom statique optimale \"1\" est déterminée (seuls des mouvements très forts produiront des bordures visibles) (valeur par défaut), '2' valeur de zoom adaptative optimale déterminée (aucune bordure visible),voir zoomspeed. Notez que la valeur donnée au zoom est ici ajoutée à celle calculée ici."
+msgstr ""
+"Définit une valeur de zoom optimale pour éviter l'ajout de bordures noires. Les valeurs acceptées sont: \"0\" désactivé, la valeur de zoom statique optimale \"1\" est déterminée (seuls des mouvements très forts produiront des bordures visibles) (valeur par défaut), '2' valeur de zoom adaptative optimale déterminée (aucune bordure visible),voir zoomspeed. Notez que la valeur donnée au zoom est "
+"ici ajoutée à celle calculée ici."
 
-#: ../../vdms_dialogs/filter_stab.py:391
 msgid "Set percent to zoom maximally each frame (enabled when optzoom is set to 2). Range is from 0 to 5, default value is 0.25."
 msgstr "Définit le pourcentage maximal pour zoomer chaque trame (activé lorsque optzoom est réglé sur 2).La plage est de 0 à 5, la valeur par défaut est de 0,25."
 
-#: ../../vdms_dialogs/filter_stab.py:395
 msgid "Specify type of interpolation. Available values are: `no` no interpolation, `linear` linear only horizontal, `bilinear` linear in both directions (default), `bicubic` cubic in both directions (slow)"
 msgstr "Spécifie le type d'interpolation.Les valeurs disponibles sont: «no» pas d'Interpolation, «linear» linéaire horizontal uniquement , «bilinear» linéaire dans les deux directions (par défaut), «bicubique» cubique dans les deux directions (lent)"
 
-#: ../../vdms_dialogs/filter_stab.py:400
 msgid "Enable virtual tripod mode if checked, which is equivalent to relative=0:smoothing=0. Default is unchecked. Use also tripod option of vidstabdetect."
 msgstr "Activez le mode trépied virtuel si coché,, équivalent à relatif = 0: lissage = 0. La valeur par défaut est désactivée .Utilisez également l'option trépied de vidstabdetect."
 
-#: ../../vdms_dialogs/filter_stab.py:405
 msgid "Sharpen or blur the input video. Note the use of the unsharp filter which is always recommended."
 msgstr "Améliore la netteté ou estompe la vidéo en entrée.L'utilisation du filtre \"unsharp\" (adoucir) est toujours recommandée."
 
-#: ../../vdms_dialogs/filter_stab.py:409
 msgid "Video Stabilizer Tool"
 msgstr "Outil Stabilisation Vidéo"
 
-#: ../../vdms_dialogs/filter_stab.py:541 ../../vdms_io/io_tools.py:73
 msgid "Videomass - Loading..."
 msgstr "Videomass - En cours de chargement..."
 
-#: ../../vdms_dialogs/filter_stab.py:542
 msgid ""
 "Please wait,\n"
 "This process will take a few seconds."
@@ -880,135 +635,96 @@ msgstr ""
 "Patientez svp,\n"
 "Ce processus ne prend que quelques secondes."
 
-#: ../../vdms_dialogs/filter_transpose.py:80
-#: ../../vdms_dialogs/filter_transpose.py:293
 msgid "Default position"
 msgstr "Position par défaut"
 
-#: ../../vdms_dialogs/filter_transpose.py:86
 msgid "Rotation setting"
 msgstr "Réglage rotation"
 
-#: ../../vdms_dialogs/filter_transpose.py:94
 msgid "90° (left)"
 msgstr "90° (gauche)"
 
-#: ../../vdms_dialogs/filter_transpose.py:96
 msgid "90° (right)"
 msgstr "90° (droite)"
 
-#: ../../vdms_dialogs/filter_transpose.py:100
 msgid "180°"
 msgstr "180°"
 
-#: ../../vdms_dialogs/filter_transpose.py:115
 msgid "Transpose Tool"
 msgstr "Outil Transposition"
 
-#: ../../vdms_dialogs/filter_transpose.py:229
 msgid "Rotate 90 degrees right"
 msgstr "Rotation horaire 90 degrés"
 
-#: ../../vdms_dialogs/filter_transpose.py:251
 msgid "Rotate 180 degrees"
 msgstr "Rotation 180 degrés"
 
-#: ../../vdms_dialogs/filter_transpose.py:272
 msgid "Rotate 90 degrees left"
 msgstr "Rotation 90 degrés anti-horaire"
 
-#: ../../vdms_dialogs/mediainfo.py:82
 msgid "Format"
 msgstr "Format"
 
-#: ../../vdms_dialogs/mediainfo.py:96
 msgid "Video Stream"
 msgstr "Stream Vidéo"
 
-#: ../../vdms_dialogs/mediainfo.py:109
 msgid "Audio Streams"
 msgstr "Streams Audio"
 
-#: ../../vdms_dialogs/mediainfo.py:122
 msgid "Subtitle Streams"
 msgstr "Streams Sous-Titres"
 
-#: ../../vdms_dialogs/mediainfo.py:126
 msgid "Copy to clipboard"
 msgstr "Cpier dans le presse-papier"
 
-#: ../../vdms_dialogs/mediainfo.py:137
 msgid "FILE SELECTION"
 msgstr "SELECTION FICHIER"
 
-#: ../../vdms_dialogs/mediainfo.py:139 ../../vdms_dialogs/mediainfo.py:142
-#: ../../vdms_dialogs/mediainfo.py:145 ../../vdms_dialogs/mediainfo.py:148
-#: ../../vdms_main/main_frame.py:1318
 msgid "Properties"
 msgstr "Propriétés"
 
-#: ../../vdms_dialogs/mediainfo.py:140 ../../vdms_dialogs/mediainfo.py:143
-#: ../../vdms_dialogs/mediainfo.py:146 ../../vdms_dialogs/mediainfo.py:149
 msgid "Values"
 msgstr "Valeurs"
 
-#: ../../vdms_dialogs/mediainfo.py:152
 msgid "Streams Properties"
 msgstr "Propriétés du Stream"
 
-#: ../../vdms_dialogs/mediainfo.py:244
 msgid "Unable to open the clipboard on Format tab"
 msgstr "Impossible d'ouvrir le Presse-papiers sous l'onglet Format"
 
-#: ../../vdms_dialogs/mediainfo.py:263
 msgid "Unable to open the clipboard on Video Streams tab"
 msgstr "Impossible d'ouvrir le presse-papiers sous l'onglet Flux vidéo"
 
-#: ../../vdms_dialogs/mediainfo.py:283
 msgid "Unable to open the clipboard on Audio Streams tab"
 msgstr "Impossible d'ouvrir le presse-papiers dans l'onglet Flux audio"
 
-#: ../../vdms_dialogs/mediainfo.py:303
 msgid "Unable to open the clipboard on Subtitle Streams tab"
 msgstr "Impossible d'ouvrir le presse-papiers sous l'onglet Flux de sous-titres"
 
-#: ../../vdms_dialogs/preferences.py:90
 msgid "Where do you prefer to save your transcodes?"
 msgstr "Où souhaitez-vous enregistrer les fichiers transcodés ?"
 
-#: ../../vdms_dialogs/preferences.py:101 ../../vdms_dialogs/preferences.py:128
-#: ../../vdms_dialogs/preferences.py:149 ../../vdms_dialogs/preferences.py:161
-#: ../../vdms_dialogs/preferences.py:173 ../../vdms_panels/filedrop.py:284
 msgid "Change"
 msgstr "Changer"
 
-#: ../../vdms_dialogs/preferences.py:103
-#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:602
-#: ../../vdms_panels/presets_manager.py:1050
 msgid "Same destination paths as source files"
 msgstr "Même destination que les fichiers source"
 
-#: ../../vdms_dialogs/preferences.py:108
 msgid "Assign optional suffix to destination file names:"
 msgstr "Attribuer un suffixe facultatif aux  fichiers de sortie:"
 
-#: ../../vdms_dialogs/preferences.py:114
 msgid "File removal preferences"
 msgstr "Préférences de suppression de fichier"
 
-#: ../../vdms_dialogs/preferences.py:118
 msgid "Trash the source files after successful encoding"
 msgstr "Supprimer les fichiers sources après un encodage réussi"
 
-#: ../../vdms_dialogs/preferences.py:131
 msgid "File Preferences"
 msgstr "Préférences Fichier"
 
-#: ../../vdms_dialogs/preferences.py:138
 msgid "Location of executables"
 msgstr "Localisation des exécutables"
 
-#: ../../vdms_dialogs/preferences.py:140
 msgid ""
 "FFmpeg can be built by enabling/disabling its options and this depends on your needs.\n"
 "For some use cases it is possible to provide a custom build of FFmpeg where you can specify\n"
@@ -1018,107 +734,81 @@ msgstr ""
 "Dans certains cas , il est possible de fournir une version personnalisée de FFmpeg por laquelle vous pouvez le spécifier \n"
 "dans cet onglet Préférences."
 
-#: ../../vdms_dialogs/preferences.py:147
 msgid "Enable a custom location to run FFmpeg"
 msgstr "Définir un chemin spécifique pour utiliser FFmpeg"
 
-#: ../../vdms_dialogs/preferences.py:159
 msgid "Enable a custom location to run FFprobe"
 msgstr "Définir un chemin spécifique pour utiliser FFprobe"
 
-#: ../../vdms_dialogs/preferences.py:171
 msgid "Enable a custom location to run FFplay"
 msgstr "Définir un chemin spécifique pour utiliser FFplay"
 
-#: ../../vdms_dialogs/preferences.py:183
 msgid "FFmpeg"
 msgstr "FFmpeg"
 
-#: ../../vdms_dialogs/preferences.py:189
 msgid "Look and Feel (requires application restart)"
 msgstr "Apparence générale (nécessite le redémarrage de l'application)"
 
-#: ../../vdms_dialogs/preferences.py:194
 msgid "Icon themes"
 msgstr "Thème d'icônes"
 
-#: ../../vdms_dialogs/preferences.py:208
 msgid "At the top of window (default)"
 msgstr "En haut de la fenêtre (par défaut)"
 
-#: ../../vdms_dialogs/preferences.py:209
 msgid "At the bottom of window"
 msgstr "En bas de la fenêtre"
 
-#: ../../vdms_dialogs/preferences.py:210
 msgid "At the right of window"
 msgstr "À droite de la fenêtre"
 
-#: ../../vdms_dialogs/preferences.py:211
 msgid "At the left of window"
 msgstr "À gauche de la fenêtre"
 
-#: ../../vdms_dialogs/preferences.py:213
 msgid "Place the toolbar"
 msgstr "Position de la barre d'outils"
 
-#: ../../vdms_dialogs/preferences.py:222
 msgid "Toolbar's icons size:"
 msgstr "Taille des icones de la barre d'outils:"
 
-#: ../../vdms_dialogs/preferences.py:236
 msgid "Application Language (requires application restart)"
 msgstr "Langue de l'application (Redémarrage requis)"
 
-#: ../../vdms_dialogs/preferences.py:248
 msgid "Look and Language"
 msgstr "Apparence et Langue"
 
-#: ../../vdms_dialogs/preferences.py:254
 msgid "Upon exiting the application"
 msgstr "Sur le point de quitter  l'application"
 
-#: ../../vdms_dialogs/preferences.py:259
 msgid "Always ask me to confirm"
 msgstr "Me demander toujours confirmation"
 
-#: ../../vdms_dialogs/preferences.py:261
 msgid "Clean the log files"
 msgstr "Effacer les fichiers log"
 
-#: ../../vdms_dialogs/preferences.py:264
 msgid "Remove cached files"
 msgstr "Supprimer les fichiers mis en cache"
 
-#: ../../vdms_dialogs/preferences.py:268
 msgid "On operations completion"
 msgstr "Achèvement des opérations"
 
-#: ../../vdms_dialogs/preferences.py:271
 msgid "These settings will remain active until the application is closed, If necessary, remember to reactivate them."
 msgstr "Ces paramètres resteront actifs jusqu'à ce que l'application soit quittée, pensez à les réactiver si nécessaire."
 
-#: ../../vdms_dialogs/preferences.py:276
 msgid "Exit the application"
 msgstr "Quitter l'application"
 
-#: ../../vdms_dialogs/preferences.py:279
 msgid "Shutdown the system"
 msgstr "Arrêter le système"
 
-#: ../../vdms_dialogs/preferences.py:283
 msgid "SUDO password:"
 msgstr "SUDO password:"
 
-#: ../../vdms_dialogs/preferences.py:292
 msgid "Exit and Shutdown"
 msgstr "Quitter et Eteindre"
 
-#: ../../vdms_dialogs/preferences.py:298
 msgid "Specify the character encoding format"
 msgstr "Spécifier le format de codage des caractères"
 
-#: ../../vdms_dialogs/preferences.py:301
 msgid ""
 "Although UTF-8 is the default and most widely used standard encoding format, it is not the only encoding format available.\n"
 "Some file metadata may still contain non-UTF-8 character encodings resulting in the error \"'utf-8' codec can't decode bytes...\".\n"
@@ -1128,31 +818,24 @@ msgstr ""
 "Certaines métadonnées de fichier peuvent encore contenir des encodages de caractères non UTF-8, ce qui entraîne l'erreur « 'UTF-8' codec ne peut pas décoder les octets... ». \n"
 "Si vous connaissez le format de codage dans lequel le fichier a été écrit, vous pouvez essayer de le spécifier ici, e.g. ISO 8859-1, ISO 8859-16, etc."
 
-#: ../../vdms_dialogs/preferences.py:311
 msgid "Character encoding:"
 msgstr "Codage Caractères:"
 
-#: ../../vdms_dialogs/preferences.py:320
 msgid "Default application directories"
 msgstr "Répertoires par défaut"
 
-#: ../../vdms_dialogs/preferences.py:324
 msgid "Configuration directory"
 msgstr "Dossier configuration"
 
-#: ../../vdms_dialogs/preferences.py:337
 msgid "Cache directory"
 msgstr "Dossier cache"
 
-#: ../../vdms_dialogs/preferences.py:349
 msgid "Log directory"
 msgstr "Dossier log"
 
-#: ../../vdms_dialogs/preferences.py:363
 msgid "Advanced"
 msgstr "Options Avancées"
 
-#: ../../vdms_dialogs/preferences.py:369
 msgid ""
 "The following settings affect output messages and the log messages during transcoding processes.\n"
 "Be careful, by changing these settings some functions of the application may not work correctly,\n"
@@ -1162,121 +845,73 @@ msgstr ""
 "Attention, en modifiant ces paramètres certaines fonctions de l'application risquent de ne pas fonctionner correctement, \n"
 "ne changez que si vous savez ce que vous faites.\n"
 
-#: ../../vdms_dialogs/preferences.py:376
 msgid "Set logging level flags used by FFmpeg"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:383
 msgid "Set logging level flags used by FFplay"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:391
 msgid "FFmpeg logging levels"
 msgstr "Niveaux de journalisation FFmpeg"
 
-#: ../../vdms_dialogs/preferences.py:437
 msgid "By assigning an additional suffix you could avoid overwriting files"
 msgstr "En attribuant un suffixe additionnel, vous  éviterez d'écraser vos fichiers"
 
-#: ../../vdms_dialogs/preferences.py:440
 msgid "Type sudo password here, only for Unix-like operating systems, not for MS Windows"
 msgstr "Tapez sudo password ici, uniquement pour les systèmes d'exploitation de type Unix, pas pour MS Windows"
 
-#: ../../vdms_dialogs/preferences.py:443
 msgid "Preferences"
 msgstr "Préférences"
 
-#: ../../vdms_dialogs/preferences.py:596 ../../vdms_dialogs/preferences.py:676
-#: ../../vdms_main/main_frame.py:879 ../../vdms_main/main_frame.py:1060
 msgid "Choose Destination"
 msgstr "Choisir la destination"
 
-#: ../../vdms_dialogs/preferences.py:627
 msgid "Enter only alphanumeric characters. You can also use the hyphen (\"-\") and the underscore (\"_\"). Spaces are not allowed."
 msgstr "Nentrez que des caractères alphanumériques.Vous pouvez également utiliser le trait d'union (\"-\") et le trait de soulignement (\"_\").Les espaces ne sont pas autorisés."
 
-#: ../../vdms_dialogs/preferences.py:642
-#: ../../vdms_dialogs/setting_profiles.py:257
-#: ../../vdms_dialogs/setting_profiles.py:264
-#: ../../vdms_dialogs/setting_profiles.py:286
-#: ../../vdms_dialogs/setting_profiles.py:309 ../../vdms_main/main_frame.py:399
-#: ../../vdms_main/main_frame.py:421 ../../vdms_panels/av_conversions.py:605
-#: ../../vdms_panels/av_conversions.py:612
-#: ../../vdms_panels/sequence_to_video.py:352
-#: ../../vdms_panels/video_to_sequence.py:399
 msgid "Videomass - Warning!"
 msgstr "Videomass - Avertissement !"
 
-#: ../../vdms_dialogs/preferences.py:731 ../../vdms_dialogs/preferences.py:771
-#: ../../vdms_dialogs/preferences.py:811 ../../vdms_dialogs/wizard_dlg.py:365
-#: ../../vdms_dialogs/wizard_dlg.py:384 ../../vdms_dialogs/wizard_dlg.py:403
 #, python-brace-format
 msgid "{} location"
 msgstr "{} emplacement"
 
-#: ../../vdms_dialogs/queue_edit.py:36
-#: ../../vdms_dialogs/setting_profiles.py:38
 msgid "One-Pass, Do not start with `ffmpeg -i filename`; do not end with `output-filename`"
 msgstr "Passe Unique, Ne pas commencer par `ffmpeg -i filename`;ne pas terminer avec `output-filename`"
 
-#: ../../vdms_dialogs/queue_edit.py:40
-#: ../../vdms_dialogs/setting_profiles.py:42
 msgid "Two-Pass (optional), Do not start with `ffmpeg -i filename`; do not end with `output-filename`"
 msgstr "Deux Passes (facultatif), ne pas commencer par `ffmpeg -i filename`;ne pas terminer avec `output-filename`"
 
-#: ../../vdms_dialogs/queue_edit.py:59
 msgid "Videomass - Edit the selected item in the queue"
 msgstr "Videomass - Modifiez l'élément sélectionné dans la file d'attente"
 
-#: ../../vdms_dialogs/queue_edit.py:71
-#: ../../vdms_dialogs/setting_profiles.py:92
 msgid "Pre-input arguments for One-Pass (optional)"
 msgstr "Arguments de pré-saisie pour encodage Une Passe (facultatif)"
 
-#: ../../vdms_dialogs/queue_edit.py:82
-#: ../../vdms_dialogs/setting_profiles.py:151
-#: ../../vdms_panels/presets_manager.py:255
 msgid "FFmpeg arguments for one-pass encoding"
 msgstr "Arguments FFmpeg pour encodage une passe"
 
-#: ../../vdms_dialogs/queue_edit.py:88
-#: ../../vdms_dialogs/setting_profiles.py:158
-#: ../../vdms_panels/presets_manager.py:259
 msgid "Any optional arguments to add before input file on the one-pass encoding, e.g required names of some hardware accelerations like -hwaccel to use with CUDA."
 msgstr "Tout argument facultatif à ajouter avant le fichier d'entrée sur l'encodage en une passe, par exemple les noms requis de certaines accélérations matérielles comme -hwaccel à utiliser avec CUDA."
 
-#: ../../vdms_dialogs/queue_edit.py:102
-#: ../../vdms_dialogs/setting_profiles.py:98
 msgid "Pre-input arguments for Two-Pass (optional)"
 msgstr "Arguments de pré-saisie pour encodage Deux Passes (facultatif)"
 
-#: ../../vdms_dialogs/queue_edit.py:113
-#: ../../vdms_dialogs/setting_profiles.py:152
-#: ../../vdms_panels/presets_manager.py:257
 msgid "FFmpeg arguments for two-pass encoding"
 msgstr "Arguments FFMPEG pour encodage en deux passes"
 
-#: ../../vdms_dialogs/queue_edit.py:120
-#: ../../vdms_dialogs/setting_profiles.py:162
-#: ../../vdms_panels/presets_manager.py:263
 msgid "Any optional arguments to add before input file on the two-pass encoding, e.g required names of some hardware accelerations like -hwaccel to use with CUDA."
 msgstr "Tout argument optionnel à ajouter avant le fichier d'entrée sur l'encodage deux passes, par exemple les noms requis de certaines accélérations matérielles comme -hwaccel à utiliser avec CUDA."
 
-#: ../../vdms_dialogs/queuedlg.py:65 ../../vdms_main/main_frame.py:508
-#: ../../vdms_panels/presets_manager.py:189
-#: ../../vdms_panels/video_to_sequence.py:171
 msgid "Edit"
 msgstr "Éditer"
 
-#: ../../vdms_dialogs/queuedlg.py:68
 msgid "Remove"
 msgstr "Retirer"
 
-#: ../../vdms_dialogs/queuedlg.py:71
 msgid "Remove all"
 msgstr "Tout Retirer"
 
-#: ../../vdms_dialogs/queuedlg.py:74
 msgid ""
 "Export\n"
 "queue file"
@@ -1284,7 +919,6 @@ msgstr ""
 "Exporter\n"
 "file d'attente"
 
-#: ../../vdms_dialogs/queuedlg.py:77
 msgid ""
 "Import\n"
 "queue file"
@@ -1292,29 +926,21 @@ msgstr ""
 "Importer\n"
 "file d'attente"
 
-#: ../../vdms_dialogs/queuedlg.py:85 ../../vdms_panels/filedrop.py:273
 msgid "Destination file name"
 msgstr "Nom du fichier de destination"
 
-#: ../../vdms_dialogs/queuedlg.py:137
 msgid "Remove all items in the queue"
 msgstr "Supprimer tous les fichiers en file d'attente"
 
-#: ../../vdms_dialogs/queuedlg.py:151
 msgid "Videomass - Queue"
 msgstr "Videomass - File d'attente"
 
-#: ../../vdms_dialogs/queuedlg.py:228
 msgid "Export queue file"
 msgstr "Exporter la file d'attente"
 
-#: ../../vdms_dialogs/queuedlg.py:296 ../../vdms_panels/av_conversions.py:1192
-#: ../../vdms_panels/presets_manager.py:1044
-#: ../../vdms_panels/video_to_sequence.py:600
 msgid "Same as source"
 msgstr "Identique à la source"
 
-#: ../../vdms_dialogs/queuedlg.py:301
 msgid ""
 "Source\n"
 "File destination\n"
@@ -1332,85 +958,64 @@ msgstr ""
 "Début de segment\n"
 "Durée du clip"
 
-#: ../../vdms_dialogs/renamer.py:76
 msgid "# will be replaced by ascending numbers starting with:"
 msgstr "# Sera remplacé par un nombre croissant commençant par:"
 
-#: ../../vdms_dialogs/set_timestamp.py:87
 msgid "Font Size"
 msgstr "Taille de la Police"
 
-#: ../../vdms_dialogs/set_timestamp.py:111
 msgid "Font Color"
 msgstr "Couleur de la Police"
 
-#: ../../vdms_dialogs/set_timestamp.py:121
 msgid "Shadow Color"
 msgstr "Couleur de l'Ombre"
 
-#: ../../vdms_dialogs/set_timestamp.py:132
 msgid "Show text box"
 msgstr "Afficher un fond  de couleur"
 
-#: ../../vdms_dialogs/set_timestamp.py:136
 msgid "Box Color"
 msgstr "Couleur du Fond"
 
-#: ../../vdms_dialogs/set_timestamp.py:156
 msgid "The timestamp size does not auto-adjust to the video size, you have to set the size here"
 msgstr "La durée ne s'ajuste pas automatiquement à la taille de la vidéo, définir la taille ici"
 
-#: ../../vdms_dialogs/set_timestamp.py:160 ../../vdms_main/main_frame.py:559
 msgid "Timestamp settings"
 msgstr "Options d'affichage du temps"
 
-#: ../../vdms_dialogs/setting_profiles.py:46
 msgid "Supported Formats list (optional). Do not include the `.`"
 msgstr "Liste des Formats pris en charge (facultatif).Ne pas inclure le `.`"
 
-#: ../../vdms_dialogs/setting_profiles.py:47
 msgid "Output Format. Empty to copy format and codec. Do not include the `.`"
 msgstr "Format de Sortie.Vide pour copier le format et le codec. Ne pas inclure le ``. '"
 
-#: ../../vdms_dialogs/setting_profiles.py:70
 msgid "Profile Name"
 msgstr "Nom du profil"
 
-#: ../../vdms_dialogs/setting_profiles.py:74
-#: ../../vdms_panels/presets_manager.py:404
 msgid "Description"
 msgstr "Description"
 
-#: ../../vdms_dialogs/setting_profiles.py:149
 msgid "A short profile name"
 msgstr "Nom de profil court"
 
-#: ../../vdms_dialogs/setting_profiles.py:150
 msgid "A long description of the profile"
 msgstr "Description longue du profil"
 
 # | msgid ""
 # | "One or more comma-separated format names that are not compatible with "
 # | "this profile."
-#: ../../vdms_dialogs/setting_profiles.py:153
 #, fuzzy
 msgid "One or more comma-separated format names compatible with this profile"
 msgstr "Un ou plusieurs noms de format séparés par une virgule incompatibles avec  ce profil."
 
-#: ../../vdms_dialogs/setting_profiles.py:155
 msgid "Output format extension. Leave empty to copy codec and format"
 msgstr "Extension du format de sortie.Laisser vide pour copier le codec et le format"
 
-#: ../../vdms_dialogs/setting_profiles.py:256
 msgid "Incomplete profile assignments"
 msgstr "Profil incomplet"
 
-#: ../../vdms_dialogs/setting_profiles.py:263
 msgid "Formats must be comma-separated"
 msgstr "Les formats doivent être séparés par une virgule"
 
-#: ../../vdms_dialogs/setting_profiles.py:279
-#: ../../vdms_utils/queue_utils.py:80
 #, python-brace-format
 msgid ""
 "ERROR: Keys mismatched for requested data.\n"
@@ -1419,105 +1024,69 @@ msgstr ""
 "ERREUR : Clés incompatibles avec les données demandées. \n"
 "Fichier non valide : « {0} »"
 
-#: ../../vdms_dialogs/setting_profiles.py:285
-#: ../../vdms_dialogs/setting_profiles.py:308
 msgid "Profile already stored with same name"
 msgstr "Profil déjà enregistré sous le même nom"
 
-#: ../../vdms_dialogs/setting_profiles.py:293
 msgid "Profile stored successfully!"
 msgstr "Profil complété avec succès !"
 
-#: ../../vdms_dialogs/setting_profiles.py:311
 msgid "Profile change successful!"
 msgstr "Changement de profil réussi!"
 
-#: ../../vdms_dialogs/showlogs.py:80
 msgid "Log file list"
 msgstr "Liste de fichier log"
 
-#: ../../vdms_dialogs/showlogs.py:82 ../../vdms_dialogs/showlogs.py:116
 msgid "Log messages"
 msgstr "Messages Log"
 
-#: ../../vdms_dialogs/showlogs.py:105
 msgid "Refresh log messages"
 msgstr "Rafraîchir les messages de log"
 
-#: ../../vdms_dialogs/showlogs.py:107
 msgid "Clear log messages"
 msgstr "Effacer les messages de log"
 
-#: ../../vdms_dialogs/showlogs.py:160
 msgid "Select a log file"
 msgstr "Choisir un fichier log"
 
-#: ../../vdms_dialogs/showlogs.py:167
 msgid "Are you sure you want to clear the selected log file?"
 msgstr "Etes vous sûr de vouloir supprimer le fichier log ?"
 
-#: ../../vdms_dialogs/showlogs.py:168 ../../vdms_dialogs/wizard_dlg.py:251
-#: ../../vdms_io/checkup.py:68 ../../vdms_main/main_frame.py:205
-#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1685
-#: ../../vdms_panels/presets_manager.py:349
-#: ../../vdms_panels/presets_manager.py:550
-#: ../../vdms_panels/presets_manager.py:590
-#: ../../vdms_panels/presets_manager.py:649
-#: ../../vdms_panels/presets_manager.py:684
-#: ../../vdms_panels/presets_manager.py:749
-#: ../../vdms_panels/presets_manager.py:775
-#: ../../vdms_panels/presets_manager.py:874
-#: ../../vdms_panels/presets_manager.py:904
 msgid "Please confirm"
 msgstr "Confirmer SVP"
 
-#: ../../vdms_dialogs/shownormlist.py:83
 msgid "File name"
 msgstr "Nom du fichier"
 
-#: ../../vdms_dialogs/shownormlist.py:84
 msgid "Max volume dBFS"
 msgstr "Volume maximal dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:85
 msgid "Mean volume dBFS"
 msgstr "Volume moyen dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:86
 msgid "Offset dBFS"
 msgstr "Décalage dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:87
 msgid "Result dBFS"
 msgstr "Résultat dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:92
 msgid "Post-normalization references:"
 msgstr "Références Post normalisation:"
 
-#: ../../vdms_dialogs/shownormlist.py:102
 msgid "=  Clipped peaks"
 msgstr "= Pics écrêtés"
 
-#: ../../vdms_dialogs/shownormlist.py:111
 msgid "=  No changes"
 msgstr "= Aucun changement"
 
-#: ../../vdms_dialogs/shownormlist.py:121
 msgid "=  Below max peak"
 msgstr "= En dessous du pic maximum"
 
-#: ../../vdms_dialogs/shownormlist.py:166
-#: ../../vdms_panels/audio_encoders/acodecs.py:841
 msgid "RMS-based volume statistics"
 msgstr "Statistiques de volume basées sur RMS"
 
-#: ../../vdms_dialogs/shownormlist.py:191
-#: ../../vdms_panels/audio_encoders/acodecs.py:839
 msgid "PEAK-based volume statistics"
 msgstr "Statistiques de volume basées sur le Pic"
 
-#: ../../vdms_dialogs/shownormlist.py:216
 msgid ""
 "...It means the resulting audio will be clipped,\n"
 "because its volume is higher than the maximum 0 db\n"
@@ -1529,7 +1098,6 @@ msgstr ""
 "Cela est dû à une perte de données et l'audio\n"
 "apparaîtra déformé."
 
-#: ../../vdms_dialogs/shownormlist.py:242
 msgid ""
 "...It means the resulting audio will not change,\n"
 "because it's equal to the source."
@@ -1537,7 +1105,6 @@ msgstr ""
 "...signifie que l'audio  ne changera pas,,\n"
 "car identique à la source."
 
-#: ../../vdms_dialogs/shownormlist.py:266
 msgid ""
 "...It means an audio signal will be produced with\n"
 "a lower volume than the source."
@@ -1545,15 +1112,12 @@ msgstr ""
 "... signifie qu'un signal audio sera produit avec\n"
 "un volume inférieur à l'original."
 
-#: ../../vdms_dialogs/videomass_check_version.py:63
 msgid "Get Latest Version"
 msgstr "Télécharger la Dernière Version"
 
-#: ../../vdms_dialogs/videomass_check_version.py:67
 msgid "Checking for newer version"
 msgstr "Recherche d'une nouvelle version"
 
-#: ../../vdms_dialogs/videomass_check_version.py:95
 msgid ""
 "\n"
 "\n"
@@ -1563,7 +1127,6 @@ msgstr ""
 "\n"
 "Les nouvelles versions corrigent des bogues et offrent de nouvelles fonctionnalités."
 
-#: ../../vdms_dialogs/videomass_check_version.py:96
 #, python-brace-format
 msgid ""
 "\n"
@@ -1576,7 +1139,6 @@ msgstr ""
 "Voici Videomass v.{0}\n"
 "\n"
 
-#: ../../vdms_dialogs/while_playing.py:37
 msgid ""
 "q, ESC\n"
 "f\n"
@@ -1618,65 +1180,51 @@ msgstr ""
 "clic droit souris\n"
 "double-clic gauche souris"
 
-#: ../../vdms_dialogs/while_playing.py:92
 msgid "Shortcut keys while playing with FFplay"
 msgstr "Raccourcis claviers FFplay"
 
-#: ../../vdms_dialogs/widget_utils.py:120 ../../vdms_main/main_frame.py:1326
 msgid "Stop"
 msgstr "Stop"
 
-#: ../../vdms_dialogs/wizard_dlg.py:63
 msgid "Please take a moment to set up the application"
 msgstr "Merci de vérifier la configuration de l'application"
 
-#: ../../vdms_dialogs/wizard_dlg.py:64
 msgid "Click the \"Next\" button to get started"
 msgstr "Cliquer le bouton \"Suivant\" pour commencer"
 
-#: ../../vdms_dialogs/wizard_dlg.py:79
 msgid "Welcome to the Videomass Wizard!"
 msgstr "Bienvenue sur l'Assistant Videomass !"
 
-#: ../../vdms_dialogs/wizard_dlg.py:123
 msgid "Videomass is an application based on FFmpeg\n"
 msgstr "Videomass est une application basée sur FFmpeg\n"
 
-#: ../../vdms_dialogs/wizard_dlg.py:125
 msgid "If FFmpeg is not on your computer, this application will be unusable"
 msgstr "Si FFmpeg n'est pas installé sur votre ordinateur, cette application ne fonctionnera pas"
 
-#: ../../vdms_dialogs/wizard_dlg.py:128
 msgid ""
 "If you have already installed FFmpeg on your operating system,\n"
 "click the \"Auto-detection\" button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:131
 msgid ""
 "If you want to use a version of FFmpeg located on your filesystem\n"
 "but not installed on your operating system,\n"
 "click the \"Locate\" button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:162
 msgid "Auto-detection"
 msgstr "Auto-détection"
 
-#: ../../vdms_dialogs/wizard_dlg.py:164
 msgid "Locate"
 msgstr "Localiser"
 
-#: ../../vdms_dialogs/wizard_dlg.py:214
 msgid "Click the \"Next\" button"
 msgstr "Cliquer le bouton \"Suivant\""
 
-#: ../../vdms_dialogs/wizard_dlg.py:235
 #, python-brace-format
 msgid "'{}' is not installed on your computer. Install it or indicate another location by clicking the 'Locate' button."
 msgstr ".'{}' n'est pas installé sur votre ordinateur. Installer-l'application ou indiquer un autre chemin en cliquant sur  le bouton \"Localiser\"."
 
-#: ../../vdms_dialogs/wizard_dlg.py:249
 msgid ""
 "Videomass already seems to include FFmpeg.\n"
 "\n"
@@ -1686,11 +1234,9 @@ msgstr ""
 "\n"
 "Voulez-vous l'utiliser?"
 
-#: ../../vdms_dialogs/wizard_dlg.py:275
 msgid "Locating FFmpeg executables\n"
 msgstr "Localisation de l'exécutable FFmpeg \n"
 
-#: ../../vdms_dialogs/wizard_dlg.py:277
 msgid ""
 "\"ffmpeg\", \"ffprobe\" and \"ffplay\" are required. Complete all\n"
 "the text boxes below by clicking on the respective buttons."
@@ -1698,40 +1244,30 @@ msgstr ""
 "\"ffmpeg\", \"ffprobe\" et \"ffplay\" requis. Cliquer sur toutes\n"
 "sur chacun de leurs boutons respectifs."
 
-#: ../../vdms_dialogs/wizard_dlg.py:437
 msgid "Wizard completed successfully!\n"
 msgstr "Assistant complété avec succès!\n"
 
-#: ../../vdms_dialogs/wizard_dlg.py:438
 msgid "Remember that you can always change these settings later, through the Preferences dialog."
 msgstr "N'oubliez pas que vous pouvez toujours modifier ces paramètres plus tard, via la boîte de dialogue Préférences."
 
-#: ../../vdms_dialogs/wizard_dlg.py:440
 msgid "Thank You!"
 msgstr "Merci!"
 
-#: ../../vdms_dialogs/wizard_dlg.py:441
 msgid "To exit click the \"Finish\" button"
 msgstr "Pour quitter cliquer sur le bouton \"Arrêter\""
 
-#: ../../vdms_dialogs/wizard_dlg.py:527
 msgid "< Previous"
 msgstr "<Précédent"
 
-#: ../../vdms_dialogs/wizard_dlg.py:530 ../../vdms_dialogs/wizard_dlg.py:613
 msgid "Next >"
 msgstr "Suivant >"
 
-#: ../../vdms_dialogs/wizard_dlg.py:535
 msgid "Videomass Wizard"
 msgstr "Assistant Videomass"
 
-#: ../../vdms_dialogs/wizard_dlg.py:563 ../../vdms_dialogs/wizard_dlg.py:586
-#: ../../vdms_dialogs/wizard_dlg.py:591
 msgid "Finish"
 msgstr "Arrêter"
 
-#: ../../vdms_io/checkup.py:44 ../../vdms_io/checkup.py:92
 #, python-brace-format
 msgid ""
 "Output folder does not exist:\n"
@@ -1742,32 +1278,25 @@ msgstr ""
 "\n"
 "\"{}\"\n"
 
-#: ../../vdms_io/checkup.py:65
 msgid "Files already exist, do you want to overwrite them?"
 msgstr "Un fichier avec ce nom existe déjà, voulez-vous l'écraser?"
 
-#: ../../vdms_io/checkup.py:67
 msgid "Already exist"
 msgstr "Fichier existant"
 
-#: ../../vdms_io/checkup.py:81
 msgid "Not found"
 msgstr "Introuvable"
 
-#: ../../vdms_io/checkup.py:82 ../../vdms_panels/filedrop.py:196
 msgid "Error list"
 msgstr "Liste d'erreurs"
 
-#: ../../vdms_io/checkup.py:83
 msgid "File(s) not found"
 msgstr "Fichier(s)Introuvable(s)"
 
-#: ../../vdms_io/io_tools.py:56
 #, python-format
 msgid "File does not exist or is invalid:  %s"
 msgstr "Le fichier n'existe pas ou n'est pas valide  %s"
 
-#: ../../vdms_io/io_tools.py:74
 msgid ""
 "Wait....\n"
 "Audio peak analysis."
@@ -1775,16 +1304,12 @@ msgstr ""
 "En attente...\n"
 "Analyse des crêtes audio."
 
-#: ../../vdms_io/io_tools.py:179
 msgid "Videomass - Downloading..."
 msgstr "Videomass - Téléchargement en cours..."
 
-#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1409
-#: ../../vdms_main/main_frame.py:1441
 msgid "Ready"
 msgstr "Prêt"
 
-#: ../../vdms_main/main_frame.py:203
 msgid ""
 "Not all items in the queue were completed.\n"
 "\n"
@@ -1794,354 +1319,267 @@ msgstr ""
 "\n"
 "Voulez-vous les conserver en file d'attente?"
 
-#: ../../vdms_main/main_frame.py:224
 #, python-brace-format
 msgid "Queue ({0})"
 msgstr "File d'attente ({0})"
 
-#: ../../vdms_main/main_frame.py:229 ../../vdms_main/main_frame.py:1334
 msgid "Queue"
 msgstr "File d'attente"
 
-#: ../../vdms_main/main_frame.py:396 ../../vdms_main/main_frame.py:418
 msgid "There are still active windows with running processes, make sure you finish your work before exit."
 msgstr "Processus actifs et toujours en cours, finissez votre travail avant de quitter."
 
-#: ../../vdms_main/main_frame.py:403
 msgid "Are you sure you want to exit the application?"
 msgstr "Voulez vous quitter l'appication?"
 
-#: ../../vdms_main/main_frame.py:405
 msgid "Exit"
 msgstr "Quitter"
 
-#: ../../vdms_main/main_frame.py:463
 msgid "Import files\tCtrl+O"
 msgstr "Import fichiers\tCtrl+O"
 
-#: ../../vdms_main/main_frame.py:466
 msgid "Open destination folder of encodings\tCtrl+D"
 msgstr "Ouvrir le dossier de destination des encodages\tCtrl+D"
 
-#: ../../vdms_main/main_frame.py:469
 msgid "Load queue file"
 msgstr "Chargement de la file d'attente"
 
-#: ../../vdms_main/main_frame.py:470
 msgid "Load a previously exported queue file"
 msgstr "Charger un fichier de file d'attente précédemment exporté"
 
-#: ../../vdms_main/main_frame.py:473
 msgid "Open trash"
 msgstr "Ouvrir la corbeille"
 
-#: ../../vdms_main/main_frame.py:474
 msgid "Open the Videomass trash folder"
 msgstr "Ouvrir lae dossiercorbeille Videomass"
 
-#: ../../vdms_main/main_frame.py:476
 msgid "Empty trash"
 msgstr "Vider la corbeille"
 
-#: ../../vdms_main/main_frame.py:477
 msgid "Delete all files in the Videomass trash folder"
 msgstr "Supprimer tous les fichiers dans le dossier corbeille Videomass"
 
-#: ../../vdms_main/main_frame.py:480
 msgid "Exit\tCtrl+Q"
 msgstr "Quitter\tCtrl+Q"
 
-#: ../../vdms_main/main_frame.py:481
 msgid "Completely exit the application"
 msgstr "Quitter définitivement l'application"
 
-#: ../../vdms_main/main_frame.py:482
 msgid "File"
 msgstr "Fichier"
 
-#: ../../vdms_main/main_frame.py:486 ../../vdms_panels/filedrop.py:340
-#: ../../vdms_panels/filedrop.py:381
 msgid "Rename selected file\tCtrl+R"
 msgstr "Renommer les fichiers sélectionnés\tCtrl+R"
 
-#: ../../vdms_main/main_frame.py:487
 msgid "Rename the destination of the selected file"
 msgstr "Renommez la destination du fichier sélectionné"
 
-#: ../../vdms_main/main_frame.py:490 ../../vdms_panels/filedrop.py:341
-#: ../../vdms_panels/filedrop.py:384
 msgid "Batch rename files\tCtrl+B"
 msgstr "Renommer en lot \tCtrl+B"
 
-#: ../../vdms_main/main_frame.py:491
 msgid "Numerically renames the destination of all items in the list"
 msgstr "Renomme numériquement la destination de tous les éléments de la liste"
 
-#: ../../vdms_main/main_frame.py:496 ../../vdms_panels/filedrop.py:343
-#: ../../vdms_panels/filedrop.py:388
 msgid "Remove selected entry\tDEL"
 msgstr "Supprimer l'entrée selectionnée\tDEL"
 
-#: ../../vdms_main/main_frame.py:497
 msgid "Remove the selected file from the list"
 msgstr "Supprimer le fichier sélectionné de la liste"
 
-#: ../../vdms_main/main_frame.py:500 ../../vdms_panels/filedrop.py:344
-#: ../../vdms_panels/filedrop.py:391
 msgid "Clear list\tShift+DEL"
 msgstr "Effacer la liste\tShift+DEL"
 
-#: ../../vdms_main/main_frame.py:501
 msgid "Clear the file list"
 msgstr "Effacer le fichier liste"
 
-#: ../../vdms_main/main_frame.py:506
 msgid "Preferences\tCtrl+P"
 msgstr "Préférences\tCtrl+P"
 
-#: ../../vdms_main/main_frame.py:507
 msgid "Application preferences"
 msgstr "Préférences de l'application"
 
-#: ../../vdms_main/main_frame.py:512
 msgid "Find FFmpeg topics"
 msgstr "Chercher des rubriques FFmpeg"
 
-#: ../../vdms_main/main_frame.py:513
 msgid "A useful tool to search for FFmpeg help topics and options"
 msgstr "Un outil pratique pour rechercher les rubriques d'aide et les options de FFmpeg"
 
-#: ../../vdms_main/main_frame.py:518
 msgid "Check for preset updates"
 msgstr "Recherche de nouveaux  profils"
 
-#: ../../vdms_main/main_frame.py:519
 #, python-brace-format
 msgid "Check for new presets updates from {0}"
 msgstr "Vérifiez les nouveaux jeux profils à partir de  {0}"
 
-#: ../../vdms_main/main_frame.py:521
 msgid "Get latest presets"
 msgstr "Télécharger les derniers jeux de profils"
 
-#: ../../vdms_main/main_frame.py:522
 #, python-brace-format
 msgid "Get the latest presets from {0}"
 msgstr "Obtenir des nouveaux jeux de profils de {0}"
 
-#: ../../vdms_main/main_frame.py:525
 msgid "Work notes\tCtrl+N"
 msgstr "Notes de travail\tCtrl+N"
 
-#: ../../vdms_main/main_frame.py:526
 msgid "Read and write useful notes and reminders."
 msgstr "Lire et écrire des notes et des rappels utiles."
 
-#: ../../vdms_main/main_frame.py:528
 msgid "Tools"
 msgstr "Outils"
 
-#: ../../vdms_main/main_frame.py:535
 msgid "Show FFmpeg's built-in configuration capabilities"
 msgstr "Affiche les capacités de configuration intégrées à FFmpeg"
 
-#: ../../vdms_main/main_frame.py:539
 msgid "Muxers and demuxers available on your version of FFmpeg"
 msgstr "Multiplexeurs et démultiplexeurs disponibles avec FFmpeg"
 
-#: ../../vdms_main/main_frame.py:543
 msgid "Encoders available on your version of FFmpeg"
 msgstr "Encodeurs disponibles pourvotre version  FFmpeg"
 
-#: ../../vdms_main/main_frame.py:546
 msgid "Decoders available on your version of FFmpeg"
 msgstr "Décocodeurs disponibles pour votre version FFmpeg"
 
-#: ../../vdms_main/main_frame.py:550
 msgid "Enable timestamps on playback"
 msgstr "Afficher le compteur de temps"
 
-#: ../../vdms_main/main_frame.py:551
 msgid "Displays timestamp when playing media with FFplay"
 msgstr "Affiche la barre de durée pendant la lecture du film avec FFPlay"
 
-#: ../../vdms_main/main_frame.py:554
 msgid "Auto-exit after playback"
 msgstr "Quitter automatiquement après lecture"
 
-#: ../../vdms_main/main_frame.py:555
 msgid "If checked, the FFplay window will auto-close when playback is complete"
 msgstr "Si activé,  la fenêtre FFplay sera automatiquement fermée en fin de lecture"
 
-#: ../../vdms_main/main_frame.py:559
 msgid "Customize the timestamp style"
 msgstr "Style de la barre de temps"
 
-#: ../../vdms_main/main_frame.py:562
 msgid "While playing..."
 msgstr "En cours de lecture ..."
 
-#: ../../vdms_main/main_frame.py:563
 msgid "Show useful shortcut keys when playing or previewing using FFplay"
 msgstr "Afficher les raccourcis pendant la lecture ou pré-lecture avec FFplay"
 
-#: ../../vdms_main/main_frame.py:567
 msgid "Show timeline editor\tCtrl+T"
 msgstr "Afficher l'éditeur de timeline \tCtrl+T"
 
-#: ../../vdms_main/main_frame.py:568
 msgid "Set duration or trim slices of time to remove unwanted parts from your files"
 msgstr "Définissez la durée ou coupez des tranches de temps pour supprimer les parties indésirables de vos fichiers"
 
-#: ../../vdms_main/main_frame.py:572
 msgid "View"
 msgstr "Contrôle"
 
-#: ../../vdms_main/main_frame.py:579
 msgid "Home panel\tCtrl+Shift+H"
 msgstr "Ecran d'Accueil\tCtrl+Shift+H"
 
 # | msgid "Go to the 'Home' panel"
-#: ../../vdms_main/main_frame.py:580
 #, fuzzy
 msgid "Go to the «Home» panel"
 msgstr "Retour à \"Ecran d'Accueil\""
 
-#: ../../vdms_main/main_frame.py:583
 msgid "Presets Manager\tCtrl+Shift+P"
 msgstr "Gestion des Jeux de Profils\tCtrl+Shift+P"
 
 # | msgid "Go to the 'Presets Manager' panel"
-#: ../../vdms_main/main_frame.py:584
 #, fuzzy
 msgid "Go to the «Presets Manager» panel"
 msgstr "Aller sur le panneau \"Gestion des Jeux de Profils\""
 
-#: ../../vdms_main/main_frame.py:586
 msgid "A/V Conversions\tCtrl+Shift+V"
 msgstr "Conversions Audio/Vidéo\tCtrl+Shift+V"
 
 # | msgid "Go to the 'A/V Conversions' panel"
-#: ../../vdms_main/main_frame.py:587
 #, fuzzy
 msgid "Go to the «A/V Conversions» panel"
 msgstr "Aller au panneau 'Conversions Audio/Vidéo'"
 
-#: ../../vdms_main/main_frame.py:589
 msgid "Concatenate Demuxer\tCtrl+Shift+D"
 msgstr "Fusion et Démultipléxage\tCtrl+Shift+D"
 
 # | msgid "Go to the 'Concatenate Demuxer' panel"
-#: ../../vdms_main/main_frame.py:590
 #, fuzzy
 msgid "Go to the «Concatenate Demuxer» panel"
 msgstr "Aller sur le panneau Assemblage et Démultipléxage"
 
-#: ../../vdms_main/main_frame.py:593
 msgid "Still Image Maker\tCtrl+Shift+I"
 msgstr "Film à partir d'image(s)\tCtrl+Shift+I"
 
 # | msgid "Go to the 'Still Image Maker' panel"
-#: ../../vdms_main/main_frame.py:594
 #, fuzzy
 msgid "Go to the «Still Image Maker» panel"
 msgstr "Aller au panneau 'Film à partir d'image(s)"
 
-#: ../../vdms_main/main_frame.py:596
 msgid "From Movie to Pictures\tCtrl+Shift+S"
 msgstr "Image(s) à partir d'un Film \tCtrl+Shift+S"
 
 # | msgid "Go to the 'From Movie to Pictures' panel"
-#: ../../vdms_main/main_frame.py:597
 #, fuzzy
 msgid "Go to the «From Movie to Pictures» panel"
 msgstr "Aller au panneau \"Créer  Image(s) à partir d'un Film\""
 
-#: ../../vdms_main/main_frame.py:600
 msgid "Output monitor\tCtrl+Shift+O"
 msgstr "Moniteur de sortie\tCtrl+Shift+O"
 
-#: ../../vdms_main/main_frame.py:601
 msgid "Keeps track of the output for debugging errors"
 msgstr "Garde une trace de la sortie pour débogage d'erreurs"
 
-#: ../../vdms_main/main_frame.py:603
 msgid "Go"
 msgstr "Aller à"
 
-#: ../../vdms_main/main_frame.py:607
 msgid "User guide"
 msgstr "Guide de l'Utilisateur"
 
-#: ../../vdms_main/main_frame.py:611
 msgid "System version"
 msgstr "Version Système"
 
-#: ../../vdms_main/main_frame.py:612
 msgid "Get version about your operating system, version of Python and wxPython."
 msgstr "Contrôle de version de votre système, version de Python et wxPython."
 
-#: ../../vdms_main/main_frame.py:616
 msgid "Show log files\tCtrl+L"
 msgstr "Afficher les fichiers logs\tCtrl+L"
 
-#: ../../vdms_main/main_frame.py:617
 msgid "Viewing log messages"
 msgstr "Visionner les messages de log"
 
-#: ../../vdms_main/main_frame.py:620
 msgid "Issue tracker"
 msgstr "Traqueur d'incidents"
 
-#: ../../vdms_main/main_frame.py:624
 msgid "Contribute to the project"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:627
 msgid "Sponsor this project"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:628
 msgid "Become a developer supporter"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:629
 msgid "Donate"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:630
 msgid "Donate to the app developer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:634
 msgid "Other projects by the developer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:650
 msgid "About Videomass"
 msgstr "A propos de Videomass"
 
-#: ../../vdms_main/main_frame.py:651
 msgid "Check for newer version"
 msgstr "Rechercher une version plus récente"
 
-#: ../../vdms_main/main_frame.py:652
 msgid "Check for the latest Videomass version"
 msgstr "Vérifier la dernière version de Videomass"
 
-#: ../../vdms_main/main_frame.py:654
 msgid "Help"
 msgstr "Aide"
 
-#: ../../vdms_main/main_frame.py:729
 msgid "Import files"
 msgstr "Importer les fichiers"
 
-#: ../../vdms_main/main_frame.py:752
 msgid "No default folder has been set for the destination of the encodings. The current setting is \"Same destination paths as source files\"."
 msgstr "Aucun dossier par défaut n'a été défini pour la destination des encodages. Le paramètre actuel est \"les mêmes chemins de destination que les fichiers source\"."
 
-#: ../../vdms_main/main_frame.py:784 ../../vdms_main/main_frame.py:809
 #, python-brace-format
 msgid ""
 "'{}':\n"
@@ -2150,11 +1588,9 @@ msgstr ""
 "'{}':\n"
 "fichier ou dossier inexistant"
 
-#: ../../vdms_main/main_frame.py:797
 msgid "Are you sure to empty trash folder?"
 msgstr "Etes vous sûr de vouloir vider la corbeille ?"
 
-#: ../../vdms_main/main_frame.py:805
 #, python-brace-format
 msgid ""
 "'{}':\n"
@@ -2163,17 +1599,14 @@ msgstr ""
 "'{}':\n"
 "Aucun fichier à supprimer."
 
-#: ../../vdms_main/main_frame.py:862
 #, python-brace-format
 msgid "Installed release v{0}. A new presets release is available {1}"
 msgstr "Version installée v{0}. Une nouvelle version de Jeux de Profils est dispo {1}"
 
-#: ../../vdms_main/main_frame.py:866
 #, python-brace-format
 msgid "Installed release v{0}. No new updates found."
 msgstr "Version installée v{0}. Pas de nouvelles versions.."
 
-#: ../../vdms_main/main_frame.py:896
 msgid ""
 "Wait....\n"
 "The archive is being downloaded"
@@ -2181,16 +1614,13 @@ msgstr ""
 "En attente...\n"
 "L'archive est en cours de téléchargement"
 
-#: ../../vdms_main/main_frame.py:908
 #, python-brace-format
 msgid "Successfully downloaded to \"{0}\""
 msgstr "Téléchargé avec succès dans\"{0}\""
 
-#: ../../vdms_main/main_frame.py:1120
 msgid "Some changes require restarting the application."
 msgstr "Les changements nécessitent un redémarrage de l'application."
 
-#: ../../vdms_main/main_frame.py:1126
 #, python-brace-format
 msgid ""
 "{0}\n"
@@ -2201,124 +1631,93 @@ msgstr ""
 "\n"
 "Voulez vous quitter l'application?"
 
-#: ../../vdms_main/main_frame.py:1128
 msgid "Restart Videomass?"
 msgstr "Redémarrer Videomass?"
 
-#: ../../vdms_main/main_frame.py:1207
 #, python-brace-format
 msgid "A new release is available - v.{0}\n"
 msgstr "Une nouvelle version est disponible - v.{0}\n"
 
-#: ../../vdms_main/main_frame.py:1210
 msgid "You are using a development version that has not yet been released!\n"
 msgstr "Vous utilisez une version de développement qui n'a pas encore été finalisée\n"
 
-#: ../../vdms_main/main_frame.py:1213
 msgid "Congratulation! You are already using the latest version.\n"
 msgstr "Félicitations! Vous utilisez déjà la dernière version\n"
 
 # | msgid "Go to the previous panel"
-#: ../../vdms_main/main_frame.py:1301
 #, fuzzy
 msgid "Previous panel"
 msgstr "Revenir au panneau précédent"
 
-#: ../../vdms_main/main_frame.py:1302
 msgid "Back"
 msgstr "Précédent"
 
 # | msgid "Next >"
-#: ../../vdms_main/main_frame.py:1305
 #, fuzzy
 msgid "Next panel"
 msgstr "Suivant >"
 
-#: ../../vdms_main/main_frame.py:1306
 msgid "Next"
 msgstr "Suivant"
 
 # | msgid "Go to the 'Home' panel"
-#: ../../vdms_main/main_frame.py:1309
 #, fuzzy
 msgid "Home panel"
 msgstr "Retour à \"Ecran d'Accueil\""
 
-#: ../../vdms_main/main_frame.py:1310
 msgid "Home"
 msgstr "Accueil"
 
 # | msgid "Delete the selected profile"
-#: ../../vdms_main/main_frame.py:1313
 #, fuzzy
 msgid "Play the selected imput file"
 msgstr "Supprimer le profil sélectionné"
 
-#: ../../vdms_main/main_frame.py:1314
 msgid "Play"
 msgstr "Lecture"
 
-#: ../../vdms_main/main_frame.py:1317
 msgid "Get informative data about imported media streams"
 msgstr "Récupère des informations à partir des flux multimédias importés"
 
-#: ../../vdms_main/main_frame.py:1321
 msgid "Start batch processing"
 msgstr "Démarrer le processus en lot"
 
-#: ../../vdms_main/main_frame.py:1325
 msgid "Stops current process"
 msgstr "Arrête le traitement en cours"
 
-#: ../../vdms_main/main_frame.py:1329
 msgid "Add an item to Queue"
 msgstr "Ajouter un élément è la File d'attente"
 
-#: ../../vdms_main/main_frame.py:1330
 msgid "Add to Queue"
 msgstr "Ajouter à la file d'attente"
 
-#: ../../vdms_main/main_frame.py:1333
 msgid "Show queue"
 msgstr "Afficher la file d'attente"
 
-#: ../../vdms_main/main_frame.py:1408 ../../vdms_panels/presets_manager.py:569
 msgid "Videomass"
 msgstr "Videomass"
 
-#: ../../vdms_main/main_frame.py:1442
 msgid "Videomass - File List"
 msgstr "Videomass - liste fichier"
 
-#: ../../vdms_main/main_frame.py:1459
 msgid "Videomass - AV Conversions"
 msgstr "Videomass - Conversion Audio/Vidéo"
 
-#: ../../vdms_main/main_frame.py:1488
 msgid "Videomass - Presets Manager"
 msgstr "Videomass - Gestion des Jeux de Profils"
 
-#: ../../vdms_main/main_frame.py:1518
 msgid "Videomass - Concatenate Demuxer"
 msgstr "Videomass - Assemblage Fichiers Multimedia"
 
-#: ../../vdms_main/main_frame.py:1547
 msgid "Videomass - From Movie to Pictures"
 msgstr "Videomass -  Image(s) à partir d'un film"
 
-#: ../../vdms_main/main_frame.py:1576
 msgid "Videomass - Still Image Maker"
 msgstr "Videomass - Extraire image(s) à partir d'un film"
 
-#: ../../vdms_main/main_frame.py:1660 ../../vdms_panels/av_conversions.py:577
-#: ../../vdms_panels/filedrop.py:500 ../../vdms_panels/filedrop.py:616
-#: ../../vdms_panels/sequence_to_video.py:322
-#: ../../vdms_panels/video_to_sequence.py:369
-#: ../../vdms_panels/video_to_sequence.py:501
 msgid "Have to select an item in the file list first"
 msgstr "Sélectionnerz d'abord un élément dans la liste des fichiers"
 
-#: ../../vdms_main/main_frame.py:1682
 msgid ""
 "An item with the same destination file already exists.\n"
 "\n"
@@ -2328,85 +1727,64 @@ msgstr ""
 "\n"
 "Voulez-vous le remplacer en ajoutant le nouvel élément à la file d'attente?"
 
-#: ../../vdms_main/main_frame.py:1703
 msgid "Videomass - FFmpeg Message Monitoring"
 msgstr "Videomass - Messages de sortie FFMPEG"
 
-#: ../../vdms_main/main_frame.py:1828
 #, python-brace-format
 msgid "The system will turn off in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1829
 msgid "Videomass - Shutdown!"
 msgstr "Videomass - Arrêt !"
 
-#: ../../vdms_main/main_frame.py:1836
 msgid "Error while shutting down. Please see file log for details."
 msgstr "Erreur à la fermeture. Consulter le fichier log pour plus de détails."
 
 # | msgid "Exit the application"
-#: ../../vdms_main/main_frame.py:1848
 #, fuzzy, python-brace-format
 msgid "Exiting the application in {0} seconds"
 msgstr "Quitter l'application"
 
-#: ../../vdms_main/main_frame.py:1849
 msgid "Videomass - Exiting!"
 msgstr "Videomass -  en cours d'arrêt !"
 
-#: ../../vdms_miniframes/timeline.py:46
 msgid "Start point adjustment"
 msgstr "Ajuster le point de départ"
 
-#: ../../vdms_miniframes/timeline.py:48
 msgid "End point adjustment"
 msgstr "Ajuster le point final"
 
-#: ../../vdms_miniframes/timeline.py:105
 msgid "Hours"
 msgstr "Heures"
 
-#: ../../vdms_miniframes/timeline.py:106
 msgid "Minutes"
 msgstr "Minutes"
 
-#: ../../vdms_miniframes/timeline.py:107
 msgid "Seconds"
 msgstr "Secondes"
 
-#: ../../vdms_miniframes/timeline.py:108
 msgid "Milliseconds"
 msgstr "Millisecondes"
 
-#: ../../vdms_miniframes/timeline.py:189 ../../vdms_miniframes/timeline.py:312
 msgid "No source duration:"
 msgstr "Aucune durée source :"
 
-#: ../../vdms_miniframes/timeline.py:208 ../../vdms_miniframes/timeline.py:298
-#: ../../vdms_miniframes/timeline.py:333 ../../vdms_miniframes/timeline.py:338
-#: ../../vdms_miniframes/timeline.py:441
 #, python-brace-format
 msgid "{0} {1}  |  Segment Duration: {2}"
 msgstr "{0} {1}  |  Durée du segment: {2}"
 
-#: ../../vdms_miniframes/timeline.py:260 ../../vdms_miniframes/timeline.py:277
 msgid "End adjustment"
 msgstr "Réglage de fin"
 
-#: ../../vdms_miniframes/timeline.py:261 ../../vdms_miniframes/timeline.py:279
 msgid "Start adjustment"
 msgstr "Réglage de départ"
 
-#: ../../vdms_miniframes/timeline.py:320
 msgid "Source duration:"
 msgstr "Durée source:"
 
-#: ../../vdms_miniframes/timeline.py:387
 msgid "WARNING: Invalid selection, out of range."
 msgstr "AVERTISSEMENT : Sélection non valide, hors plage."
 
-#: ../../vdms_miniframes/timeline.py:461
 msgid ""
 "Start by dragging the bottom left handle,\n"
 "or right-click for options."
@@ -2414,15 +1792,12 @@ msgstr ""
 "Commencez par faire glisser la poignée en bas à gauche,\n"
 " ou cliquez avec le bouton droit pour les options."
 
-#: ../../vdms_miniframes/timeline.py:497
 msgid "Start"
 msgstr "Début"
 
-#: ../../vdms_miniframes/timeline.py:498
 msgid "End"
 msgstr "Fin"
 
-#: ../../vdms_miniframes/timeline.py:548
 msgid ""
 "The timeline editor is a tool that allows you to trim slices of time on selected imported media (see File List panel).\n"
 "\n"
@@ -2444,39 +1819,30 @@ msgstr ""
 "\n"
 "Les valeurs de durée « Début\"/\"Fin » font toujours référence à la position initiale de la timeline: 00:00:00.000. Pour d'autres informations telles que la durée du segment et les avertissements, veuillez vous référer aux messages de la barre d'état."
 
-#: ../../vdms_miniframes/timeline.py:565
 msgid "Timeline Editor Usage"
 msgstr "Utilisation de la timeline"
 
-#: ../../vdms_panels/av_conversions.py:153
 msgid "Media:"
 msgstr "Média:"
 
-#: ../../vdms_panels/av_conversions.py:169
 msgid "Container:"
 msgstr "Conteneur:"
 
-#: ../../vdms_panels/av_conversions.py:180
 msgid "Save profile"
 msgstr "Enregistrer le profil"
 
-#: ../../vdms_panels/av_conversions.py:183
 msgid "Target"
 msgstr "Cible"
 
-#: ../../vdms_panels/av_conversions.py:316
 msgid "Miscellaneous"
 msgstr "Divers"
 
-#: ../../vdms_panels/av_conversions.py:323
 msgid "Save as a new profile of the Presets Manager."
 msgstr "Enregistrer ce nouveau profil dans le Gestionnaire de Jeux de Profils."
 
-#: ../../vdms_panels/av_conversions.py:325
 msgid "Available video encoders. \"Copy\" means that the video stream will not be re-encoded and will allow you (depending on the encoder) to change the container, audio codec and a few other parameters."
 msgstr "Codecs vidéo disponibles.\"Copy\" indique que le flux vidéo ne sera pas ré-encodé et permet (selon l'encodeur) de modifier le container, le codec audio et quelques paramètres."
 
-#: ../../vdms_panels/av_conversions.py:330
 msgid ""
 "Container format. It is usually represented by the file extension (output format).\n"
 "\n"
@@ -2490,7 +1856,6 @@ msgstr ""
 "\n"
 "Si la cible multimédia est définie sur « Audio », vous pouvez extraire uniquement les flux audio des vidéos, ou simplement convertir les fichiers sources audio."
 
-#: ../../vdms_panels/av_conversions.py:338
 msgid ""
 "Set output files target: \"Video\" to save output files as video files; \"Audio\" to save files using an audio encoder and format.\n"
 "\n"
@@ -2499,45 +1864,33 @@ msgstr ""
 "Définir la cible des fichiers de sortie : « Vidéo » pour enregistrer les fichiers de sortie en tant que fichiers vidéo ; « Audio » pour enregistrer des fichiers à l'aide d'un encodeur et d'un format audio. \n"
 "Notez qu'en utilisant « Audio » comme cible, vous pourrez toujours travailler sur les fichiers sources vidéo, mais vous ne pourrez qu'extraire les flux audio, les convertir et appliquer des filtres audio tels que la normalisation."
 
-#: ../../vdms_panels/av_conversions.py:346
 msgid "Preview video filters"
 msgstr "Aperçu des filtres vidéo"
 
-#: ../../vdms_panels/av_conversions.py:347
 msgid "Disable active filters"
 msgstr "Désactiver les filtres en cours"
 
-#: ../../vdms_panels/av_conversions.py:348
-#: ../../vdms_panels/sequence_to_video.py:156
-#: ../../vdms_panels/video_to_sequence.py:113
 msgid "Resize"
 msgstr "Redimensionnement"
 
-#: ../../vdms_panels/av_conversions.py:349
 msgid "Crop"
 msgstr "Découpage"
 
-#: ../../vdms_panels/av_conversions.py:350
 msgid "Transpose"
 msgstr "Transposition"
 
-#: ../../vdms_panels/av_conversions.py:352
 msgid "Denoise"
 msgstr "Débruiter"
 
-#: ../../vdms_panels/av_conversions.py:353
 msgid "Stabilize"
 msgstr "Stabiliser"
 
-#: ../../vdms_panels/av_conversions.py:354
 msgid "Equalize"
 msgstr "Egaliser"
 
-#: ../../vdms_panels/av_conversions.py:517
 msgid "Unable to preview Video Stabilizer filter"
 msgstr "Impossible de prévisualiser le filtre stabilisateur vidéo"
 
-#: ../../vdms_panels/av_conversions.py:602
 msgid ""
 "Unsupported file:\n"
 "Missing decoder or library? Check FFmpeg configuration."
@@ -2545,22 +1898,15 @@ msgstr ""
 "Fichier non supporté:\n"
 "Décodeur ou bibliothèque absents? Vérifier la configuration de FFMPEG."
 
-#: ../../vdms_panels/av_conversions.py:611
-#: ../../vdms_panels/sequence_to_video.py:351
-#: ../../vdms_panels/video_to_sequence.py:398
 msgid "The file is not a frame or a video file"
 msgstr "Le fichier n'est pas une image ou un fichier vidéo"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:434
-#: ../../vdms_panels/av_conversions.py:861
 msgid "Undetected volume values! Click the \"Volume detect\" button to analyze audio volume data."
 msgstr "Valeurs de volume non détectées!Cliquez sur le bouton \"Détecter le volume\" pour analyser les données de volume audio."
 
-#: ../../vdms_panels/av_conversions.py:1186
 msgid "Off"
 msgstr "Off"
 
-#: ../../vdms_panels/av_conversions.py:1203
 msgid ""
 "Batch processing items\n"
 "Destination\n"
@@ -2585,109 +1931,81 @@ msgstr ""
 "Début de segment\n"
 "Durée du clip"
 
-#: ../../vdms_panels/av_conversions.py:1246
-#: ../../vdms_panels/presets_manager.py:814
 #, python-brace-format
 msgid "Write profile on «{0}»"
 msgstr "Ecrire le profil sur «{0}»"
 
-#: ../../vdms_panels/av_conversions.py:1266
-#: ../../vdms_panels/presets_manager.py:513
 msgid "Enter name for new preset"
 msgstr "Entrez le nom du nouveau jeu de profil"
 
-#: ../../vdms_panels/av_conversions.py:1276
-#: ../../vdms_panels/presets_manager.py:524
 msgid "Invalid file name, make sure to provide a valid name including the «.json» extension"
 msgstr "Nom de fichier non valide, assurez-vous de fournir un nom valide avec l'extension «.json »"
 
-#: ../../vdms_panels/av_conversions.py:1284
 #, python-brace-format
 msgid "Cannot save current data in file «{}»."
 msgstr "Impossible d'enregistrer les données dans le fichier'{}'."
 
-#: ../../vdms_panels/av_conversions.py:1289
 msgid "Open Videomass preset"
 msgstr "Choisiir un jeu de profils Videomass"
 
-#: ../../vdms_panels/av_conversions.py:1307
 msgid "Videomass - Save new profile"
 msgstr "Videomass - Créer un nouveau profil"
 
-#: ../../vdms_panels/av_conversions.py:1308
 msgid "Where do you want to save this profile?"
 msgstr "Où voulez-vous enregistrer le profil ?"
 
-#: ../../vdms_panels/av_conversions.py:1309
 msgid "Save the profile to a new preset"
 msgstr "Enregistrer le profil dans un nouveau jeu de profils"
 
-#: ../../vdms_panels/av_conversions.py:1310
 msgid "Save the profile to an existing preset"
 msgstr "Sauvegarder le profil dans un jeu de profils existant"
 
-#: ../../vdms_panels/choose_topic.py:69
 msgid "Welcome to Videomass"
 msgstr "Bienvenue sur Videomass"
 
-#: ../../vdms_panels/choose_topic.py:71
 #, python-brace-format
 msgid "Version {}"
 msgstr "Version {}"
 
-#: ../../vdms_panels/choose_topic.py:82
 msgid "Presets Manager"
 msgstr "Gestion des Jeux de Profils"
 
-#: ../../vdms_panels/choose_topic.py:85
 msgid "AV-Conversions"
 msgstr "Conversion Audio/Vidéo"
 
-#: ../../vdms_panels/choose_topic.py:88
 msgid "Concatenate media files"
 msgstr "Fusion de Fichiers Multimédia"
 
-#: ../../vdms_panels/choose_topic.py:91
 msgid "Still Image Maker"
 msgstr "Film à partir d'image(s)"
 
-#: ../../vdms_panels/choose_topic.py:94
 msgid "From Movie to Pictures"
 msgstr "Image(s) à partir d'un Film"
 
-#: ../../vdms_panels/choose_topic.py:123
 msgid "Create, edit and use quickly your favorite FFmpeg presets and profiles with full formats support and codecs."
 msgstr "Créez, modifiez et utilisez rapidement vos réglages et profils FFmpeg préférés avec une prise en charge complète des formats et des codecs."
 
-#: ../../vdms_panels/choose_topic.py:127
 msgid "A set of useful tools for audio and video conversions. Save your profiles and reuse them with Presets Manager."
 msgstr "Un ensemble d'outils pratiques pour les conversions audio et vidéo. Enregistrez vos profils et utilisez-les avec le Gestionnaire de Jeux de Profils."
 
-#: ../../vdms_panels/choose_topic.py:131
 msgid "Concatenate multiple media files based on import order without re-encoding"
 msgstr "Assemblez vos fichiers multimédias suivant l'ordre d'importation et sans ré-encodage"
 
-#: ../../vdms_panels/choose_topic.py:134
 msgid "Create video from a sequence of images, based on import order, with the ability to add an audio file."
 msgstr "Créez une vidéo à partir d'une séquence d'images suivant l'ordre d'importation, avec possibilité d'ajouter une piste audio."
 
-#: ../../vdms_panels/choose_topic.py:137
 msgid "Extract images (frames) from your movies in JPG, PNG, BMP, GIF formats."
 msgstr "Extraire des images de vos films aux formats JPG, PNG, BMP et GIF animé."
 
-#: ../../vdms_panels/concatenate.py:47
 msgid "At least two files are required to perform concatenation."
 msgstr "Deux fichiers au minimum sont nécessaires pour effectuer un assemblage vidéo."
 
-#: ../../vdms_panels/concatenate.py:63
 msgid "Invalid data found"
 msgstr "Données invalides"
 
-#: ../../vdms_panels/concatenate.py:68
 msgid "The files do not have the same \"codec_types\", same \"sample_rate\" or same \"width\" or \"height\". Unable to proceed."
 msgstr "Les fichiers n'ont pas les mêmes \"types de codec\", le même \"échantillonnage\" ou la même \"largeur\" ou \"hauteur\".Impossibile de procéder."
 
-#: ../../vdms_panels/concatenate.py:84
 msgid ""
 "\n"
 "- The concatenation function is performed only with Audio files or only with Video files.\n"
@@ -2715,17 +2033,12 @@ msgstr ""
 "\n"
 "- Les fichiers audio doivent avoir exactement les mêmes formats, mêmes codecs et  même fréquence d'échantillonnage."
 
-#: ../../vdms_panels/concatenate.py:125
 msgid "Videomass Documentation:"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:136
-#: ../../vdms_panels/sequence_to_video.py:212
-#: ../../vdms_panels/video_to_sequence.py:181
 msgid "Official FFmpeg documentation:"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:253
 msgid ""
 "Items to concatenate\n"
 "File destination\n"
@@ -2739,250 +2052,188 @@ msgstr ""
 "Format de sortie multimedia\n"
 "Durée"
 
-#: ../../vdms_panels/filedrop.py:45
 msgid "File has illegal characters like:"
 msgstr "Le fichier comporte des caractères non acceptés comme:"
 
-#: ../../vdms_panels/filedrop.py:46
 msgid "Invalid character found in path name: (\")"
 msgstr "Caractère invalide trouvé dans le nom du chemin: (\")"
 
-#: ../../vdms_panels/filedrop.py:47
 msgid "Directories are not allowed, just add files, please."
 msgstr "Les répertoires ne sont pas autorisés, ajouter uniquement des fichiers svp."
 
-#: ../../vdms_panels/filedrop.py:48
 msgid "File without format extension: please give an appropriate extension to the file name, example '.mkv', '.avi', '.mp3', etc."
 msgstr "Fichier sans extension veuillez donner une extension appropriée au nom du fichier, exemple '.mkv', '.avi', '.mp3', etc."
 
-#: ../../vdms_panels/filedrop.py:84
 #, python-brace-format
 msgid "Name has illegal characters like: {0}"
 msgstr "Caractères non acceptés comme: {0}"
 
-#: ../../vdms_panels/filedrop.py:85
 msgid "Name already in use:"
 msgstr "Nom déjà utilisé:"
 
-#: ../../vdms_panels/filedrop.py:185
 msgid "Duplicate file, it has already been added to the list."
 msgstr "Fichier déjà ajouté à la liiste."
 
-#: ../../vdms_panels/filedrop.py:197
 msgid "Rejected files"
 msgstr "Fichiers refusés"
 
-#: ../../vdms_panels/filedrop.py:269
 msgid "Source file"
 msgstr "Fichier Source"
 
-#: ../../vdms_panels/filedrop.py:270
 msgid "Duration"
 msgstr "Durée"
 
-#: ../../vdms_panels/filedrop.py:271
 msgid "Media type"
 msgstr "Type de média"
 
-#: ../../vdms_panels/filedrop.py:272
 msgid "Size"
 msgstr "Taille"
 
-#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:405
 msgid "Drag one or more files below"
 msgstr "Faites glisser un ou plusieurs fichiers ci-dessous"
 
-#: ../../vdms_panels/filedrop.py:282
 msgid "Save to:"
 msgstr "Enregistrer vers:"
 
-#: ../../vdms_panels/filedrop.py:306
 msgid "Set a new destination folder for encodings"
 msgstr "Définir un nouveau dossier pour l'encodage"
 
-#: ../../vdms_panels/filedrop.py:308
 msgid "Encodings destination folder"
 msgstr "Dossier de destination de l'encodage"
 
-#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:394
 msgid "Play file"
 msgstr "Jouer le fichier"
 
-#: ../../vdms_panels/filedrop.py:408
 msgid "Drag two or more Audio/Video files below"
 msgstr "Faites glisser deux ou plusieurs fichiersAudio/Vidéo ci-dessous"
 
-#: ../../vdms_panels/filedrop.py:412
 msgid "Drag one or more Image files below"
 msgstr "Faites glisser un ou plusieurs fichiers d'images ci-dessous"
 
-#: ../../vdms_panels/filedrop.py:415
 msgid "Drag one or more Video files below"
 msgstr "Faites glisser un ou plusieurs fichiers Vidéo ci-dessous"
 
-#: ../../vdms_panels/filedrop.py:623
 msgid "Rename the file destination"
 msgstr "Renommer le fichier de destination"
 
-#: ../../vdms_panels/filedrop.py:624
 msgid "Rename the selected file to:"
 msgstr "Renommer le fichier selectionné:"
 
-#: ../../vdms_panels/filedrop.py:638 ../../vdms_panels/filedrop.py:648
-#: ../../vdms_panels/filedrop.py:679
 msgid "Add Files"
 msgstr "Ajouter des Fichiers"
 
-#: ../../vdms_panels/filedrop.py:655
 msgid "Rename in batch"
 msgstr "Renommer par lot"
 
-#: ../../vdms_panels/filedrop.py:656
 #, python-brace-format
 msgid "Rename the {0} items to:"
 msgstr "Renommer les {0} éléments en:"
 
-#: ../../vdms_panels/filedrop.py:658
 msgid "New Name #"
 msgstr "Nouveau Nom #"
 
-#: ../../vdms_panels/long_processing_task.py:114
 msgid "Sorry, all task failed !"
 msgstr "Désolé, échec de la tâche !"
 
-#: ../../vdms_panels/long_processing_task.py:115
 msgid "The process was stopped due to a fatal error."
 msgstr "Le traitement s'est interrompu suite à une erreur fatale."
 
-#: ../../vdms_panels/long_processing_task.py:116
 msgid "Interrupted Process !"
 msgstr "Traitement interrompu!"
 
-#: ../../vdms_panels/long_processing_task.py:117
 msgid "Successfully completed !"
 msgstr "Terminé avec succès !"
 
-#: ../../vdms_panels/long_processing_task.py:118
 msgid "Not everything was successful."
 msgstr "Tout n'a pas réussi."
 
-#: ../../vdms_panels/long_processing_task.py:148
 msgid "Encoding Status"
 msgstr "Statut de l'encodage"
 
-#: ../../vdms_panels/long_processing_task.py:152
 msgid "Current Log"
 msgstr "Log actuel"
 
-#: ../../vdms_panels/long_processing_task.py:354
 msgid "Fatal Error !"
 msgstr "Erreur fatale !"
 
-#: ../../vdms_panels/long_processing_task.py:363
 msgid "Get your files at the destination you specified"
 msgstr "Récupérez vos fichiers à  l'emplacement de destination"
 
-#: ../../vdms_panels/long_processing_task.py:377
 msgid "For more details please read the Current Log."
 msgstr "Pour plus de détails, veuillez lire le journal actuel."
 
-#: ../../vdms_panels/long_processing_task.py:380
 msgid "...Finished"
 msgstr "...Terminé"
 
-#: ../../vdms_panels/long_processing_task.py:399
 msgid "Please wait... interruption in progress"
 msgstr "Attendez svp... interruption en cours"
 
-#: ../../vdms_panels/long_processing_task.py:402
 msgid "...Interrupted"
 msgstr "...Interrompu"
 
-#: ../../vdms_panels/presets_manager.py:166
 msgid "Presets"
 msgstr "Jeux de Profils"
 
-#: ../../vdms_panels/presets_manager.py:180
 msgid "Write"
 msgstr "Ecrire"
 
-#: ../../vdms_panels/presets_manager.py:184
 msgid "Delete"
 msgstr "Supprimer"
 
-#: ../../vdms_panels/presets_manager.py:194
 msgid "Duplicate"
 msgstr "Dupliquer"
 
-#: ../../vdms_panels/presets_manager.py:199
 msgid "Profiles"
 msgstr "Profils"
 
-#: ../../vdms_panels/presets_manager.py:206
 msgid "One-Pass Encoding"
 msgstr "Encodage 1 Passe"
 
-#: ../../vdms_panels/presets_manager.py:218
 msgid "Two-Pass Encoding"
 msgstr "Encodage 2 Passes"
 
-#: ../../vdms_panels/presets_manager.py:232
 msgid "Choose a preset and view its profiles"
 msgstr "Choisissez un jeu de profils et affichez tous ses profils"
 
-#: ../../vdms_panels/presets_manager.py:233
 msgid "Write a new profile and save it in the selected preset"
 msgstr "Créez un nouveau profil et enregistrez-le dans le profil sélectionné"
 
-#: ../../vdms_panels/presets_manager.py:235
 msgid "Delete the selected profile"
 msgstr "Supprimer le profil sélectionné"
 
-#: ../../vdms_panels/presets_manager.py:236
 msgid "Edit the selected profile"
 msgstr "Éditer le profil sélectionné"
 
-#: ../../vdms_panels/presets_manager.py:237
 msgid "Duplicate the selected profile"
 msgstr "Dupliquer le profil sélectionné"
 
-#: ../../vdms_panels/presets_manager.py:238
 msgid "Create new preset"
 msgstr "Créer un nouveau profil"
 
-#: ../../vdms_panels/presets_manager.py:240
 msgid "Remove selected preset"
 msgstr "Supprimer le profil sélectionné"
 
-#: ../../vdms_panels/presets_manager.py:242
 msgid "Backup selected preset"
 msgstr "Sauvegarder le profil choisi"
 
-#: ../../vdms_panels/presets_manager.py:244
 msgid "Backup the presets folder"
 msgstr "Sauvegarder le dossier de jeux de profils"
 
-#: ../../vdms_panels/presets_manager.py:246
 msgid "Restore a preset"
 msgstr "Restaurer un profil"
 
-#: ../../vdms_panels/presets_manager.py:248
 msgid "Restore a presets folder"
 msgstr "Restaurer un dossier de jeu de profils"
 
-#: ../../vdms_panels/presets_manager.py:250
 msgid "Resets the selected preset to default values"
 msgstr "Réinitialise le profil sélectionné aux valeurs par défaut"
 
-#: ../../vdms_panels/presets_manager.py:252
 msgid "Reset all presets to default values"
 msgstr "Restaurer tous les jeux de profils par défaut"
 
-#: ../../vdms_panels/presets_manager.py:254
 msgid "Refresh the presets list"
 msgstr "Rafraîchir la liste des jeux de profils"
 
-#: ../../vdms_panels/presets_manager.py:338
 #, python-brace-format
 msgid ""
 "Outdated presets version found: v{1}\n"
@@ -3005,28 +2256,22 @@ msgstr ""
 "\n"
 "Voulez-vous effectuer cette mise à jour maintenant?"
 
-#: ../../vdms_panels/presets_manager.py:403
 msgid "Name"
 msgstr "Nom"
 
-#: ../../vdms_panels/presets_manager.py:405
 msgid "Output Format"
 msgstr "Format de sortie"
 
-#: ../../vdms_panels/presets_manager.py:406
 msgid "Supported Format List"
 msgstr "Liste de formats supportés"
 
-#: ../../vdms_panels/presets_manager.py:531
 #, python-brace-format
 msgid "Cannot save current data in file '{}'."
 msgstr "Impossible d'enregistrer les données dans le fichier'{}'."
 
-#: ../../vdms_panels/presets_manager.py:535
 msgid "You just successfully created a new preset!"
 msgstr "Vous venez de créer un nouveau profil avec succès !"
 
-#: ../../vdms_panels/presets_manager.py:547
 #, python-brace-format
 msgid ""
 "Are you sure you want to remove \"{}\" preset?\n"
@@ -3037,7 +2282,6 @@ msgstr ""
 "\n"
 "Il sera déplacé vers le sous-dossier \"Removals\"  dans le répertoire du jeu de profils."
 
-#: ../../vdms_panels/presets_manager.py:558
 #, python-brace-format
 msgid ""
 "{}\n"
@@ -3048,30 +2292,22 @@ msgstr ""
 "\n"
 "désolé, la suppression a échoué, impossible de continuer."
 
-#: ../../vdms_panels/presets_manager.py:568
 #, python-brace-format
 msgid "The preset \"{0}\" was successfully removed"
 msgstr "Le profil \"{0}\" a été supprimé avec succès"
 
-#: ../../vdms_panels/presets_manager.py:583
-#: ../../vdms_panels/presets_manager.py:612
 msgid "Open a destination folder"
 msgstr "Ouvrir un dossier de destination"
 
-#: ../../vdms_panels/presets_manager.py:588
 msgid "A file with this name already exists, do you want to overwrite it?"
 msgstr "Un fichier avec ce nom existe déjà, voulez-vous l'écraser ?"
 
-#: ../../vdms_panels/presets_manager.py:602
-#: ../../vdms_panels/presets_manager.py:622
 msgid "Backup completed successfully"
 msgstr "Sauvegarde effectuée avec succès"
 
-#: ../../vdms_panels/presets_manager.py:631
 msgid "Open the preset you want to restore"
 msgstr "Ouvrir le profil à restaurer"
 
-#: ../../vdms_panels/presets_manager.py:645
 msgid ""
 "This preset already exists and is about to be updated. Don't worry, it will keep all your saved profiles.\n"
 "\n"
@@ -3081,11 +2317,9 @@ msgstr ""
 "\n"
 "Voulez-vous continuer?"
 
-#: ../../vdms_panels/presets_manager.py:663
 msgid "Restore successful"
 msgstr "Restauration réussie"
 
-#: ../../vdms_panels/presets_manager.py:681
 msgid ""
 "This will update the presets database. Don't worry, it will keep all your saved profiles.\n"
 "\n"
@@ -3095,19 +2329,15 @@ msgstr ""
 "\n"
 "Voulez-vous continuer ?"
 
-#: ../../vdms_panels/presets_manager.py:689
 msgid "Open the presets folder to restore"
 msgstr "Ouvrir le dossier de jeux de profils à restaurer"
 
-#: ../../vdms_panels/presets_manager.py:725
 msgid "The presets database has been successfully updated"
 msgstr "La base de données des jeux de profils a été mise à jour avec succès"
 
-#: ../../vdms_panels/presets_manager.py:740
 msgid "The selected preset is not part of Videomass's default presets."
 msgstr "Le profil sélectionné ne fait pas partie des profils par défaut de  Videomass ."
 
-#: ../../vdms_panels/presets_manager.py:745
 msgid ""
 "Be careful! The selected preset will be overwritten with the default one. Your profiles may be deleted!\n"
 "\n"
@@ -3117,12 +2347,9 @@ msgstr ""
 "\n"
 "Voulez-vous continuer ?"
 
-#: ../../vdms_panels/presets_manager.py:760
-#: ../../vdms_panels/presets_manager.py:794
 msgid "Successful recovery"
 msgstr "Récupération réussie"
 
-#: ../../vdms_panels/presets_manager.py:769
 msgid ""
 "Be careful! This action will restore all presets to default ones. Your profiles may be deleted!\n"
 "\n"
@@ -3136,20 +2363,16 @@ msgstr ""
 "\n"
 "Voulez-vous continuer ?"
 
-#: ../../vdms_panels/presets_manager.py:833
 #, python-brace-format
 msgid "Edit profile on «{0}»"
 msgstr "Éditer un profil sur «{0}»"
 
-#: ../../vdms_panels/presets_manager.py:872
 msgid "Are you sure you want to delete the selected profile? It will no longer be possible to recover it."
 msgstr "Etes vous sûr de vouloir supprimer le profil? Il sera impossible de le récupérer."
 
-#: ../../vdms_panels/presets_manager.py:891
 msgid "First select a profile in the list"
 msgstr "Sélectionnez d'abord un profil dans la liste"
 
-#: ../../vdms_panels/presets_manager.py:899
 msgid ""
 "The selected profile command has been changed manually.\n"
 "Do you want to apply it during the conversion process?"
@@ -3157,11 +2380,9 @@ msgstr ""
 "La commande de profil sélectionnée a été modifiée manuellement..\n"
 "Voulez-vous l'appliquer pendant le processus de conversion?"
 
-#: ../../vdms_panels/presets_manager.py:909
 msgid "Don't show this dialog again"
 msgstr "Ne plus afficher cette boîte de dialogue"
 
-#: ../../vdms_panels/presets_manager.py:1054
 msgid ""
 "Batch processing items\n"
 "Destination\n"
@@ -3181,11 +2402,9 @@ msgstr ""
 "Début du segment\n"
 "Durée du clip"
 
-#: ../../vdms_panels/sequence_to_video.py:54
 msgid "Images need to be resized, please use Resize function."
 msgstr "Les images doivent être redimensionnées, veuillez utiliser la fonction de Redimensionnement."
 
-#: ../../vdms_panels/sequence_to_video.py:73
 msgid ""
 "\n"
 "1. Import one or more image files such as JPG, PNG and BMP formats, then select one.\n"
@@ -3216,11 +2435,9 @@ msgstr ""
 "La vidéo créee aura le nom du fichier sélectionné dans la liste «Fichier en file d'attente» et sera enregistrée dans un dossier nommé «Still_images»'\n"
 "avec un chiffre croissant, dans le repertoire spécifié."
 
-#: ../../vdms_panels/sequence_to_video.py:129
 msgid "Enable a single still image"
 msgstr "Activer une seule image fixe"
 
-#: ../../vdms_panels/sequence_to_video.py:162
 msgid ""
 "Force original aspect ratio using\n"
 "padding rather than stretching"
@@ -3228,28 +2445,21 @@ msgstr ""
 "Forcer le rapport de proportion en utilisant\n"
 "comprimer (padding) plutôt qu'étirer (stretching)"
 
-#: ../../vdms_panels/sequence_to_video.py:170
 msgid "Include audio file"
 msgstr "Inclure un fichier audio"
 
-#: ../../vdms_panels/sequence_to_video.py:173
 msgid "Play the video until audio track finishes"
 msgstr "Lisez la vidéo jusqu'à la fin de la piste audio"
 
-#: ../../vdms_panels/sequence_to_video.py:180
-#: ../../vdms_panels/sequence_to_video.py:439
 msgid "Open audio file"
 msgstr "Ouvrir un fichier audio"
 
-#: ../../vdms_panels/sequence_to_video.py:199
 msgid "Additional arguments"
 msgstr "Arguments supplémentaires"
 
-#: ../../vdms_panels/sequence_to_video.py:454
 msgid "Open Audio File"
 msgstr "Ouvrir Fichier Audio"
 
-#: ../../vdms_panels/sequence_to_video.py:466
 #, python-brace-format
 msgid ""
 "Invalid file: '{}'\n"
@@ -3260,7 +2470,6 @@ msgstr ""
 "\n"
 "{}"
 
-#: ../../vdms_panels/sequence_to_video.py:471
 #, python-brace-format
 msgid ""
 "Invalid file: '{}'\n"
@@ -3271,21 +2480,14 @@ msgstr ""
 "\n"
 "Ceci n'est pas un fichier audio."
 
-#: ../../vdms_panels/sequence_to_video.py:560
-#: ../../vdms_panels/sequence_to_video.py:587
-#: ../../vdms_panels/video_to_sequence.py:511
 #, python-brace-format
 msgid "Invalid file: '{}'"
 msgstr "Fichier non valide '{}'"
 
-#: ../../vdms_panels/sequence_to_video.py:570
-#: ../../vdms_panels/sequence_to_video.py:595
 #, python-brace-format
 msgid "Unsupported format '{}'"
 msgstr "Format non supporté '{}'"
 
-#: ../../vdms_panels/sequence_to_video.py:576
-#: ../../vdms_panels/sequence_to_video.py:600
 #, python-brace-format
 msgid ""
 "File does not exist:\n"
@@ -3296,15 +2498,9 @@ msgstr ""
 "\n"
 "\"{}\"\n"
 
-#: ../../vdms_panels/sequence_to_video.py:577
 msgid "ERROR"
 msgstr "ERREUR"
 
-#: ../../vdms_panels/sequence_to_video.py:707
-msgid "Shortest"
-msgstr ""
-
-#: ../../vdms_panels/sequence_to_video.py:715
 msgid ""
 "Items to concatenate\n"
 "Output filename\n"
@@ -3332,7 +2528,6 @@ msgstr ""
 "Durée image par Seconde\n"
 "Durée Totale de la vidéo"
 
-#: ../../vdms_panels/video_to_sequence.py:50
 msgid ""
 "\n"
 "1. Import one or more video files, then select one.\n"
@@ -3361,51 +2556,39 @@ msgstr ""
 "Les images créées seront enregistrées dans un dossier nommé «Movie_to_Pictures» avec une numérotation croissante \n"
 "dans le repertoire spécifié."
 
-#: ../../vdms_panels/video_to_sequence.py:86
 msgid "Create thumbnails"
 msgstr "Créer des vignettes"
 
-#: ../../vdms_panels/video_to_sequence.py:87
 msgid "Create tiled mosaics"
 msgstr "Créer une mosaîque"
 
-#: ../../vdms_panels/video_to_sequence.py:88
 msgid "Create animated GIF"
 msgstr "Créer un GIF animé"
 
-#: ../../vdms_panels/video_to_sequence.py:90
 msgid "Options"
 msgstr "Options"
 
-#: ../../vdms_panels/video_to_sequence.py:119
 msgid "Output format:"
 msgstr "Format de sortie:"
 
-#: ../../vdms_panels/video_to_sequence.py:131
 msgid "Rows:"
 msgstr "Rangées:"
 
-#: ../../vdms_panels/video_to_sequence.py:141
 msgid "Columns:"
 msgstr "Colonnes:"
 
-#: ../../vdms_panels/video_to_sequence.py:205
 msgid "Other unofficial resources:"
 msgstr "Autres ressources non-officielles:"
 
-#: ../../vdms_panels/video_to_sequence.py:229
 msgid "Set FPS control from 0.1 to 30.0 fps. The higher this value, the more images will be extracted."
 msgstr "Réglez le contrôle FPS de 0,1 à 30,0 fps. Plus cette valeur est élevée, plus d'images seront extraites."
 
-#: ../../vdms_panels/video_to_sequence.py:232
 msgid "Spaces around the mosaic tiles. From 0 to 32 pixels"
 msgstr "Espace autour des mosaïque.d'images.De 0 à 32 pixels"
 
-#: ../../vdms_panels/video_to_sequence.py:234
 msgid "Spaces around the mosaic borders. From 0 to 32 pixels"
 msgstr "Contour autour de la mosaïque d'images.De 0 à 32 pixels"
 
-#: ../../vdms_panels/video_to_sequence.py:626
 msgid ""
 "Selected File\n"
 "Output Format\n"
@@ -3432,60 +2615,48 @@ msgstr ""
 "Début du segment \n"
 "Durée"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:118
 msgid "Audio encoder settings, mapping and filters"
 msgstr "Paramètres de l'encodeur audio, mappage et filtres"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:128
 msgid "Audio Encoder"
 msgstr "Encodeur Audio"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:137
 msgid "Settings"
 msgstr "Réglages"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:148
 msgid "Index Selection:"
 msgstr "Sélection d'Index:"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:157
 msgid "Map:"
 msgstr "Map:"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:180
 msgid "Normalization"
 msgstr "Normalisation"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:191
 msgid "Volume detect"
 msgstr "Détection Volume"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:195
 msgid "Volume Statistics"
 msgstr "Statistiques Volume"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:199
 msgid "Target level:"
 msgstr "Niveau cible:"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:264
 msgid "Gets maximum volume and average volume data in dBFS, then calculates the offset amount for audio normalization."
 msgstr "Obtient les données de volume maximum et de volume moyen en dBFS, puis calcule la quantité de décalage pour la normalisation audio."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:267
 msgid "Limiter for the maximum peak level or the mean level (when switch to RMS) in dBFS. From -99.0 to +0.0; default for PEAK level is -1.0; default for RMS is -20.0"
 msgstr "Limiteur pour l'écrêtage maximum ou le niveau moyen (lors du passage en RMS) en dBFS. De -99,0 à +0,0 ; la valeur par défaut pour le niveau PEAK est -1,0 ; la valeur par défaut pour RMS est -20,0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:271
 msgid ""
 "Normally on a video with correctly indexed streams and having one or more audio streams, the first audio stream should be indexed at \"1\", the second at \"2\" and so on (the video stream on the other hand is always indexed at \"0\"). In this case it is recommended to select the desired stream by setting a specific index, e.g \"1\" for for the first available audio stream.\n"
 "\n"
 "Set this control to \"Auto\" if the source file is simply an audio track."
 msgstr ""
-"Normalement, sur une vidéo avec des flux correctement indexés et ayant un ou plusieurs flux audio, le premier flux audio doit être indexé à « 1 », le second à « 2 » et ainsi de suite (le flux vidéo en revanche est toujours indexé à « 0 »). Dans ce cas, il est recommandé de sélectionner le flux souhaité en définissant un index spécifique, par exemple « 1 » pour le premier flux audio disponible. \n"
+"Normalement, sur une vidéo avec des flux correctement indexés et ayant un ou plusieurs flux audio, le premier flux audio doit être indexé à « 1 », le second à « 2 » et ainsi de suite (le flux vidéo en revanche est toujours indexé à « 0 »). Dans ce cas, il est recommandé de sélectionner le flux souhaité en définissant un index spécifique, par exemple « 1 » pour le premier flux audio disponible."
+" \n"
 "Réglez cette commande sur « Auto » si le fichier source est une unique piste audio."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:280
 msgid ""
 "\"Auto\" keeps all audio streams and processes only the one selected by the \"Index Selection\" control.\n"
 "\n"
@@ -3499,27 +2670,21 @@ msgstr ""
 "\n"
 "\"Index Uniquement » traite uniquement le flux audio sélectionné par la commande « Sélection d'index » et supprime tous les autres de la vidéo"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:288
 msgid "Integrated Loudness Target in LUFS. From -70.0 to -5.0, default is -16.0"
 msgstr "Cible d'intensité volume intégrée dans LUFS.De -70,0 à -5,0, valeur par défaut -16.0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:291
 msgid "Maximum True Peak in dBTP. From -1.5 to +0.0, default is -2.0"
 msgstr "Pic d'écrêtage maximal dans dBTP.De -1.5 à +0,0, la valeur par défaut est -2.0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:294
 msgid "Loudness Range Target in LUFS. From +1.0 to +20.0, default is +11.0"
 msgstr "Cible de plage d'intensité volume dans LUFS. De +1.0 à +20.0, la valeur par défaut est +11.0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:297
 msgid "Play the audio stream selected in the \"Index Selection\" control. Using this function you can test the result of audio normalization."
 msgstr "Lis  le flux audio sélectionné dans la commande « Sélection d'index ». À l'aide de cette fonction, vous pouvez tester le résultat de la normalisation audio."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:503
 msgid "Selected index does not exist or does not contain any audio streams"
 msgstr "L'index sélectionné n'existe pas ou ne contient aucun flux audio"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:508
 #, python-brace-format
 msgid ""
 "ERROR: Missing audio stream:\n"
@@ -3528,15 +2693,12 @@ msgstr ""
 "ERREUR: Aucun flux audio:\n"
 "\"{}\""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:726
 msgid "PEAK level normalization, which will produce a maximum peak level equal to the set target level."
 msgstr "Active la normalisation du niveau d'écrêtage, qui produira un niveau de crête maximal égal au niveau cible définie."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:729
 msgid "RMS-based normalization, which according to mean volume calculates the amount of gain to reach same average power signal."
 msgstr "Active la normalisation basée sur RMS, qui selon le volume moyen calcule la quantité de gain pour atteindre le même signal de puissance moyenne."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:733
 msgid ""
 "Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements the EBU R128 algorithm.\n"
 "Ideal for live normalization. It produces worse results than the High-quality two-pass Loudnorm normalization, but is faster."
@@ -3544,7 +2706,6 @@ msgstr ""
 "Loudnorm normalisation à deux passes. Normalise le volume perçu à l'aide du filtre \"loudnorm\", qui implémente l'algorithme EBU R128.\n"
 "Idéal pour la normalisation en direct. Produit des résultats moins bons que la normalisation Loudnorm à deux passes de haute qualité, mais elle est plus rapide."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:740
 msgid ""
 "High-quality two-pass Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements\n"
 "the EBU R128 algorithm. Ideal for postprocessing."
@@ -3552,23 +2713,18 @@ msgstr ""
 "Normalisation Loudnorm à deux passes de haute qualité. Normalise le volume perçu à l'aide du filtre \"loudnorm\", qui implémente\n"
 "l'algorithme EBU R128. Idéal pour le post-traitement."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:789
 msgid "You need to import at least one file"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:63
 msgid "Subtitle Mapping:"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:77
 msgid "Copy Chapters"
 msgstr "Copier les chapîtres"
 
-#: ../../vdms_panels/miscellaneous/miscell.py:79
 msgid "Copy Metadata"
 msgstr "Copier les metadonnées"
 
-#: ../../vdms_panels/miscellaneous/miscell.py:85
 msgid ""
 "Select \"All\" to include any source file subtitles in the output video.\n"
 "\n"
@@ -3582,147 +2738,63 @@ msgstr ""
 "\n"
 "Cette option est automatiquement ignorée pour les fichiers audio en sortie."
 
-#: ../../vdms_panels/miscellaneous/miscell.py:90
 msgid "Copy the chapter markers as is from source file. This option is automatically ignored for output audio files."
 msgstr "Copiez les marqueurs de chapitre à l'identique du fichier source. Cette option est automatiquement ignorée pour les fichiers de sortie audio."
 
-#: ../../vdms_panels/miscellaneous/miscell.py:93
 msgid "Copy all incoming metadata from source file, such as audio/video tags, titles, unique marks, and so on."
 msgstr "Copiez toutes les métadonnées entrantes à partir du fichier source, telles que des balises audio / vidéo, les titres, des marques uniques, etc."
 
-#: ../../vdms_panels/miscellaneous/miscell.py:108
 msgid "Additional options"
 msgstr "Options supplémentaires"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:89
-#: ../../vdms_panels/video_encoders/av1_svt.py:120
-#: ../../vdms_panels/video_encoders/avc_x264.py:90
-#: ../../vdms_panels/video_encoders/hevc_x265.py:98
-#: ../../vdms_panels/video_encoders/mpeg4.py:71
-#: ../../vdms_panels/video_encoders/vp9_webm.py:131
 msgid "Reload"
 msgstr "Recharger"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:101
-#: ../../vdms_panels/video_encoders/av1_svt.py:129
-#: ../../vdms_panels/video_encoders/avc_x264.py:101
-#: ../../vdms_panels/video_encoders/hevc_x265.py:109
-#: ../../vdms_panels/video_encoders/mpeg4.py:82
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:97
-#: ../../vdms_panels/video_encoders/vp9_webm.py:141
 msgid "Optimize for Web"
 msgstr "Optimisé pour le  Web"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:247
-#: ../../vdms_panels/video_encoders/av1_svt.py:313
-#: ../../vdms_panels/video_encoders/avc_x264.py:242
-#: ../../vdms_panels/video_encoders/hevc_x265.py:250
-#: ../../vdms_panels/video_encoders/mpeg4.py:198
-#: ../../vdms_panels/video_encoders/vp9_webm.py:288
 msgid "Reloads the selected video encoder settings. Changes will be discarded."
 msgstr "Recharge les paramètres de l'encodeur vidéo sélectionnés. Les modifications seront ignorées."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:250
-#: ../../vdms_panels/video_encoders/avc_x264.py:273
-#: ../../vdms_panels/video_encoders/hevc_x265.py:277
-#: ../../vdms_panels/video_encoders/vp9_webm.py:291
 msgid "Constant rate factor. Lower values correspond to higher quality and greater file size. Set to -1 to disable this control."
 msgstr "Facteur de taux constant. Des valeurs plus faibles correspondent à une meilleure qualité et à une taille de fichier plus importante. Réglez sur -1 pour désactiver ce contrôle."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:254
-#: ../../vdms_panels/video_encoders/av1_svt.py:357
-#: ../../vdms_panels/video_encoders/vp9_webm.py:295
 msgid "Number of tile rows to use, default changes per resolution"
 msgstr "Nombre de rangées de tuiles à utiliser, modifications par défaut selon résolution"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:256
-#: ../../vdms_panels/video_encoders/av1_svt.py:359
-#: ../../vdms_panels/video_encoders/vp9_webm.py:297
 msgid "Number of tile columns to use, default changes per resolution"
 msgstr "Nombre de colonnes de tuiles à utiliser, modifications par défaut selon résolution"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:259
-#: ../../vdms_panels/video_encoders/av1_svt.py:368
-#: ../../vdms_panels/video_encoders/avc_x264.py:253
-#: ../../vdms_panels/video_encoders/hevc_x265.py:261
-#: ../../vdms_panels/video_encoders/mpeg4.py:201
-#: ../../vdms_panels/video_encoders/vp9_webm.py:300
 msgid "Set the Group Of Picture (GOP). Set to -1 to disable this control."
 msgstr "Définir la taille du  group of picture (GOP). Mettre à  -1 pour désactiver ce contrôle."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:262
-#: ../../vdms_panels/video_encoders/av1_svt.py:371
-#: ../../vdms_panels/video_encoders/avc_x264.py:256
-#: ../../vdms_panels/video_encoders/hevc_x265.py:264
-#: ../../vdms_panels/video_encoders/mpeg4.py:204
-#: ../../vdms_panels/video_encoders/vp9_webm.py:303
 msgid "It can reduce the file size, but takes longer."
 msgstr "Peut réduire la taille du fichier, mais prend plus de temps."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:264
-#: ../../vdms_panels/video_encoders/av1_svt.py:373
-#: ../../vdms_panels/video_encoders/avc_x264.py:258
-#: ../../vdms_panels/video_encoders/hevc_x265.py:266
-#: ../../vdms_panels/video_encoders/mpeg4.py:206
-#: ../../vdms_panels/video_encoders/vp9_webm.py:305
 msgid "Set minimum bitrate tolerance. Most useful in setting up a CBR encode. It is of little use otherwise. Set to -1 to disable this control."
 msgstr "Définit la tolérance minimale du débit. Le plus utile pour configurer un encodage CBR. Sinon, il n'est pas d'une grande utilité. Réglez sur -1 pour désactiver ce contrôle."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:268
-#: ../../vdms_panels/video_encoders/av1_svt.py:377
-#: ../../vdms_panels/video_encoders/avc_x264.py:262
-#: ../../vdms_panels/video_encoders/hevc_x265.py:270
-#: ../../vdms_panels/video_encoders/mpeg4.py:210
-#: ../../vdms_panels/video_encoders/vp9_webm.py:309
 msgid "Specifies a maximum tolerance. Requires bufsize to be set. Set to -1 to disable this control."
 msgstr "Spécifie une tolérance maximale. Nécessite que bufsize soit réglé. Réglez sur -1 pour désactiver ce contrôle."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:271
-#: ../../vdms_panels/video_encoders/av1_svt.py:380
-#: ../../vdms_panels/video_encoders/avc_x264.py:265
-#: ../../vdms_panels/video_encoders/hevc_x265.py:273
-#: ../../vdms_panels/video_encoders/mpeg4.py:213
-#: ../../vdms_panels/video_encoders/vp9_webm.py:312
 msgid "Set ratecontrol buffer size, which determines the variability of the output bitrate. Set to -1 to disable this control."
 msgstr "Spécifie la taille tampon du décodage, déterminant la variabilité du débit en sortie. Mettre sur -1 pour désactiver ce contrôle."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:275
-#: ../../vdms_panels/video_encoders/av1_svt.py:384
-#: ../../vdms_panels/video_encoders/avc_x264.py:277
-#: ../../vdms_panels/video_encoders/hevc_x265.py:281
-#: ../../vdms_panels/video_encoders/mpeg4.py:231
-#: ../../vdms_panels/video_encoders/vp9_webm.py:316
 msgid "Specifies the target (average) bit rate for the encoder to use. Higher value = higher quality. Set -1 to disable this control."
 msgstr "Spécifie le débit binaire cible (moyen) que l'encodeur doit utiliser. Valeur supérieure = meilleure qualité.Réglez sur -1 pour désactiver ce contrôle."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:279
-#: ../../vdms_panels/video_encoders/av1_svt.py:388
-#: ../../vdms_panels/video_encoders/avc_x264.py:281
-#: ../../vdms_panels/video_encoders/hevc_x265.py:285
-#: ../../vdms_panels/video_encoders/mpeg4.py:235
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:131
-#: ../../vdms_panels/video_encoders/vp9_webm.py:320
 msgid "Video width and video height ratio."
 msgstr "Proportions largeur/ hauteur de la vidéo."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:281
-#: ../../vdms_panels/video_encoders/av1_svt.py:390
-#: ../../vdms_panels/video_encoders/avc_x264.py:283
-#: ../../vdms_panels/video_encoders/hevc_x265.py:287
-#: ../../vdms_panels/video_encoders/mpeg4.py:237
-#: ../../vdms_panels/video_encoders/vp9_webm.py:322
 msgid "Frame rate (frames per second). Frames repeat a given number of times per second. In some countries this is 30 for NTSC, other countries (like Italy) use 25 for PAL"
 msgstr "Fréquence d'images (images par seconde). Les images se répètent un certain nombre de fois par seconde. Dans certains pays, c'est 30 pour NTSC, d'autres pays (comme l'Italie) utilisent 25 pour PAL"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:285
 msgid "Quality/Speed ratio modifier. CPU Used sets how efficient the compression will be. Lower values mean slower encoding with better quality, and vice-versa. Valid values are from 0 to 8 inclusive."
 msgstr "Modificateur de rapport qualité/vitesse. Le processeur utilisé définit l'efficacité de la compression. Des valeurs plus faibles signifient un encodage plus lent avec une meilleure qualité, et vice-versa. Les valeurs valides sont comprises entre 0 et 8 inclus."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:290
 msgid "Quality and compression efficiency vs speed trade-off. \"good\" is the default and recommended for most applications; \"realtime\" is recommended for live/fast encoding (live streaming, video conferencing, etc); \"allintra\" for All Intra encoding."
 msgstr "Qualité et efficacité de compression par rapport à la vitesse. « good » est la valeur par défaut et recommandé pour la plupart des applications ; « RealTime » est recommandé pour l'encodage en direct/rapide (streaming en direct, vidéoconférence, etc.) ; « allintra » pour l'encodage All Intra."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:297
 msgid ""
 "Row Multi-Threading enables row-based multi-threading which maximizes CPU usage.\n"
 "\n"
@@ -3736,7 +2808,6 @@ msgstr ""
 "\n"
 "L'activation du multithreading de ligne n'est plus rapide que lorsque le processeur a plus de threads que le nombre de tuiles encodées."
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:316
 msgid ""
 "presets 1-3 represent extremely high efficiency, for use when encode time is not important and quality/size of the resulting video file is critical.\n"
 "\n"
@@ -3754,7 +2825,6 @@ msgstr ""
 "\n"
 "Le profil 13 est encore plus rapide, mais n'est pas destiné à usage humain - il peut être utilisé, par exemple, comme mesure de qualité par scène dans les applications de VOD. Il faut utiliser le préréglage le plus bas tolérable."
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:327
 msgid ""
 "Constant rate factor. This parameter governs the quality/size trade-off.\n"
 "\n"
@@ -3772,7 +2842,6 @@ msgstr ""
 "\n"
 "Réglez sur -1 pour désactiver ce contrôle."
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:334
 msgid ""
 "The \"Film Grain\" parameter allows SVT-AV1 to detect and delete film grain from the source video, and replace it with synthetic grain of the same character, resulting in significant bitrate savings.\n"
 "\n"
@@ -3794,7 +2863,6 @@ msgstr ""
 "\n"
 "Si la vidéo source n'a pas de grain naturel, ce paramètre peut être réglé sur -1 pour le désactiver ou au moins 0."
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:346
 msgid ""
 "If enabled, the \"Film Grain Denoiser\" option can mitigate the detail removal caused by high \"Film Grain\" values required to preserve the look of very grainy films\n"
 "\n"
@@ -3804,64 +2872,44 @@ msgstr ""
 "\n"
 "Par défaut, les images débruitées sont transmises pour être encodées en tant qu'images finales, l'activation de cette fonctionnalité conduira à l'utilisation des images d'origine à la place. "
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:353
 msgid "Enables encoder optimization to produce faster (less CPU intensive) bit streams to decode, similar to the fastdecode tuning in x264 and x265."
 msgstr "Permet l'optimisation de l'encodeur pour produire des flux plus rapides (moins gourmands en CPU) à décoder, similaires au réglage fastdecode dans x264 et x265."
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:362
-#: ../../vdms_panels/video_encoders/avc_x264.py:247
-#: ../../vdms_panels/video_encoders/hevc_x265.py:255
 msgid "Set profile restrictions"
 msgstr "Définir les restrictions du profil"
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:364
-#: ../../vdms_panels/video_encoders/avc_x264.py:249
-#: ../../vdms_panels/video_encoders/hevc_x265.py:257
 msgid "Specify level for a selected profile"
 msgstr "Spécifier le niveau du profil sélectionné"
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:366
-#: ../../vdms_panels/video_encoders/avc_x264.py:251
-#: ../../vdms_panels/video_encoders/hevc_x265.py:259
 msgid "Tune the encoding params"
 msgstr "Réglages des paramètres d'encodage"
 
-#: ../../vdms_panels/video_encoders/avc_x264.py:245
-#: ../../vdms_panels/video_encoders/hevc_x265.py:253
 msgid "Set the encoding preset (default \"medium\")"
 msgstr "Définir le profil de l\"encodage (défaut\"medium\")"
 
-#: ../../vdms_panels/video_encoders/avc_x264.py:269
 msgid "specifies the target (average) bit rate for the encoder to use. Higher value = higher quality. Set -1 to disable this control."
 msgstr "spécifie le débit binaire cible (moyen) pour l'encodeur. Valeur supérieure = meilleure qualité.Réglez sur -1 pour désactiver ce contrôle."
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:217
 msgid "Variable Bit Rate. From 0-30, with 1 being highest quality/largest filesize and 30 being the lowest quality/smallest filesize. Set to -1 to disable this control."
 msgstr "Bit Rate variable. De 0 à 30, 1 étant la qualité la plus élevée/la taille de fichier la plus élevée et 30 étant la qualité la plus basse/la plus petite taille de fichier. Réglez sur -1 pour désactiver ce contrôle."
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:222
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:133
 msgid "Frames repeat a given number of times per second. In some countries this is 30 for NTSC, other countries (like Italy) use 25 for PAL"
 msgstr "Les images se répètent un nombre donné de fois par seconde. Dans certains pays, c'est 30 pour le NTSC, dans d'autres pays (comme l'Italie) on utilise 25 pour le PAL"
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:226
 msgid "The default FourCC stored in an MPEG-4-coded file will be FMP4. If you want a different FourCC, set this option to xvid to force the FourCC xvid to be stored as the video FourCC rather than the default."
 msgstr "Le FourCC par défaut stocké dans un fichier codé en MPEG-4 sera FMP4. Si vous voulez un FourCC différent, réglez cette option sur xvid pour forcer le FourCC xvid à être stocké en tant que vidéo FourCC plutôt que par défaut."
 
 # | msgid "Video Codec"
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:162
 #, fuzzy
 msgid "Copy Video Codec"
 msgstr "Codec Vidéo"
 
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:163
 msgid ""
 "This will just copy the video track as is, without any video re-encoding.\n"
 "You will only be able to change output format, select other audio encoders and\n"
 "a few other options."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_no_enc.py:74
 msgid "Video export disabled"
 msgstr ""
 
@@ -3872,7 +2920,6 @@ msgstr ""
 # "
 # | "to\n"
 # | "video files."
-#: ../../vdms_panels/video_encoders/video_no_enc.py:75
 #, fuzzy
 msgid ""
 "The Media target you just selected will only allow you to export files as audio tracks.\n"
@@ -3883,7 +2930,6 @@ msgstr ""
 "Vous pouvez ensuite traiter des fichiers sources audio ou extraire des flux audio indexés sur\n"
 "fichiers vidéo."
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:326
 msgid ""
 "Speed sets how efficient the compression will be.\n"
 "\n"
@@ -3905,7 +2951,6 @@ msgstr ""
 "\n"
 "Lorsque la qualité est définie sur temps réel, les valeurs disponibles pour la vitesse sont comprises entre 0 et 8."
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:335
 msgid ""
 "Time to spend encoding.\n"
 "\n"
@@ -3923,24 +2968,23 @@ msgstr ""
 "\n"
 "\"en temps réel\" est recommandé pour le codage direct / rapide"
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:341
-msgid "If enabled, adds support for row based multithreading which greatly enhances the number of threads the encoder can utilise. This improves encoding speed significantly on systems that are otherwise underutilised when encoding VP9. Since the amount of additional threads depends on the number of \"tiles\", which itself depends on the video resolution, encoding higher resolution videos will see a larger performance improvement."
-msgstr "S'il est activé, ajoute la prise en charge du multithreading basé qui améliore considérablement le nombre de threads que l'encodeur peut utiliser. Cela améliore considérablement la vitesse d'encodage sur des systèmes qui sont autrement sous-utilisés lors de l'encodage  VP9. Étant donné que la quantité de threads supplémentaires dépend du nombre de \"tiles\", qui dépend lui-même de la résolution vidéo, les vidéos de résolution plus élevée verront une amélioration des performances plus importante."
+msgid ""
+"If enabled, adds support for row based multithreading which greatly enhances the number of threads the encoder can utilise. This improves encoding speed significantly on systems that are otherwise underutilised when encoding VP9. Since the amount of additional threads depends on the number of \"tiles\", which itself depends on the video resolution, encoding higher resolution videos will see a "
+"larger performance improvement."
+msgstr ""
+"S'il est activé, ajoute la prise en charge du multithreading basé qui améliore considérablement le nombre de threads que l'encodeur peut utiliser. Cela améliore considérablement la vitesse d'encodage sur des systèmes qui sont autrement sous-utilisés lors de l'encodage  VP9. Étant donné que la quantité de threads supplémentaires dépend du nombre de \"tiles\", qui dépend lui-même de la résolution"
+" vidéo, les vidéos de résolution plus élevée verront une amélioration des performances plus importante."
 
-#: ../../vdms_utils/presets_manager_utils.py:46
 #, python-brace-format
 msgid "Supports ({0}) formats only, not ({1})"
 msgstr "Supportse({0}) uniquement les formats, pas ({1})"
 
-#: ../../vdms_utils/presets_manager_utils.py:49
 msgid "File formats not supported by the selected profile"
 msgstr "Formats de fichier non supporté par le profil"
 
-#: ../../vdms_utils/presets_manager_utils.py:52
 msgid "Warning"
 msgstr "Attention"
 
-#: ../../vdms_utils/presets_manager_utils.py:90
 msgid ""
 "No presets found.\n"
 "\n"
@@ -3950,11 +2994,9 @@ msgstr ""
 "\n"
 "Solution possible: ouvrir le panneau du Gestionnaire de Profils, accédez à la colonne Pofils et essayez de cliquer sur le bouton \"Restaurer tout ...\""
 
-#: ../../vdms_utils/queue_utils.py:54
 msgid "Import queue file"
 msgstr "Importer le fichier de file d'attente"
 
-#: ../../vdms_utils/queue_utils.py:89
 #, python-brace-format
 msgid ""
 "ERROR: invalid data found loading queue file.\n"
@@ -3967,11 +3009,9 @@ msgstr ""
 "\n"
 "Ne peut pas contenir plusieurs occurrences dans la valeur des clés 'destination'."
 
-#: ../../vdms_utils/queue_utils.py:118
 msgid "Videomass - Add Items to Queue"
 msgstr "Videomass - Ajouter des éléments à la file d'attente"
 
-#: ../../vdms_utils/queue_utils.py:119
 msgid ""
 "Multiple items with identical names and destination paths cannot coexist.\n"
 "Please choose one of the following actions:"
@@ -3979,15 +3019,12 @@ msgstr ""
 "Plusieurs éléments portant des noms et des chemins de destination identiques ne peuvent coexister. \n"
 "Veuillez choisir l'une des actions suivantes :"
 
-#: ../../vdms_utils/queue_utils.py:123
 msgid "Replace occurrences with items from the imported queue."
 msgstr "Remplacez les occurrences par des éléments de la file d'attente importée."
 
-#: ../../vdms_utils/queue_utils.py:124
 msgid "Add only the currently missing items to the queue."
 msgstr "N'ajoutez que les éléments actuellement manquants à la file d'attente."
 
-#: ../../vdms_utils/queue_utils.py:125
 msgid "Remove the current queue and replace it with the imported one."
 msgstr "Supprimez la file d'attente actuelle et remplacez-la par la file d'attente importée."
 
@@ -3999,4 +3036,7 @@ msgstr "Supprimez la file d'attente actuelle et remplacez-la par la file d'atten
 
 #~ msgid "Subtitle Mapping"
 #~ msgstr "Subtitle Mapping"
+
+#~ msgid "Shortest"
+#~ msgstr ""
 

--- a/videomass/data/locale/fr_FR/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/fr_FR/LC_MESSAGES/videomass.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Videomass 5.0.14\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-30 11:02+0200\n"
+"POT-Creation-Date: 2025-07-30 15:28+0200\n"
 "PO-Revision-Date: 2024-08-18 00:59+0200\n"
 "Last-Translator: Phil Aug <philiaug@live.fr>\n"
 "Language: fr_FR\n"
@@ -3027,16 +3027,4 @@ msgstr "N'ajoutez que les éléments actuellement manquants à la file d'attente
 
 msgid "Remove the current queue and replace it with the imported one."
 msgstr "Supprimez la file d'attente actuelle et remplacez-la par la file d'attente importée."
-
-#~ msgid "Some text boxes are still incomplete"
-#~ msgstr "Certaines options de texte sont  incomplètes"
-
-#~ msgid "FFplay"
-#~ msgstr "FFplay"
-
-#~ msgid "Subtitle Mapping"
-#~ msgstr "Subtitle Mapping"
-
-#~ msgid "Shortest"
-#~ msgstr ""
 

--- a/videomass/data/locale/hu_HU/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/hu_HU/LC_MESSAGES/videomass.po
@@ -1,13 +1,13 @@
-# Hungarian (Hungary) translations for PROJECT.
-# Copyright (C) 2024 ORGANIZATION
-# This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+# Hungarian (Hungary) translations for Videomass.
+# Copyright (C) 2025 ORGANIZATION
+# This file is distributed under the same license as the Videomass project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-26 15:04+0200\n"
+"POT-Creation-Date: 2025-07-30 11:02+0200\n"
 "PO-Revision-Date: 2024-07-17 16:31+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: hu_HU\n"
@@ -18,7 +18,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
-#: ../../gui_app.py:196
 #, python-brace-format
 msgid ""
 "Unexpected error while deleting file contents:\n"
@@ -26,162 +25,111 @@ msgid ""
 "{0}"
 msgstr ""
 
-#: ../../vdms_dialogs/about_dialog.py:52
 msgid "Cross-platform graphical user interface for FFmpeg\n"
 msgstr ""
 
-#: ../../vdms_dialogs/audioproperties.py:224
 msgid "Videomass supports mono and stereo audio channels. If you are not sure set to \"Auto\" and source values will be copied."
 msgstr ""
 
-#: ../../vdms_dialogs/audioproperties.py:228
 msgid "The audio Rate (or sample-rate) is the sound sampling frequency and is measured in Hertz. The higher the frequency, the more true it will be to the sound source and the more the file will increase in size. For audio CD playback, set a sampling frequency of 44100 kHz. If you are not sure, set to \"Auto\" and source values will be copied."
 msgstr ""
 
-#: ../../vdms_dialogs/audioproperties.py:237
 msgid "The audio bitrate affects the file compression and thus the quality of listening. The higher the value, the higher the quality."
 msgstr ""
 
-#: ../../vdms_dialogs/audioproperties.py:241
 msgid "Bit depth is the number of bits of information in each sample, and it directly corresponds to the resolution of each sample. Bit depth is only meaningful in reference to a PCM digital signal. Non-PCM formats, such as lossy compression formats, do not have associated bit depths."
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:74 ../../vdms_dialogs/queuedlg.py:120
 msgid "When finished, once the operations have been completed successfully:"
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:80 ../../vdms_dialogs/queuedlg.py:126
 msgid "Trash the source files"
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:84 ../../vdms_dialogs/queuedlg.py:130
 msgid "Clear the File List"
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:91 ../../vdms_dialogs/queuedlg.py:142
-#: ../../vdms_main/main_frame.py:1322
 msgid "Run"
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:97
 msgid "Videomass - Batch Mode"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:47
 msgid "FFmpeg encoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:48
 msgid "supported encoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:50
 msgid "FFmpeg decoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:51
 msgid "supported decoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:77
-#: ../../vdms_panels/av_conversions.py:293
 msgid "Video"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:87
-#: ../../vdms_panels/av_conversions.py:305
 msgid "Audio"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:97
 msgid "Subtitle"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:114
-#: ../../vdms_dialogs/ffmpeg_codecs.py:123
-#: ../../vdms_dialogs/ffmpeg_codecs.py:132
-#: ../../vdms_dialogs/ffmpeg_formats.py:112
-#: ../../vdms_dialogs/ffmpeg_formats.py:115
-#: ../../vdms_dialogs/ffmpeg_formats.py:118
 msgid "description"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:72
 msgid "Informations"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:83
 msgid "Flags settings"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:93
 msgid "Flags enabled"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:103
 msgid "Flags disabled"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:116
 msgid "FFmpeg configuration"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:124
 msgid "flags"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:125 ../../vdms_dialogs/ffmpeg_conf.py:129
-#: ../../vdms_dialogs/ffmpeg_conf.py:133
 msgid "options"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:128 ../../vdms_dialogs/ffmpeg_conf.py:132
 msgid "status"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:167
 msgid "FFprobe   ...not found !"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:175
 msgid "FFplay   ...not found !"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:205
-#: ../../vdms_panels/sequence_to_video.py:706
-#: ../../vdms_panels/video_to_sequence.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:216
-#: ../../vdms_panels/sequence_to_video.py:706
-#: ../../vdms_panels/video_to_sequence.py:610
 msgid "Disabled"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:71
 msgid "Demuxing only"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:82
 msgid "Muxing only"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:93
 msgid "Demuxing/Muxing support"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:104
 msgid "FFmpeg file formats"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:111
-#: ../../vdms_dialogs/ffmpeg_formats.py:114
-#: ../../vdms_dialogs/ffmpeg_formats.py:117
 msgid "supported formats"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:46
 msgid ""
 "Contextual help based on the argument entered in the additional text field.\n"
 "Each argument consists of the type and a type-specific name.\n"
@@ -196,117 +144,84 @@ msgid ""
 "Some examples:"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:68 ../../vdms_dialogs/ffmpeg_help.py:301
-#: ../../vdms_dialogs/ffmpeg_help.py:315
 msgid "Help topic"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:69
 msgid "List basic options"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:70
 msgid "List more options"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:71
 msgid "List all options (very long)"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:72
 msgid "Show available devices"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:73
 msgid "Show available bit stream filters"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:74
 msgid "Show available protocols"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:75
 msgid "Show available filters"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:76
 msgid "Show available pixel formats"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:77
 msgid "Show available audio sample formats"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:78
 msgid "Show available color names"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:79
 msgid "List sources of the input device"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:80
 msgid "List sinks of the output device"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:81
 msgid "Show available HW acceleration methods"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:82
 msgid "Show license"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:117 ../../vdms_dialogs/filter_scale.py:76
-#: ../../vdms_dialogs/shownormlist.py:98 ../../vdms_dialogs/shownormlist.py:107
-#: ../../vdms_dialogs/shownormlist.py:116 ../../vdms_miniframes/timeline.py:263
-#: ../../vdms_miniframes/timeline.py:283 ../../vdms_panels/concatenate.py:117
-#: ../../vdms_panels/sequence_to_video.py:117
-#: ../../vdms_panels/video_to_sequence.py:81
 msgid "Read me"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:123 ../../vdms_main/main_frame.py:534
 msgid "Show configuration"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:127 ../../vdms_main/main_frame.py:542
 msgid "Encoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:131 ../../vdms_main/main_frame.py:545
 msgid "Decoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:135 ../../vdms_main/main_frame.py:538
 msgid "Muxers and Demuxers"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:165
 msgid "help topic list"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:184
 msgid "Type the argument here and confirm with the enter key on your keyboard"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:192
 msgid "The search function allows you to find entries in the current topic"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:195
 msgid "Ignore case"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:196
 msgid "Ignore case distinctions: characters with different case will match."
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:206
 msgid "FFmpeg help topics"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:254
 msgid ""
 "This is a multifunctional search tool useful for local help searches\n"
 "on multiple FFmpeg topics and options. The search control, to\n"
@@ -319,942 +234,647 @@ msgid ""
 "with those features."
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:320 ../../vdms_dialogs/ffmpeg_help.py:345
-#: ../../vdms_dialogs/ffmpeg_help.py:371
 msgid ""
 "\n"
 "  ..Nothing available"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:391
 msgid ""
 "\n"
 "  ..Not found"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:91
 msgid "Before"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:97
 msgid "After"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:103
-#: ../../vdms_dialogs/filter_crop.py:239
 msgid "Search for a specific frame"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:117
-#: ../../vdms_dialogs/filter_crop.py:253
 msgid "Load"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:120
 msgid "Color EQ"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:126
 msgid "Contrast:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:134
-#: ../../vdms_dialogs/filter_colorcorrection.py:148
 msgid "-100 to +100, default value 0"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:139
 msgid "Brightness:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:158
 msgid "Saturation:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:166
 msgid "0 to 300, default value 100"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:170
 msgid "Gamma:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:179
 msgid "0 to 100, default value 10"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:187
-#: ../../vdms_dialogs/filter_crop.py:306
-#: ../../vdms_dialogs/filter_deinterlace.py:209
-#: ../../vdms_dialogs/filter_denoisers.py:110
-#: ../../vdms_dialogs/filter_scale.py:210 ../../vdms_dialogs/filter_stab.py:316
-#: ../../vdms_dialogs/filter_transpose.py:105
-#: ../../vdms_miniframes/timeline.py:262 ../../vdms_miniframes/timeline.py:281
 msgid "Reset"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:207
 msgid "Color Correction EQ Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:343
-#: ../../vdms_dialogs/filter_colorcorrection.py:383
-#: ../../vdms_dialogs/filter_colorcorrection.py:390
-#: ../../vdms_dialogs/filter_crop.py:417 ../../vdms_dialogs/filter_scale.py:287
-#: ../../vdms_dialogs/filter_scale.py:394 ../../vdms_dialogs/filter_stab.py:473
-#: ../../vdms_dialogs/filter_stab.py:483 ../../vdms_dialogs/filter_stab.py:494
-#: ../../vdms_dialogs/filter_transpose.py:182
-#: ../../vdms_dialogs/mediainfo.py:245 ../../vdms_dialogs/mediainfo.py:265
-#: ../../vdms_dialogs/mediainfo.py:285 ../../vdms_dialogs/mediainfo.py:305
-#: ../../vdms_dialogs/setting_profiles.py:281
-#: ../../vdms_dialogs/setting_profiles.py:289 ../../vdms_io/checkup.py:45
-#: ../../vdms_io/checkup.py:93 ../../vdms_io/io_tools.py:144
-#: ../../vdms_main/main_frame.py:904 ../../vdms_main/main_frame.py:939
-#: ../../vdms_main/main_frame.py:961 ../../vdms_main/main_frame.py:979
-#: ../../vdms_main/main_frame.py:999
-#: ../../vdms_panels/audio_encoders/acodecs.py:510
-#: ../../vdms_panels/audio_encoders/acodecs.py:800
-#: ../../vdms_panels/concatenate.py:186
-#: ../../vdms_panels/long_processing_task.py:60
-#: ../../vdms_panels/presets_manager.py:426
-#: ../../vdms_panels/presets_manager.py:490
-#: ../../vdms_panels/presets_manager.py:560
-#: ../../vdms_panels/presets_manager.py:599
-#: ../../vdms_panels/presets_manager.py:619
-#: ../../vdms_panels/presets_manager.py:657
-#: ../../vdms_panels/presets_manager.py:701
-#: ../../vdms_panels/presets_manager.py:714
-#: ../../vdms_panels/presets_manager.py:721
-#: ../../vdms_panels/presets_manager.py:756
-#: ../../vdms_panels/presets_manager.py:785
-#: ../../vdms_panels/presets_manager.py:791
-#: ../../vdms_panels/sequence_to_video.py:467
-#: ../../vdms_panels/sequence_to_video.py:473
-#: ../../vdms_panels/sequence_to_video.py:561
-#: ../../vdms_panels/sequence_to_video.py:571
-#: ../../vdms_panels/sequence_to_video.py:588
-#: ../../vdms_panels/sequence_to_video.py:596
-#: ../../vdms_panels/sequence_to_video.py:602
-#: ../../vdms_panels/sequence_to_video.py:643
-#: ../../vdms_panels/sequence_to_video.py:689
-#: ../../vdms_panels/video_to_sequence.py:512
-#: ../../vdms_panels/video_to_sequence.py:583
-#: ../../vdms_threads/ffplay_file.py:43
-#: ../../vdms_utils/presets_manager_utils.py:86
-#: ../../vdms_utils/presets_manager_utils.py:95
-#: ../../vdms_utils/queue_utils.py:68 ../../vdms_utils/queue_utils.py:82
-#: ../../vdms_utils/queue_utils.py:95
 msgid "Videomass - Error!"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:228 ../../vdms_dialogs/filter_scale.py:109
 #, python-brace-format
 msgid "Source size: {0} x {1} pixels"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:236
 msgid "Crop color"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:256
 msgid "Cropping area selection "
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:261 ../../vdms_dialogs/filter_scale.py:121
 msgid "Height"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:281
 msgid "Center"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:292 ../../vdms_dialogs/filter_scale.py:121
 msgid "Width"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:334
 msgid "Crop Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:335
 msgid "Choose the color to draw the cropping area"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:337
 msgid "Crop to width"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:338
 msgid "Move vertically (set to -1 to center the vertical axis)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:340
 msgid "Move horizontally (set to -1 to center the horizontal axis)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:342
 msgid "Crop to height"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:56
 msgid "Advanced Options"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:57
-#: ../../vdms_panels/av_conversions.py:351
 msgid "Deinterlace"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:59
 msgid "Interlace"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:63
 msgid "Deinterlaces with w3fdif filter"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:77
 msgid "Deinterlaces with yadif filter"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:101
 msgid "Interlaces with interlace filter"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:118
 msgid "Deinterlacing and Interlacing"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:144
 msgid "Deinterlace the input video with `w3fdif` filter"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:146
 msgid "Set the interlacing filter coefficients."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:148
-#: ../../vdms_dialogs/filter_deinterlace.py:158
 msgid "Specify which frames to deinterlace."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:150
 msgid "Deinterlace the input video with `yadif` filter. Using FFmpeg, this is the best and fastest choice"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:153
 msgid ""
 "mode\n"
 "The interlacing mode to adopt."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:155
 msgid ""
 "parity\n"
 "The picture field parity assumed for the input interlaced video."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:160
 msgid "Simple interlacing filter from progressive contents."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:162
 msgid ""
 "scan:\n"
 "determines whether the interlaced frame is taken from the even (tff - default) or odd (bff) lines of the progressive frame."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:166
 msgid ""
 "lowpass:\n"
 "Enable (default) or disable the vertical lowpass filter to avoid twitter interlacing and reduce moire patterns.\n"
 "Default is no setting."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:56
 msgid "Denoiser Filters"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:60
 msgid "Enable nlmeans denoiser"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:73
 msgid "nlmeans options"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:82
 msgid "Enable hqdn3d denoiser"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:91
 msgid "hqdn3d options"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:116
 msgid "Denoiser Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:117
 msgid ""
 "nlmeans:\n"
 "Denoise frames using Non-Local Means algorithm is capable of restoring video sequences, even with strong noise. It is ideal for enhancing the quality of old VHS tapes."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:122
 msgid ""
 "hqdn3d:\n"
 "This is a high precision/quality 3d denoise filter. It aims to reduce image noise, producing smooth images and making still images really still. It should enhance compressibility."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:81
 msgid "View result"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:85
 msgid "New size in pixels"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:89
 msgid "Width:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:99
 msgid "Height:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:115
 msgid "Constrain proportions (keep aspect ratio)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:120
 msgid "Which dimension to adjust?"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:129
 msgid "Aspect Ratio"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:132
 msgid "Setdar filter (display aspect ratio) example 16/9, 4/3 "
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:137
-#: ../../vdms_dialogs/filter_scale.py:171
 msgid "Numerator"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:162
-#: ../../vdms_dialogs/filter_scale.py:196
 msgid "Denominator"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:166
 msgid "Setsar filter (sample aspect ratio) example 1/1"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:217
 msgid "Resize Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:218
 msgid "Scale filter, set to 0 to disable"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:221
 msgid "Display Aspect Ratio. Set to 0 to disable"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:224
 msgid ""
 "Sample (aka Pixel) Aspect Ratio.\n"
 "Set to 0 to disable"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:366
 msgid ""
 "If you want to keep the aspect ratio, select \"Constrain proportions\" below and\n"
 "specify only one dimension, either width or height, and set the other dimension\n"
 "to -1 or -2 (some codecs require -2, so you should do some testing first)."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:81
 msgid "Enable stabilizer"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:83
 msgid "Create a side-by-side comparison video"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:88
 msgid "Create a snapshot"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:106
-#: ../../vdms_panels/audio_encoders/acodecs.py:167
 msgid "Preview"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:109
 msgid "Duration seconds:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:118
 msgid "Video Detect"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:176
 msgid "[TRIPOD] Enable tripod mode if checked"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:183
 msgid "Video transform"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:202
 msgid "[OPTALGO] optimization algorithm"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:224
 msgid "[CROP] Specify how to deal with borders at movement compensation"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:231
 msgid "[INVERT] Invert transforms if checked"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:234
 msgid "[RELATIVE] Consider transforms as relative to previous frame if checked, absolute if unchecked"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:279
 msgid "Specify type of interpolation"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:287
 msgid "[TRIPOD2] virtual tripod mode, equivalent to relative=unchecked:smoothing=0"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:294
 msgid "Unsharp filter:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:323
 msgid "Seek to a position on the video."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:325
 msgid "Make a snapshot of the video with the settings made."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:327
 msgid "Set the snapshot duration from 3 to 15 seconds from the seek position, default is 5 seconds."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:331
 msgid "Set how shaky the video is and how quick the camera is. A value of 1 means little shakiness, a value of 10 means strong shakiness. Default value is 5."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:335
 msgid "Set the accuracy of the detection process. A value of 1 means low accuracy, a value of 15 means high accuracy. Default value is 15."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:339
 msgid "Set stepsize of the search process. The region around minimum is scanned with 1 pixel resolution. Default value is 6."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:343
 msgid "Set minimum contrast. Below this value a local measurement field is discarded. The range is 0-1. Default value is 0.25."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:346
 msgid "Set reference frame number for tripod mode. If enabled, the motion of the frames is compared to a reference frame in the filtered stream, identified by the specified number. The idea is to compensate all movements in a more-or-less static scene and keep the camera view absolutely still. The frames are counted starting from 1."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:355
-msgid "Set the number of frames (value*2 + 1) used for lowpass filtering the camera movements. Default value is 15. For example a number of 10 means that 21 frames are used (10 in the past and 10 in the future) to smoothen the motion in the video. A larger value leads to a smoother video, but limits the acceleration of the camera (pan/tilt movements). 0 is a special case where a static camera is simulated."
+msgid ""
+"Set the number of frames (value*2 + 1) used for lowpass filtering the camera movements. Default value is 15. For example a number of 10 means that 21 frames are used (10 in the past and 10 in the future) to smoothen the motion in the video. A larger value leads to a smoother video, but limits the acceleration of the camera (pan/tilt movements). 0 is a special case where a static camera is "
+"simulated."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:363
 msgid "Set the camera path optimization algorithm. Values are: `gauss`: gaussian kernel low-pass filter on camera motion (default), and `avg`: averaging on transformations"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:367
 msgid "Set maximal angle in radians (degree*PI/180) to rotate frames. Default value is -1, meaning no limit."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:370
 msgid "Specify how to deal with borders that may be visible due to movement compensation. Values are: `keep` keep image information from previous frame (default), `black` fill the border black"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:375
 msgid "Invert transforms if checked. Default is unchecked."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:377
 msgid "Consider transforms as relative to previous frame if checked, absolute if unchecked. Default is checked."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:380
 msgid "Set percentage to zoom. A positive value will result in a zoom-in effect, a negative value in a zoom-out effect. Default value is 0 (no zoom)."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:384
 msgid "Set optimal zooming to avoid borders. Accepted values are: `0` disabled, `1` optimal static zoom value is determined (only very strong movements will lead to visible borders) (default), `2` optimal adaptive zoom value is determined (no borders will be visible), see zoomspeed. Note that the value given at zoom is added to the one calculated here."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:391
 msgid "Set percent to zoom maximally each frame (enabled when optzoom is set to 2). Range is from 0 to 5, default value is 0.25."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:395
 msgid "Specify type of interpolation. Available values are: `no` no interpolation, `linear` linear only horizontal, `bilinear` linear in both directions (default), `bicubic` cubic in both directions (slow)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:400
 msgid "Enable virtual tripod mode if checked, which is equivalent to relative=0:smoothing=0. Default is unchecked. Use also tripod option of vidstabdetect."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:405
 msgid "Sharpen or blur the input video. Note the use of the unsharp filter which is always recommended."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:409
 msgid "Video Stabilizer Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:541 ../../vdms_io/io_tools.py:73
 msgid "Videomass - Loading..."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:542
 msgid ""
 "Please wait,\n"
 "This process will take a few seconds."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:80
-#: ../../vdms_dialogs/filter_transpose.py:293
 msgid "Default position"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:86
 msgid "Rotation setting"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:94
 msgid "90° (left)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:96
 msgid "90° (right)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:100
 msgid "180°"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:115
 msgid "Transpose Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:229
 msgid "Rotate 90 degrees right"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:251
 msgid "Rotate 180 degrees"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:272
 msgid "Rotate 90 degrees left"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:82
 msgid "Format"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:96
 msgid "Video Stream"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:109
 msgid "Audio Streams"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:122
 msgid "Subtitle Streams"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:126
 msgid "Copy to clipboard"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:137
 msgid "FILE SELECTION"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:139 ../../vdms_dialogs/mediainfo.py:142
-#: ../../vdms_dialogs/mediainfo.py:145 ../../vdms_dialogs/mediainfo.py:148
-#: ../../vdms_main/main_frame.py:1318
 msgid "Properties"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:140 ../../vdms_dialogs/mediainfo.py:143
-#: ../../vdms_dialogs/mediainfo.py:146 ../../vdms_dialogs/mediainfo.py:149
 msgid "Values"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:152
 msgid "Streams Properties"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:244
 msgid "Unable to open the clipboard on Format tab"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:263
 msgid "Unable to open the clipboard on Video Streams tab"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:283
 msgid "Unable to open the clipboard on Audio Streams tab"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:303
 msgid "Unable to open the clipboard on Subtitle Streams tab"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:90
 msgid "Where do you prefer to save your transcodes?"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:101 ../../vdms_dialogs/preferences.py:128
-#: ../../vdms_dialogs/preferences.py:149 ../../vdms_dialogs/preferences.py:161
-#: ../../vdms_dialogs/preferences.py:173 ../../vdms_panels/filedrop.py:284
 msgid "Change"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:103
-#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:602
-#: ../../vdms_panels/presets_manager.py:1050
 msgid "Same destination paths as source files"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:108
 msgid "Assign optional suffix to destination file names:"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:114
 msgid "File removal preferences"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:118
 msgid "Trash the source files after successful encoding"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:131
 msgid "File Preferences"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:138
 msgid "Location of executables"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:140
 msgid ""
 "FFmpeg can be built by enabling/disabling its options and this depends on your needs.\n"
 "For some use cases it is possible to provide a custom build of FFmpeg where you can specify\n"
 "it in this preferences tab."
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:147
 msgid "Enable a custom location to run FFmpeg"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:159
 msgid "Enable a custom location to run FFprobe"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:171
 msgid "Enable a custom location to run FFplay"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:183
 msgid "FFmpeg"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:189
 msgid "Look and Feel (requires application restart)"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:194
 msgid "Icon themes"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:208
 msgid "At the top of window (default)"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:209
 msgid "At the bottom of window"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:210
 msgid "At the right of window"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:211
 msgid "At the left of window"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:213
 msgid "Place the toolbar"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:222
 msgid "Toolbar's icons size:"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:236
 msgid "Application Language (requires application restart)"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:248
 msgid "Look and Language"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:254
 msgid "Upon exiting the application"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:259
 msgid "Always ask me to confirm"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:261
 msgid "Clean the log files"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:264
 msgid "Remove cached files"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:268
 msgid "On operations completion"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:271
 msgid "These settings will remain active until the application is closed, If necessary, remember to reactivate them."
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:276
 msgid "Exit the application"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:279
 msgid "Shutdown the system"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:283
 msgid "SUDO password:"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:292
 msgid "Exit and Shutdown"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:298
 msgid "Specify the character encoding format"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:301
 msgid ""
 "Although UTF-8 is the default and most widely used standard encoding format, it is not the only encoding format available.\n"
 "Some file metadata may still contain non-UTF-8 character encodings resulting in the error \"'utf-8' codec can't decode bytes...\".\n"
 "If you know the encoding format the file was written in, you can try specifying it here, e.g. ISO 8859-1, ISO 8859-16, etc."
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:311
 msgid "Character encoding:"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:320
 msgid "Default application directories"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:324
 msgid "Configuration directory"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:337
 msgid "Cache directory"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:349
 msgid "Log directory"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:363
 msgid "Advanced"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:369
 msgid ""
 "The following settings affect output messages and the log messages during transcoding processes.\n"
 "Be careful, by changing these settings some functions of the application may not work correctly,\n"
 "change only if you know what you are doing.\n"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:376
 msgid "Set logging level flags used by FFmpeg"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:383
 msgid "Set logging level flags used by FFplay"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:391
 msgid "FFmpeg logging levels"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:437
 msgid "By assigning an additional suffix you could avoid overwriting files"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:440
 msgid "Type sudo password here, only for Unix-like operating systems, not for MS Windows"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:443
 msgid "Preferences"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:596 ../../vdms_dialogs/preferences.py:676
-#: ../../vdms_main/main_frame.py:879 ../../vdms_main/main_frame.py:1060
 msgid "Choose Destination"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:627
 msgid "Enter only alphanumeric characters. You can also use the hyphen (\"-\") and the underscore (\"_\"). Spaces are not allowed."
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:642
-#: ../../vdms_dialogs/setting_profiles.py:257
-#: ../../vdms_dialogs/setting_profiles.py:264
-#: ../../vdms_dialogs/setting_profiles.py:286
-#: ../../vdms_dialogs/setting_profiles.py:309 ../../vdms_main/main_frame.py:399
-#: ../../vdms_main/main_frame.py:421 ../../vdms_panels/av_conversions.py:605
-#: ../../vdms_panels/av_conversions.py:612
-#: ../../vdms_panels/sequence_to_video.py:352
-#: ../../vdms_panels/video_to_sequence.py:399
 msgid "Videomass - Warning!"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:731 ../../vdms_dialogs/preferences.py:771
-#: ../../vdms_dialogs/preferences.py:811 ../../vdms_dialogs/wizard_dlg.py:365
-#: ../../vdms_dialogs/wizard_dlg.py:384 ../../vdms_dialogs/wizard_dlg.py:403
 #, python-brace-format
 msgid "{} location"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:36
-#: ../../vdms_dialogs/setting_profiles.py:38
 msgid "One-Pass, Do not start with `ffmpeg -i filename`; do not end with `output-filename`"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:40
-#: ../../vdms_dialogs/setting_profiles.py:42
 msgid "Two-Pass (optional), Do not start with `ffmpeg -i filename`; do not end with `output-filename`"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:59
 msgid "Videomass - Edit the selected item in the queue"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:71
-#: ../../vdms_dialogs/setting_profiles.py:92
 msgid "Pre-input arguments for One-Pass (optional)"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:82
-#: ../../vdms_dialogs/setting_profiles.py:151
-#: ../../vdms_panels/presets_manager.py:255
 msgid "FFmpeg arguments for one-pass encoding"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:88
-#: ../../vdms_dialogs/setting_profiles.py:158
-#: ../../vdms_panels/presets_manager.py:259
 msgid "Any optional arguments to add before input file on the one-pass encoding, e.g required names of some hardware accelerations like -hwaccel to use with CUDA."
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:102
-#: ../../vdms_dialogs/setting_profiles.py:98
 msgid "Pre-input arguments for Two-Pass (optional)"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:113
-#: ../../vdms_dialogs/setting_profiles.py:152
-#: ../../vdms_panels/presets_manager.py:257
 msgid "FFmpeg arguments for two-pass encoding"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:120
-#: ../../vdms_dialogs/setting_profiles.py:162
-#: ../../vdms_panels/presets_manager.py:263
 msgid "Any optional arguments to add before input file on the two-pass encoding, e.g required names of some hardware accelerations like -hwaccel to use with CUDA."
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:65 ../../vdms_main/main_frame.py:508
-#: ../../vdms_panels/presets_manager.py:189
-#: ../../vdms_panels/video_to_sequence.py:171
 msgid "Edit"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:68
 msgid "Remove"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:71
 msgid "Remove all"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:74
 msgid ""
 "Export\n"
 "queue file"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:77
 msgid ""
 "Import\n"
 "queue file"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:85 ../../vdms_panels/filedrop.py:273
 msgid "Destination file name"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:137
 msgid "Remove all items in the queue"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:151
 msgid "Videomass - Queue"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:228
 msgid "Export queue file"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:296 ../../vdms_panels/av_conversions.py:1192
-#: ../../vdms_panels/presets_manager.py:1044
-#: ../../vdms_panels/video_to_sequence.py:600
 msgid "Same as source"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:301
 msgid ""
 "Source\n"
 "File destination\n"
@@ -1265,186 +885,129 @@ msgid ""
 "Clip duration"
 msgstr ""
 
-#: ../../vdms_dialogs/renamer.py:76
 msgid "# will be replaced by ascending numbers starting with:"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:87
 msgid "Font Size"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:111
 msgid "Font Color"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:121
 msgid "Shadow Color"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:132
 msgid "Show text box"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:136
 msgid "Box Color"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:156
 msgid "The timestamp size does not auto-adjust to the video size, you have to set the size here"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:160 ../../vdms_main/main_frame.py:559
 msgid "Timestamp settings"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:46
 msgid "Supported Formats list (optional). Do not include the `.`"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:47
 msgid "Output Format. Empty to copy format and codec. Do not include the `.`"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:70
 msgid "Profile Name"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:74
-#: ../../vdms_panels/presets_manager.py:404
 msgid "Description"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:149
 msgid "A short profile name"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:150
 msgid "A long description of the profile"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:153
 msgid "One or more comma-separated format names compatible with this profile"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:155
 msgid "Output format extension. Leave empty to copy codec and format"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:256
 msgid "Incomplete profile assignments"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:263
 msgid "Formats must be comma-separated"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:279
-#: ../../vdms_utils/queue_utils.py:80
 #, python-brace-format
 msgid ""
 "ERROR: Keys mismatched for requested data.\n"
 "Invalid file: «{0}»"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:285
-#: ../../vdms_dialogs/setting_profiles.py:308
 msgid "Profile already stored with same name"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:293
 msgid "Profile stored successfully!"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:311
 msgid "Profile change successful!"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:80
 msgid "Log file list"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:82 ../../vdms_dialogs/showlogs.py:116
 msgid "Log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:105
 msgid "Refresh log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:107
 msgid "Clear log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:160
 msgid "Select a log file"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:167
 msgid "Are you sure you want to clear the selected log file?"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:168 ../../vdms_dialogs/wizard_dlg.py:251
-#: ../../vdms_io/checkup.py:68 ../../vdms_main/main_frame.py:205
-#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1685
-#: ../../vdms_panels/presets_manager.py:349
-#: ../../vdms_panels/presets_manager.py:550
-#: ../../vdms_panels/presets_manager.py:590
-#: ../../vdms_panels/presets_manager.py:649
-#: ../../vdms_panels/presets_manager.py:684
-#: ../../vdms_panels/presets_manager.py:749
-#: ../../vdms_panels/presets_manager.py:775
-#: ../../vdms_panels/presets_manager.py:874
-#: ../../vdms_panels/presets_manager.py:904
 msgid "Please confirm"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:83
 msgid "File name"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:84
 msgid "Max volume dBFS"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:85
 msgid "Mean volume dBFS"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:86
 msgid "Offset dBFS"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:87
 msgid "Result dBFS"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:92
 msgid "Post-normalization references:"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:102
 msgid "=  Clipped peaks"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:111
 msgid "=  No changes"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:121
 msgid "=  Below max peak"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:166
-#: ../../vdms_panels/audio_encoders/acodecs.py:841
 msgid "RMS-based volume statistics"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:191
-#: ../../vdms_panels/audio_encoders/acodecs.py:839
 msgid "PEAK-based volume statistics"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:216
 msgid ""
 "...It means the resulting audio will be clipped,\n"
 "because its volume is higher than the maximum 0 db\n"
@@ -1452,34 +1015,28 @@ msgid ""
 "sound distorted."
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:242
 msgid ""
 "...It means the resulting audio will not change,\n"
 "because it's equal to the source."
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:266
 msgid ""
 "...It means an audio signal will be produced with\n"
 "a lower volume than the source."
 msgstr ""
 
-#: ../../vdms_dialogs/videomass_check_version.py:63
 msgid "Get Latest Version"
 msgstr ""
 
-#: ../../vdms_dialogs/videomass_check_version.py:67
 msgid "Checking for newer version"
 msgstr ""
 
-#: ../../vdms_dialogs/videomass_check_version.py:95
 msgid ""
 "\n"
 "\n"
 "New releases fix bugs and offer new features."
 msgstr ""
 
-#: ../../vdms_dialogs/videomass_check_version.py:96
 #, python-brace-format
 msgid ""
 "\n"
@@ -1488,7 +1045,6 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../../vdms_dialogs/while_playing.py:37
 msgid ""
 "q, ESC\n"
 "f\n"
@@ -1511,115 +1067,89 @@ msgid ""
 "left mouse double-click"
 msgstr ""
 
-#: ../../vdms_dialogs/while_playing.py:92
 msgid "Shortcut keys while playing with FFplay"
 msgstr ""
 
-#: ../../vdms_dialogs/widget_utils.py:120 ../../vdms_main/main_frame.py:1326
 msgid "Stop"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:63
 msgid "Please take a moment to set up the application"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:64
 msgid "Click the \"Next\" button to get started"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:79
 msgid "Welcome to the Videomass Wizard!"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:123
 msgid "Videomass is an application based on FFmpeg\n"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:125
 msgid "If FFmpeg is not on your computer, this application will be unusable"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:128
 msgid ""
 "If you have already installed FFmpeg on your operating system,\n"
 "click the \"Auto-detection\" button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:131
 msgid ""
 "If you want to use a version of FFmpeg located on your filesystem\n"
 "but not installed on your operating system,\n"
 "click the \"Locate\" button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:162
 msgid "Auto-detection"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:164
 msgid "Locate"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:214
 msgid "Click the \"Next\" button"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:235
 #, python-brace-format
 msgid "'{}' is not installed on your computer. Install it or indicate another location by clicking the 'Locate' button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:249
 msgid ""
 "Videomass already seems to include FFmpeg.\n"
 "\n"
 "Do you want to use that?"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:275
 msgid "Locating FFmpeg executables\n"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:277
 msgid ""
 "\"ffmpeg\", \"ffprobe\" and \"ffplay\" are required. Complete all\n"
 "the text boxes below by clicking on the respective buttons."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:437
 msgid "Wizard completed successfully!\n"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:438
 msgid "Remember that you can always change these settings later, through the Preferences dialog."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:440
 msgid "Thank You!"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:441
 msgid "To exit click the \"Finish\" button"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:527
 msgid "< Previous"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:530 ../../vdms_dialogs/wizard_dlg.py:613
 msgid "Next >"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:535
 msgid "Videomass Wizard"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:563 ../../vdms_dialogs/wizard_dlg.py:586
-#: ../../vdms_dialogs/wizard_dlg.py:591
 msgid "Finish"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:44 ../../vdms_io/checkup.py:92
 #, python-brace-format
 msgid ""
 "Output folder does not exist:\n"
@@ -1627,432 +1157,326 @@ msgid ""
 "\"{}\"\n"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:65
 msgid "Files already exist, do you want to overwrite them?"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:67
 msgid "Already exist"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:81
 msgid "Not found"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:82 ../../vdms_panels/filedrop.py:196
 msgid "Error list"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:83
 msgid "File(s) not found"
 msgstr ""
 
-#: ../../vdms_io/io_tools.py:56
 #, python-format
 msgid "File does not exist or is invalid:  %s"
 msgstr ""
 
-#: ../../vdms_io/io_tools.py:74
 msgid ""
 "Wait....\n"
 "Audio peak analysis."
 msgstr ""
 
-#: ../../vdms_io/io_tools.py:179
 msgid "Videomass - Downloading..."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1409
-#: ../../vdms_main/main_frame.py:1441
 msgid "Ready"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:203
 msgid ""
 "Not all items in the queue were completed.\n"
 "\n"
 "Would you like to keep them in the queue?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:224
 #, python-brace-format
 msgid "Queue ({0})"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:229 ../../vdms_main/main_frame.py:1334
 msgid "Queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:396 ../../vdms_main/main_frame.py:418
 msgid "There are still active windows with running processes, make sure you finish your work before exit."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:403
 msgid "Are you sure you want to exit the application?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:405
 msgid "Exit"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:463
 msgid "Import files\tCtrl+O"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:466
 msgid "Open destination folder of encodings\tCtrl+D"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:469
 msgid "Load queue file"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:470
 msgid "Load a previously exported queue file"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:473
 msgid "Open trash"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:474
 msgid "Open the Videomass trash folder"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:476
 msgid "Empty trash"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:477
 msgid "Delete all files in the Videomass trash folder"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:480
 msgid "Exit\tCtrl+Q"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:481
 msgid "Completely exit the application"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:482
 msgid "File"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:486 ../../vdms_panels/filedrop.py:340
-#: ../../vdms_panels/filedrop.py:381
 msgid "Rename selected file\tCtrl+R"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:487
 msgid "Rename the destination of the selected file"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:490 ../../vdms_panels/filedrop.py:341
-#: ../../vdms_panels/filedrop.py:384
 msgid "Batch rename files\tCtrl+B"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:491
 msgid "Numerically renames the destination of all items in the list"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:496 ../../vdms_panels/filedrop.py:343
-#: ../../vdms_panels/filedrop.py:388
 msgid "Remove selected entry\tDEL"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:497
 msgid "Remove the selected file from the list"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:500 ../../vdms_panels/filedrop.py:344
-#: ../../vdms_panels/filedrop.py:391
 msgid "Clear list\tShift+DEL"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:501
 msgid "Clear the file list"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:506
 msgid "Preferences\tCtrl+P"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:507
 msgid "Application preferences"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:512
 msgid "Find FFmpeg topics"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:513
 msgid "A useful tool to search for FFmpeg help topics and options"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:518
 msgid "Check for preset updates"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:519
 #, python-brace-format
 msgid "Check for new presets updates from {0}"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:521
 msgid "Get latest presets"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:522
 #, python-brace-format
 msgid "Get the latest presets from {0}"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:525
 msgid "Work notes\tCtrl+N"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:526
 msgid "Read and write useful notes and reminders."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:528
 msgid "Tools"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:535
 msgid "Show FFmpeg's built-in configuration capabilities"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:539
 msgid "Muxers and demuxers available on your version of FFmpeg"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:543
 msgid "Encoders available on your version of FFmpeg"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:546
 msgid "Decoders available on your version of FFmpeg"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:550
 msgid "Enable timestamps on playback"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:551
 msgid "Displays timestamp when playing media with FFplay"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:554
 msgid "Auto-exit after playback"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:555
 msgid "If checked, the FFplay window will auto-close when playback is complete"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:559
 msgid "Customize the timestamp style"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:562
 msgid "While playing..."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:563
 msgid "Show useful shortcut keys when playing or previewing using FFplay"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:567
 msgid "Show timeline editor\tCtrl+T"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:568
 msgid "Set duration or trim slices of time to remove unwanted parts from your files"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:572
 msgid "View"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:579
 msgid "Home panel\tCtrl+Shift+H"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:580
 msgid "Go to the «Home» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:583
 msgid "Presets Manager\tCtrl+Shift+P"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:584
 msgid "Go to the «Presets Manager» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:586
 msgid "A/V Conversions\tCtrl+Shift+V"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:587
 msgid "Go to the «A/V Conversions» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:589
 msgid "Concatenate Demuxer\tCtrl+Shift+D"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:590
 msgid "Go to the «Concatenate Demuxer» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:593
 msgid "Still Image Maker\tCtrl+Shift+I"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:594
 msgid "Go to the «Still Image Maker» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:596
 msgid "From Movie to Pictures\tCtrl+Shift+S"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:597
 msgid "Go to the «From Movie to Pictures» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:600
 msgid "Output monitor\tCtrl+Shift+O"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:601
 msgid "Keeps track of the output for debugging errors"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:603
 msgid "Go"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:607
 msgid "User guide"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:611
 msgid "System version"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:612
 msgid "Get version about your operating system, version of Python and wxPython."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:616
 msgid "Show log files\tCtrl+L"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:617
 msgid "Viewing log messages"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:620
 msgid "Issue tracker"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:624
 msgid "Contribute to the project"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:627
 msgid "Sponsor this project"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:628
 msgid "Become a developer supporter"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:629
 msgid "Donate"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:630
 msgid "Donate to the app developer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:634
 msgid "Other projects by the developer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:650
 msgid "About Videomass"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:651
 msgid "Check for newer version"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:652
 msgid "Check for the latest Videomass version"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:654
 msgid "Help"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:729
 msgid "Import files"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:752
 msgid "No default folder has been set for the destination of the encodings. The current setting is \"Same destination paths as source files\"."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:784 ../../vdms_main/main_frame.py:809
 #, python-brace-format
 msgid ""
 "'{}':\n"
 "No such file or directory"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:797
 msgid "Are you sure to empty trash folder?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:805
 #, python-brace-format
 msgid ""
 "'{}':\n"
 "There are no files to delete."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:862
 #, python-brace-format
 msgid "Installed release v{0}. A new presets release is available {1}"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:866
 #, python-brace-format
 msgid "Installed release v{0}. No new updates found."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:896
 msgid ""
 "Wait....\n"
 "The archive is being downloaded"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:908
 #, python-brace-format
 msgid "Successfully downloaded to \"{0}\""
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1120
 msgid "Some changes require restarting the application."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1126
 #, python-brace-format
 msgid ""
 "{0}\n"
@@ -2060,214 +1484,159 @@ msgid ""
 "Do you want to restart the application now?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1128
 msgid "Restart Videomass?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1207
 #, python-brace-format
 msgid "A new release is available - v.{0}\n"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1210
 msgid "You are using a development version that has not yet been released!\n"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1213
 msgid "Congratulation! You are already using the latest version.\n"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1301
 msgid "Previous panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1302
 msgid "Back"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1305
 msgid "Next panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1306
 msgid "Next"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1309
 msgid "Home panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1310
 msgid "Home"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1313
 msgid "Play the selected imput file"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1314
 msgid "Play"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1317
 msgid "Get informative data about imported media streams"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1321
 msgid "Start batch processing"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1325
 msgid "Stops current process"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1329
 msgid "Add an item to Queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1330
 msgid "Add to Queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1333
 msgid "Show queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1408 ../../vdms_panels/presets_manager.py:569
 msgid "Videomass"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1442
 msgid "Videomass - File List"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1459
 msgid "Videomass - AV Conversions"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1488
 msgid "Videomass - Presets Manager"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1518
 msgid "Videomass - Concatenate Demuxer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1547
 msgid "Videomass - From Movie to Pictures"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1576
 msgid "Videomass - Still Image Maker"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1660 ../../vdms_panels/av_conversions.py:577
-#: ../../vdms_panels/filedrop.py:500 ../../vdms_panels/filedrop.py:616
-#: ../../vdms_panels/sequence_to_video.py:322
-#: ../../vdms_panels/video_to_sequence.py:369
-#: ../../vdms_panels/video_to_sequence.py:501
 msgid "Have to select an item in the file list first"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1682
 msgid ""
 "An item with the same destination file already exists.\n"
 "\n"
 "Do you want to replace it by adding the new item to the queue?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1703
 msgid "Videomass - FFmpeg Message Monitoring"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1828
 #, python-brace-format
 msgid "The system will turn off in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1829
 msgid "Videomass - Shutdown!"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1836
 msgid "Error while shutting down. Please see file log for details."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1848
 #, python-brace-format
 msgid "Exiting the application in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1849
 msgid "Videomass - Exiting!"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:46
 msgid "Start point adjustment"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:48
 msgid "End point adjustment"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:105
 msgid "Hours"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:106
 msgid "Minutes"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:107
 msgid "Seconds"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:108
 msgid "Milliseconds"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:189 ../../vdms_miniframes/timeline.py:312
 msgid "No source duration:"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:208 ../../vdms_miniframes/timeline.py:298
-#: ../../vdms_miniframes/timeline.py:333 ../../vdms_miniframes/timeline.py:338
-#: ../../vdms_miniframes/timeline.py:441
 #, python-brace-format
 msgid "{0} {1}  |  Segment Duration: {2}"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:260 ../../vdms_miniframes/timeline.py:277
 msgid "End adjustment"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:261 ../../vdms_miniframes/timeline.py:279
 msgid "Start adjustment"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:320
 msgid "Source duration:"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:387
 msgid "WARNING: Invalid selection, out of range."
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:461
 msgid ""
 "Start by dragging the bottom left handle,\n"
 "or right-click for options."
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:497
 msgid "Start"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:498
 msgid "End"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:548
 msgid ""
 "The timeline editor is a tool that allows you to trim slices of time on selected imported media (see File List panel).\n"
 "\n"
@@ -2280,39 +1649,30 @@ msgid ""
 "The \"Start\"/\"End\" duration values always refer to the initial position of the timeline: 00:00:00.000. For other informations as the segment duration and warnings, please refer to the status bar messages."
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:565
 msgid "Timeline Editor Usage"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:153
 msgid "Media:"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:169
 msgid "Container:"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:180
 msgid "Save profile"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:183
 msgid "Target"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:316
 msgid "Miscellaneous"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:323
 msgid "Save as a new profile of the Presets Manager."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:325
 msgid "Available video encoders. \"Copy\" means that the video stream will not be re-encoded and will allow you (depending on the encoder) to change the container, audio codec and a few other parameters."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:330
 msgid ""
 "Container format. It is usually represented by the file extension (output format).\n"
 "\n"
@@ -2321,73 +1681,53 @@ msgid ""
 "If the media target is set to \"Audio\", you can extract only the audio streams from videos, or simply convert audio source files."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:338
 msgid ""
 "Set output files target: \"Video\" to save output files as video files; \"Audio\" to save files using an audio encoder and format.\n"
 "\n"
 "Note that by using \"Audio\" as the target, you will still be able to work on the video source files but you will only be able to extract the audio streams, convert them and apply audio filters such as normalization."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:346
 msgid "Preview video filters"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:347
 msgid "Disable active filters"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:348
-#: ../../vdms_panels/sequence_to_video.py:156
-#: ../../vdms_panels/video_to_sequence.py:113
 msgid "Resize"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:349
 msgid "Crop"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:350
 msgid "Transpose"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:352
 msgid "Denoise"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:353
 msgid "Stabilize"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:354
 msgid "Equalize"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:517
 msgid "Unable to preview Video Stabilizer filter"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:602
 msgid ""
 "Unsupported file:\n"
 "Missing decoder or library? Check FFmpeg configuration."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:611
-#: ../../vdms_panels/sequence_to_video.py:351
-#: ../../vdms_panels/video_to_sequence.py:398
 msgid "The file is not a frame or a video file"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:434
-#: ../../vdms_panels/av_conversions.py:861
 msgid "Undetected volume values! Click the \"Volume detect\" button to analyze audio volume data."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1186
 msgid "Off"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1203
 msgid ""
 "Batch processing items\n"
 "Destination\n"
@@ -2402,109 +1742,81 @@ msgid ""
 "Clip duration"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1246
-#: ../../vdms_panels/presets_manager.py:814
 #, python-brace-format
 msgid "Write profile on «{0}»"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1266
-#: ../../vdms_panels/presets_manager.py:513
 msgid "Enter name for new preset"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1276
-#: ../../vdms_panels/presets_manager.py:524
 msgid "Invalid file name, make sure to provide a valid name including the «.json» extension"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1284
 #, python-brace-format
 msgid "Cannot save current data in file «{}»."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1289
 msgid "Open Videomass preset"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1307
 msgid "Videomass - Save new profile"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1308
 msgid "Where do you want to save this profile?"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1309
 msgid "Save the profile to a new preset"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1310
 msgid "Save the profile to an existing preset"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:69
 msgid "Welcome to Videomass"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:71
 #, python-brace-format
 msgid "Version {}"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:82
 msgid "Presets Manager"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:85
 msgid "AV-Conversions"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:88
 msgid "Concatenate media files"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:91
 msgid "Still Image Maker"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:94
 msgid "From Movie to Pictures"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:123
 msgid "Create, edit and use quickly your favorite FFmpeg presets and profiles with full formats support and codecs."
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:127
 msgid "A set of useful tools for audio and video conversions. Save your profiles and reuse them with Presets Manager."
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:131
 msgid "Concatenate multiple media files based on import order without re-encoding"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:134
 msgid "Create video from a sequence of images, based on import order, with the ability to add an audio file."
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:137
 msgid "Extract images (frames) from your movies in JPG, PNG, BMP, GIF formats."
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:47
 msgid "At least two files are required to perform concatenation."
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:63
 msgid "Invalid data found"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:68
 msgid "The files do not have the same \"codec_types\", same \"sample_rate\" or same \"width\" or \"height\". Unable to proceed."
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:84
 msgid ""
 "\n"
 "- The concatenation function is performed only with Audio files or only with Video files.\n"
@@ -2520,17 +1832,12 @@ msgid ""
 "- Audio files must have exactly the same formats, same codecs with equal sample rate."
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:125
 msgid "Videomass Documentation:"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:136
-#: ../../vdms_panels/sequence_to_video.py:212
-#: ../../vdms_panels/video_to_sequence.py:181
 msgid "Official FFmpeg documentation:"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:253
 msgid ""
 "Items to concatenate\n"
 "File destination\n"
@@ -2539,250 +1846,188 @@ msgid ""
 "Duration"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:45
 msgid "File has illegal characters like:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:46
 msgid "Invalid character found in path name: (\")"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:47
 msgid "Directories are not allowed, just add files, please."
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:48
 msgid "File without format extension: please give an appropriate extension to the file name, example '.mkv', '.avi', '.mp3', etc."
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:84
 #, python-brace-format
 msgid "Name has illegal characters like: {0}"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:85
 msgid "Name already in use:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:185
 msgid "Duplicate file, it has already been added to the list."
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:197
 msgid "Rejected files"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:269
 msgid "Source file"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:270
 msgid "Duration"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:271
 msgid "Media type"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:272
 msgid "Size"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:405
 msgid "Drag one or more files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:282
 msgid "Save to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:306
 msgid "Set a new destination folder for encodings"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:308
 msgid "Encodings destination folder"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:394
 msgid "Play file"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:408
 msgid "Drag two or more Audio/Video files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:412
 msgid "Drag one or more Image files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:415
 msgid "Drag one or more Video files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:623
 msgid "Rename the file destination"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:624
 msgid "Rename the selected file to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:638 ../../vdms_panels/filedrop.py:648
-#: ../../vdms_panels/filedrop.py:679
 msgid "Add Files"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:655
 msgid "Rename in batch"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:656
 #, python-brace-format
 msgid "Rename the {0} items to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:658
 msgid "New Name #"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:114
 msgid "Sorry, all task failed !"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:115
 msgid "The process was stopped due to a fatal error."
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:116
 msgid "Interrupted Process !"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:117
 msgid "Successfully completed !"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:118
 msgid "Not everything was successful."
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:148
 msgid "Encoding Status"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:152
 msgid "Current Log"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:354
 msgid "Fatal Error !"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:363
 msgid "Get your files at the destination you specified"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:377
 msgid "For more details please read the Current Log."
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:380
 msgid "...Finished"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:399
 msgid "Please wait... interruption in progress"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:402
 msgid "...Interrupted"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:166
 msgid "Presets"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:180
 msgid "Write"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:184
 msgid "Delete"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:194
 msgid "Duplicate"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:199
 msgid "Profiles"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:206
 msgid "One-Pass Encoding"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:218
 msgid "Two-Pass Encoding"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:232
 msgid "Choose a preset and view its profiles"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:233
 msgid "Write a new profile and save it in the selected preset"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:235
 msgid "Delete the selected profile"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:236
 msgid "Edit the selected profile"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:237
 msgid "Duplicate the selected profile"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:238
 msgid "Create new preset"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:240
 msgid "Remove selected preset"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:242
 msgid "Backup selected preset"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:244
 msgid "Backup the presets folder"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:246
 msgid "Restore a preset"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:248
 msgid "Restore a presets folder"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:250
 msgid "Resets the selected preset to default values"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:252
 msgid "Reset all presets to default values"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:254
 msgid "Refresh the presets list"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:338
 #, python-brace-format
 msgid ""
 "Outdated presets version found: v{1}\n"
@@ -2796,28 +2041,22 @@ msgid ""
 "Do you want to perform this update now?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:403
 msgid "Name"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:405
 msgid "Output Format"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:406
 msgid "Supported Format List"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:531
 #, python-brace-format
 msgid "Cannot save current data in file '{}'."
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:535
 msgid "You just successfully created a new preset!"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:547
 #, python-brace-format
 msgid ""
 "Are you sure you want to remove \"{}\" preset?\n"
@@ -2825,7 +2064,6 @@ msgid ""
 " It will be moved to the \"Removals\" subfolder inside the presets folder."
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:558
 #, python-brace-format
 msgid ""
 "{}\n"
@@ -2833,72 +2071,55 @@ msgid ""
 "Sorry, removal failed, cannot continue.."
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:568
 #, python-brace-format
 msgid "The preset \"{0}\" was successfully removed"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:583
-#: ../../vdms_panels/presets_manager.py:612
 msgid "Open a destination folder"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:588
 msgid "A file with this name already exists, do you want to overwrite it?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:602
-#: ../../vdms_panels/presets_manager.py:622
 msgid "Backup completed successfully"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:631
 msgid "Open the preset you want to restore"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:645
 msgid ""
 "This preset already exists and is about to be updated. Don't worry, it will keep all your saved profiles.\n"
 "\n"
 "Do you want to continue?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:663
 msgid "Restore successful"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:681
 msgid ""
 "This will update the presets database. Don't worry, it will keep all your saved profiles.\n"
 "\n"
 "Do you want to continue?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:689
 msgid "Open the presets folder to restore"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:725
 msgid "The presets database has been successfully updated"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:740
 msgid "The selected preset is not part of Videomass's default presets."
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:745
 msgid ""
 "Be careful! The selected preset will be overwritten with the default one. Your profiles may be deleted!\n"
 "\n"
 "Do you want to continue?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:760
-#: ../../vdms_panels/presets_manager.py:794
 msgid "Successful recovery"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:769
 msgid ""
 "Be careful! This action will restore all presets to default ones. Your profiles may be deleted!\n"
 "\n"
@@ -2907,30 +2128,24 @@ msgid ""
 "Do you want to continue?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:833
 #, python-brace-format
 msgid "Edit profile on «{0}»"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:872
 msgid "Are you sure you want to delete the selected profile? It will no longer be possible to recover it."
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:891
 msgid "First select a profile in the list"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:899
 msgid ""
 "The selected profile command has been changed manually.\n"
 "Do you want to apply it during the conversion process?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:909
 msgid "Don't show this dialog again"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:1054
 msgid ""
 "Batch processing items\n"
 "Destination\n"
@@ -2942,11 +2157,9 @@ msgid ""
 "Clip duration"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:54
 msgid "Images need to be resized, please use Resize function."
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:73
 msgid ""
 "\n"
 "1. Import one or more image files such as JPG, PNG and BMP formats, then select one.\n"
@@ -2964,38 +2177,29 @@ msgid ""
 "will be saved in a folder named 'Still_Images' with a progressive digit, in the path you specify."
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:129
 msgid "Enable a single still image"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:162
 msgid ""
 "Force original aspect ratio using\n"
 "padding rather than stretching"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:170
 msgid "Include audio file"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:173
 msgid "Play the video until audio track finishes"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:180
-#: ../../vdms_panels/sequence_to_video.py:439
 msgid "Open audio file"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:199
 msgid "Additional arguments"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:454
 msgid "Open Audio File"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:466
 #, python-brace-format
 msgid ""
 "Invalid file: '{}'\n"
@@ -3003,7 +2207,6 @@ msgid ""
 "{}"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:471
 #, python-brace-format
 msgid ""
 "Invalid file: '{}'\n"
@@ -3011,21 +2214,14 @@ msgid ""
 "It doesn't appear to be an audio file."
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:560
-#: ../../vdms_panels/sequence_to_video.py:587
-#: ../../vdms_panels/video_to_sequence.py:511
 #, python-brace-format
 msgid "Invalid file: '{}'"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:570
-#: ../../vdms_panels/sequence_to_video.py:595
 #, python-brace-format
 msgid "Unsupported format '{}'"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:576
-#: ../../vdms_panels/sequence_to_video.py:600
 #, python-brace-format
 msgid ""
 "File does not exist:\n"
@@ -3033,15 +2229,9 @@ msgid ""
 "\"{}\"\n"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:577
 msgid "ERROR"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:707
-msgid "Shortest"
-msgstr ""
-
-#: ../../vdms_panels/sequence_to_video.py:715
 msgid ""
 "Items to concatenate\n"
 "Output filename\n"
@@ -3057,7 +2247,6 @@ msgid ""
 "Overall video duration"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:50
 msgid ""
 "\n"
 "1. Import one or more video files, then select one.\n"
@@ -3074,51 +2263,39 @@ msgid ""
 "with a progressive digit, in the path you specify."
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:86
 msgid "Create thumbnails"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:87
 msgid "Create tiled mosaics"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:88
 msgid "Create animated GIF"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:90
 msgid "Options"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:119
 msgid "Output format:"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:131
 msgid "Rows:"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:141
 msgid "Columns:"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:205
 msgid "Other unofficial resources:"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:229
 msgid "Set FPS control from 0.1 to 30.0 fps. The higher this value, the more images will be extracted."
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:232
 msgid "Spaces around the mosaic tiles. From 0 to 32 pixels"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:234
 msgid "Spaces around the mosaic borders. From 0 to 32 pixels"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:626
 msgid ""
 "Selected File\n"
 "Output Format\n"
@@ -3134,58 +2311,45 @@ msgid ""
 "Duration"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:118
 msgid "Audio encoder settings, mapping and filters"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:128
 msgid "Audio Encoder"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:137
 msgid "Settings"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:148
 msgid "Index Selection:"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:157
 msgid "Map:"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:180
 msgid "Normalization"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:191
 msgid "Volume detect"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:195
 msgid "Volume Statistics"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:199
 msgid "Target level:"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:264
 msgid "Gets maximum volume and average volume data in dBFS, then calculates the offset amount for audio normalization."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:267
 msgid "Limiter for the maximum peak level or the mean level (when switch to RMS) in dBFS. From -99.0 to +0.0; default for PEAK level is -1.0; default for RMS is -20.0"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:271
 msgid ""
 "Normally on a video with correctly indexed streams and having one or more audio streams, the first audio stream should be indexed at \"1\", the second at \"2\" and so on (the video stream on the other hand is always indexed at \"0\"). In this case it is recommended to select the desired stream by setting a specific index, e.g \"1\" for for the first available audio stream.\n"
 "\n"
 "Set this control to \"Auto\" if the source file is simply an audio track."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:280
 msgid ""
 "\"Auto\" keeps all audio streams and processes only the one selected by the \"Index Selection\" control.\n"
 "\n"
@@ -3194,70 +2358,55 @@ msgid ""
 "\"Index Only\" processes only the audio stream selected by the \"Index Selection\" control and removes all others from the video"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:288
 msgid "Integrated Loudness Target in LUFS. From -70.0 to -5.0, default is -16.0"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:291
 msgid "Maximum True Peak in dBTP. From -1.5 to +0.0, default is -2.0"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:294
 msgid "Loudness Range Target in LUFS. From +1.0 to +20.0, default is +11.0"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:297
 msgid "Play the audio stream selected in the \"Index Selection\" control. Using this function you can test the result of audio normalization."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:503
 msgid "Selected index does not exist or does not contain any audio streams"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:508
 #, python-brace-format
 msgid ""
 "ERROR: Missing audio stream:\n"
 "\"{}\""
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:726
 msgid "PEAK level normalization, which will produce a maximum peak level equal to the set target level."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:729
 msgid "RMS-based normalization, which according to mean volume calculates the amount of gain to reach same average power signal."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:733
 msgid ""
 "Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements the EBU R128 algorithm.\n"
 "Ideal for live normalization. It produces worse results than the High-quality two-pass Loudnorm normalization, but is faster."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:740
 msgid ""
 "High-quality two-pass Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements\n"
 "the EBU R128 algorithm. Ideal for postprocessing."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:789
 msgid "You need to import at least one file"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:63
 msgid "Subtitle Mapping:"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:77
 msgid "Copy Chapters"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:79
 msgid "Copy Metadata"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:85
 msgid ""
 "Select \"All\" to include any source file subtitles in the output video.\n"
 "\n"
@@ -3266,147 +2415,63 @@ msgid ""
 "This option is automatically ignored for output audio files."
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:90
 msgid "Copy the chapter markers as is from source file. This option is automatically ignored for output audio files."
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:93
 msgid "Copy all incoming metadata from source file, such as audio/video tags, titles, unique marks, and so on."
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:108
 msgid "Additional options"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:89
-#: ../../vdms_panels/video_encoders/av1_svt.py:120
-#: ../../vdms_panels/video_encoders/avc_x264.py:90
-#: ../../vdms_panels/video_encoders/hevc_x265.py:98
-#: ../../vdms_panels/video_encoders/mpeg4.py:71
-#: ../../vdms_panels/video_encoders/vp9_webm.py:131
 msgid "Reload"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:101
-#: ../../vdms_panels/video_encoders/av1_svt.py:129
-#: ../../vdms_panels/video_encoders/avc_x264.py:101
-#: ../../vdms_panels/video_encoders/hevc_x265.py:109
-#: ../../vdms_panels/video_encoders/mpeg4.py:82
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:97
-#: ../../vdms_panels/video_encoders/vp9_webm.py:141
 msgid "Optimize for Web"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:247
-#: ../../vdms_panels/video_encoders/av1_svt.py:313
-#: ../../vdms_panels/video_encoders/avc_x264.py:242
-#: ../../vdms_panels/video_encoders/hevc_x265.py:250
-#: ../../vdms_panels/video_encoders/mpeg4.py:198
-#: ../../vdms_panels/video_encoders/vp9_webm.py:288
 msgid "Reloads the selected video encoder settings. Changes will be discarded."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:250
-#: ../../vdms_panels/video_encoders/avc_x264.py:273
-#: ../../vdms_panels/video_encoders/hevc_x265.py:277
-#: ../../vdms_panels/video_encoders/vp9_webm.py:291
 msgid "Constant rate factor. Lower values correspond to higher quality and greater file size. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:254
-#: ../../vdms_panels/video_encoders/av1_svt.py:357
-#: ../../vdms_panels/video_encoders/vp9_webm.py:295
 msgid "Number of tile rows to use, default changes per resolution"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:256
-#: ../../vdms_panels/video_encoders/av1_svt.py:359
-#: ../../vdms_panels/video_encoders/vp9_webm.py:297
 msgid "Number of tile columns to use, default changes per resolution"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:259
-#: ../../vdms_panels/video_encoders/av1_svt.py:368
-#: ../../vdms_panels/video_encoders/avc_x264.py:253
-#: ../../vdms_panels/video_encoders/hevc_x265.py:261
-#: ../../vdms_panels/video_encoders/mpeg4.py:201
-#: ../../vdms_panels/video_encoders/vp9_webm.py:300
 msgid "Set the Group Of Picture (GOP). Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:262
-#: ../../vdms_panels/video_encoders/av1_svt.py:371
-#: ../../vdms_panels/video_encoders/avc_x264.py:256
-#: ../../vdms_panels/video_encoders/hevc_x265.py:264
-#: ../../vdms_panels/video_encoders/mpeg4.py:204
-#: ../../vdms_panels/video_encoders/vp9_webm.py:303
 msgid "It can reduce the file size, but takes longer."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:264
-#: ../../vdms_panels/video_encoders/av1_svt.py:373
-#: ../../vdms_panels/video_encoders/avc_x264.py:258
-#: ../../vdms_panels/video_encoders/hevc_x265.py:266
-#: ../../vdms_panels/video_encoders/mpeg4.py:206
-#: ../../vdms_panels/video_encoders/vp9_webm.py:305
 msgid "Set minimum bitrate tolerance. Most useful in setting up a CBR encode. It is of little use otherwise. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:268
-#: ../../vdms_panels/video_encoders/av1_svt.py:377
-#: ../../vdms_panels/video_encoders/avc_x264.py:262
-#: ../../vdms_panels/video_encoders/hevc_x265.py:270
-#: ../../vdms_panels/video_encoders/mpeg4.py:210
-#: ../../vdms_panels/video_encoders/vp9_webm.py:309
 msgid "Specifies a maximum tolerance. Requires bufsize to be set. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:271
-#: ../../vdms_panels/video_encoders/av1_svt.py:380
-#: ../../vdms_panels/video_encoders/avc_x264.py:265
-#: ../../vdms_panels/video_encoders/hevc_x265.py:273
-#: ../../vdms_panels/video_encoders/mpeg4.py:213
-#: ../../vdms_panels/video_encoders/vp9_webm.py:312
 msgid "Set ratecontrol buffer size, which determines the variability of the output bitrate. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:275
-#: ../../vdms_panels/video_encoders/av1_svt.py:384
-#: ../../vdms_panels/video_encoders/avc_x264.py:277
-#: ../../vdms_panels/video_encoders/hevc_x265.py:281
-#: ../../vdms_panels/video_encoders/mpeg4.py:231
-#: ../../vdms_panels/video_encoders/vp9_webm.py:316
 msgid "Specifies the target (average) bit rate for the encoder to use. Higher value = higher quality. Set -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:279
-#: ../../vdms_panels/video_encoders/av1_svt.py:388
-#: ../../vdms_panels/video_encoders/avc_x264.py:281
-#: ../../vdms_panels/video_encoders/hevc_x265.py:285
-#: ../../vdms_panels/video_encoders/mpeg4.py:235
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:131
-#: ../../vdms_panels/video_encoders/vp9_webm.py:320
 msgid "Video width and video height ratio."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:281
-#: ../../vdms_panels/video_encoders/av1_svt.py:390
-#: ../../vdms_panels/video_encoders/avc_x264.py:283
-#: ../../vdms_panels/video_encoders/hevc_x265.py:287
-#: ../../vdms_panels/video_encoders/mpeg4.py:237
-#: ../../vdms_panels/video_encoders/vp9_webm.py:322
 msgid "Frame rate (frames per second). Frames repeat a given number of times per second. In some countries this is 30 for NTSC, other countries (like Italy) use 25 for PAL"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:285
 msgid "Quality/Speed ratio modifier. CPU Used sets how efficient the compression will be. Lower values mean slower encoding with better quality, and vice-versa. Valid values are from 0 to 8 inclusive."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:290
 msgid "Quality and compression efficiency vs speed trade-off. \"good\" is the default and recommended for most applications; \"realtime\" is recommended for live/fast encoding (live streaming, video conferencing, etc); \"allintra\" for All Intra encoding."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:297
 msgid ""
 "Row Multi-Threading enables row-based multi-threading which maximizes CPU usage.\n"
 "\n"
@@ -3415,7 +2480,6 @@ msgid ""
 "Enabling Row Multi-Threading is only faster when the CPU has more threads than the number of encoded tiles."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:316
 msgid ""
 "presets 1-3 represent extremely high efficiency, for use when encode time is not important and quality/size of the resulting video file is critical.\n"
 "\n"
@@ -3426,7 +2490,6 @@ msgid ""
 "Preset 13 is even faster but not intended for direct human consumption--it can be used, for example, as a per-scene quality metric in VOD applications. One should use the lowest preset that is tolerable."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:327
 msgid ""
 "Constant rate factor. This parameter governs the quality/size trade-off.\n"
 "\n"
@@ -3437,7 +2500,6 @@ msgid ""
 "Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:334
 msgid ""
 "The \"Film Grain\" parameter allows SVT-AV1 to detect and delete film grain from the source video, and replace it with synthetic grain of the same character, resulting in significant bitrate savings.\n"
 "\n"
@@ -3450,80 +2512,57 @@ msgid ""
 "If the source video does not have natural grain, this parameter can be set to -1 to disable it or at least 0."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:346
 msgid ""
 "If enabled, the \"Film Grain Denoiser\" option can mitigate the detail removal caused by high \"Film Grain\" values required to preserve the look of very grainy films\n"
 "\n"
 "By default, the denoised frames are passed to be encoded as the final pictures, enabling this feature will lead to the original frames to be used instead. "
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:353
 msgid "Enables encoder optimization to produce faster (less CPU intensive) bit streams to decode, similar to the fastdecode tuning in x264 and x265."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:362
-#: ../../vdms_panels/video_encoders/avc_x264.py:247
-#: ../../vdms_panels/video_encoders/hevc_x265.py:255
 msgid "Set profile restrictions"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:364
-#: ../../vdms_panels/video_encoders/avc_x264.py:249
-#: ../../vdms_panels/video_encoders/hevc_x265.py:257
 msgid "Specify level for a selected profile"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:366
-#: ../../vdms_panels/video_encoders/avc_x264.py:251
-#: ../../vdms_panels/video_encoders/hevc_x265.py:259
 msgid "Tune the encoding params"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/avc_x264.py:245
-#: ../../vdms_panels/video_encoders/hevc_x265.py:253
 msgid "Set the encoding preset (default \"medium\")"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/avc_x264.py:269
 msgid "specifies the target (average) bit rate for the encoder to use. Higher value = higher quality. Set -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:217
 msgid "Variable Bit Rate. From 0-30, with 1 being highest quality/largest filesize and 30 being the lowest quality/smallest filesize. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:222
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:133
 msgid "Frames repeat a given number of times per second. In some countries this is 30 for NTSC, other countries (like Italy) use 25 for PAL"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:226
 msgid "The default FourCC stored in an MPEG-4-coded file will be FMP4. If you want a different FourCC, set this option to xvid to force the FourCC xvid to be stored as the video FourCC rather than the default."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:162
 msgid "Copy Video Codec"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:163
 msgid ""
 "This will just copy the video track as is, without any video re-encoding.\n"
 "You will only be able to change output format, select other audio encoders and\n"
 "a few other options."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_no_enc.py:74
 msgid "Video export disabled"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_no_enc.py:75
 msgid ""
 "The Media target you just selected will only allow you to export files as audio tracks.\n"
 "You can then process audio source files only or extract indexed audio streams on\n"
 "video files."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:326
 msgid ""
 "Speed sets how efficient the compression will be.\n"
 "\n"
@@ -3536,7 +2575,6 @@ msgid ""
 "When the Quality is set to realtime, the available values for Speed are 0 to 8."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:335
 msgid ""
 "Time to spend encoding.\n"
 "\n"
@@ -3547,35 +2585,30 @@ msgid ""
 "\"realtime\" is recommended for live / fast encoding."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:341
-msgid "If enabled, adds support for row based multithreading which greatly enhances the number of threads the encoder can utilise. This improves encoding speed significantly on systems that are otherwise underutilised when encoding VP9. Since the amount of additional threads depends on the number of \"tiles\", which itself depends on the video resolution, encoding higher resolution videos will see a larger performance improvement."
+msgid ""
+"If enabled, adds support for row based multithreading which greatly enhances the number of threads the encoder can utilise. This improves encoding speed significantly on systems that are otherwise underutilised when encoding VP9. Since the amount of additional threads depends on the number of \"tiles\", which itself depends on the video resolution, encoding higher resolution videos will see a "
+"larger performance improvement."
 msgstr ""
 
-#: ../../vdms_utils/presets_manager_utils.py:46
 #, python-brace-format
 msgid "Supports ({0}) formats only, not ({1})"
 msgstr ""
 
-#: ../../vdms_utils/presets_manager_utils.py:49
 msgid "File formats not supported by the selected profile"
 msgstr ""
 
-#: ../../vdms_utils/presets_manager_utils.py:52
 msgid "Warning"
 msgstr ""
 
-#: ../../vdms_utils/presets_manager_utils.py:90
 msgid ""
 "No presets found.\n"
 "\n"
 "Possible solution: open the Presets Manager panel, go to the presets column and try to click the \"Restore all...\" button"
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:54
 msgid "Import queue file"
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:89
 #, python-brace-format
 msgid ""
 "ERROR: invalid data found loading queue file.\n"
@@ -3584,25 +2617,20 @@ msgid ""
 "Cannot contain multiple occurrences in `destination` keys value."
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:118
 msgid "Videomass - Add Items to Queue"
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:119
 msgid ""
 "Multiple items with identical names and destination paths cannot coexist.\n"
 "Please choose one of the following actions:"
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:123
 msgid "Replace occurrences with items from the imported queue."
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:124
 msgid "Add only the currently missing items to the queue."
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:125
 msgid "Remove the current queue and replace it with the imported one."
 msgstr ""
 
@@ -3613,5 +2641,8 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "Subtitle Mapping"
+#~ msgstr ""
+
+#~ msgid "Shortest"
 #~ msgstr ""
 

--- a/videomass/data/locale/hu_HU/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/hu_HU/LC_MESSAGES/videomass.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-30 11:02+0200\n"
+"POT-Creation-Date: 2025-07-30 15:28+0200\n"
 "PO-Revision-Date: 2024-07-17 16:31+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: hu_HU\n"
@@ -2633,16 +2633,4 @@ msgstr ""
 
 msgid "Remove the current queue and replace it with the imported one."
 msgstr ""
-
-#~ msgid "Some text boxes are still incomplete"
-#~ msgstr ""
-
-#~ msgid "FFplay"
-#~ msgstr ""
-
-#~ msgid "Subtitle Mapping"
-#~ msgstr ""
-
-#~ msgid "Shortest"
-#~ msgstr ""
 

--- a/videomass/data/locale/it_IT/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/it_IT/LC_MESSAGES/videomass.po
@@ -1,25 +1,23 @@
-# Italian translation for Videomass.
-# Copyleft -  2024 Gianluca Pernigotto
-# This file is distributed under the same license as the Videomass package
-# FIRST AUTHOR Gianluca Pernigotto <jeanlucperni@gmail.com>, 2020
+# Italian (Italy) translations for Videomass.
+# Copyright (C) 2025 ORGANIZATION
+# This file is distributed under the same license as the Videomass project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Videomass - IT - 12.07.2025\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-26 15:04+0200\n"
+"POT-Creation-Date: 2025-07-30 11:02+0200\n"
 "PO-Revision-Date: 2025-07-26 15:07+0200\n"
 "Last-Translator: bovirus <bovirus@gmail.comn>\n"
-"Language-Team: bovirus (bovirus@gmail.com)\n"
 "Language: it_IT\n"
+"Language-Team: bovirus (bovirus@gmail.com)\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.17.0\n"
-"X-Generator: Poedit 3.2.2\n"
 
-#: ../../gui_app.py:196
 #, python-brace-format
 msgid ""
 "Unexpected error while deleting file contents:\n"
@@ -30,162 +28,111 @@ msgstr ""
 "\n"
 "{0}"
 
-#: ../../vdms_dialogs/about_dialog.py:52
 msgid "Cross-platform graphical user interface for FFmpeg\n"
 msgstr "Interfaccia utente grafica multipiattaforma per FFMPEG\n"
 
-#: ../../vdms_dialogs/audioproperties.py:224
 msgid "Videomass supports mono and stereo audio channels. If you are not sure set to \"Auto\" and source values will be copied."
 msgstr "Videomass supporta i canali mono e stereo. Se non sicuro imposta su \"Auto\" e verranno copiati i valori di origine."
 
-#: ../../vdms_dialogs/audioproperties.py:228
 msgid "The audio Rate (or sample-rate) is the sound sampling frequency and is measured in Hertz. The higher the frequency, the more true it will be to the sound source and the more the file will increase in size. For audio CD playback, set a sampling frequency of 44100 kHz. If you are not sure, set to \"Auto\" and source values will be copied."
 msgstr "La frequenza audio è la frequenza di campionamento del suono la quale viene misurata in hertz. Più alta è la frequenza, più il segnale audio sarà fedele alla sorgente sonora, e maggiori saranno le dimensioni del file. Per la riproduzione di CD audio impostare una frequenza di campionamento a 44100 kHz. Se non sicuri, lasciare su \"Auto\", e i valori di origine verranno copiati."
 
-#: ../../vdms_dialogs/audioproperties.py:237
 msgid "The audio bitrate affects the file compression and thus the quality of listening. The higher the value, the higher the quality."
 msgstr "L'audio bit-rate influisce sulla compressione dei file e sulla qualità di ascolto. Più alto è il suo valore maggiore sarà la qualità del suono."
 
-#: ../../vdms_dialogs/audioproperties.py:241
 msgid "Bit depth is the number of bits of information in each sample, and it directly corresponds to the resolution of each sample. Bit depth is only meaningful in reference to a PCM digital signal. Non-PCM formats, such as lossy compression formats, do not have associated bit depths."
 msgstr "La profondità di bit è la risoluzione in bit delle informazioni in ciascun campione audio ed è significativa solo in riferimento a un segnale digitale PCM. I formati non PCM, come i formati di compressione con perdita, non hanno profondità di bit associate."
 
-#: ../../vdms_dialogs/epilogue.py:74 ../../vdms_dialogs/queuedlg.py:120
 msgid "When finished, once the operations have been completed successfully:"
 msgstr "Al termine, una volta che le operazioni sono state completate correttamente:"
 
-#: ../../vdms_dialogs/epilogue.py:80 ../../vdms_dialogs/queuedlg.py:126
 msgid "Trash the source files"
 msgstr "Elimina i file sorgenti"
 
-#: ../../vdms_dialogs/epilogue.py:84 ../../vdms_dialogs/queuedlg.py:130
 msgid "Clear the File List"
 msgstr "Azzera elenco file"
 
-#: ../../vdms_dialogs/epilogue.py:91 ../../vdms_dialogs/queuedlg.py:142
-#: ../../vdms_main/main_frame.py:1322
 msgid "Run"
 msgstr "Esegui"
 
-#: ../../vdms_dialogs/epilogue.py:97
 msgid "Videomass - Batch Mode"
 msgstr "Videomass - Modalità batch"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:47
 msgid "FFmpeg encoders"
 msgstr "Codificatori di FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:48
 msgid "supported encoders"
 msgstr "codificatori supportati"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:50
 msgid "FFmpeg decoders"
 msgstr "Decodificatori di FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:51
 msgid "supported decoders"
 msgstr "decodificatori supportati"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:77
-#: ../../vdms_panels/av_conversions.py:293
 msgid "Video"
 msgstr "Video"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:87
-#: ../../vdms_panels/av_conversions.py:305
 msgid "Audio"
 msgstr "Audio"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:97
 msgid "Subtitle"
 msgstr "Sottotitolo"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:114
-#: ../../vdms_dialogs/ffmpeg_codecs.py:123
-#: ../../vdms_dialogs/ffmpeg_codecs.py:132
-#: ../../vdms_dialogs/ffmpeg_formats.py:112
-#: ../../vdms_dialogs/ffmpeg_formats.py:115
-#: ../../vdms_dialogs/ffmpeg_formats.py:118
 msgid "description"
 msgstr "descrizione"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:72
 msgid "Informations"
 msgstr "Informazioni"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:83
 msgid "Flags settings"
 msgstr "Impostazioni flag"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:93
 msgid "Flags enabled"
 msgstr "Flag abilitati"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:103
 msgid "Flags disabled"
 msgstr "Flag disabilitati"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:116
 msgid "FFmpeg configuration"
 msgstr "Configurazione di FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:124
 msgid "flags"
 msgstr "flag"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:125 ../../vdms_dialogs/ffmpeg_conf.py:129
-#: ../../vdms_dialogs/ffmpeg_conf.py:133
 msgid "options"
 msgstr "opzioni"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:128 ../../vdms_dialogs/ffmpeg_conf.py:132
 msgid "status"
 msgstr "stato"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:167
 msgid "FFprobe   ...not found !"
 msgstr "FFprobe   ...non trovato !"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:175
 msgid "FFplay   ...not found !"
 msgstr "FFplay   ...non trovato !"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:205
-#: ../../vdms_panels/sequence_to_video.py:706
-#: ../../vdms_panels/video_to_sequence.py:606
 msgid "Enabled"
 msgstr "Abilitato"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:216
-#: ../../vdms_panels/sequence_to_video.py:706
-#: ../../vdms_panels/video_to_sequence.py:610
 msgid "Disabled"
 msgstr "Disabilitato"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:71
 msgid "Demuxing only"
 msgstr "Solo demuxing"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:82
 msgid "Muxing only"
 msgstr "Solo muxing"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:93
 msgid "Demuxing/Muxing support"
 msgstr "Demuxing e muxing"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:104
 msgid "FFmpeg file formats"
 msgstr "Formati file FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:111
-#: ../../vdms_dialogs/ffmpeg_formats.py:114
-#: ../../vdms_dialogs/ffmpeg_formats.py:117
 msgid "supported formats"
 msgstr "formati supportati"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:46
 msgid ""
 "Contextual help based on the argument entered in the additional text field.\n"
 "Each argument consists of the type and a type-specific name.\n"
@@ -211,117 +158,84 @@ msgstr ""
 "\n"
 "Qualche esempio:"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:68 ../../vdms_dialogs/ffmpeg_help.py:301
-#: ../../vdms_dialogs/ffmpeg_help.py:315
 msgid "Help topic"
 msgstr "Argomenti di aiuto"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:69
 msgid "List basic options"
 msgstr "Elenca le opzioni basilari"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:70
 msgid "List more options"
 msgstr "Elenca più opzioni"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:71
 msgid "List all options (very long)"
 msgstr "Elenca tutte le opzioni (molto lungo)"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:72
 msgid "Show available devices"
 msgstr "Visualizza dispositivi disponibili"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:73
 msgid "Show available bit stream filters"
 msgstr "Visualizza filtri bitstream disponibili"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:74
 msgid "Show available protocols"
 msgstr "Visualizza protocolli disponibili"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:75
 msgid "Show available filters"
 msgstr "Visualizza filtri disponibili"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:76
 msgid "Show available pixel formats"
 msgstr "Visualizza formati pixel disponibili"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:77
 msgid "Show available audio sample formats"
 msgstr "Visualizza formati campionamento audio disponibili"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:78
 msgid "Show available color names"
 msgstr "Visualizza nomi colori disponibili"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:79
 msgid "List sources of the input device"
 msgstr "Elenca le fonti del dispositivo di input"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:80
 msgid "List sinks of the output device"
 msgstr "Elenca sink dispositivo output"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:81
 msgid "Show available HW acceleration methods"
 msgstr "Visualizza metodi accelerazione hardware disponibili"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:82
 msgid "Show license"
 msgstr "Visualizza licenza"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:117 ../../vdms_dialogs/filter_scale.py:76
-#: ../../vdms_dialogs/shownormlist.py:98 ../../vdms_dialogs/shownormlist.py:107
-#: ../../vdms_dialogs/shownormlist.py:116 ../../vdms_miniframes/timeline.py:263
-#: ../../vdms_miniframes/timeline.py:283 ../../vdms_panels/concatenate.py:117
-#: ../../vdms_panels/sequence_to_video.py:117
-#: ../../vdms_panels/video_to_sequence.py:81
 msgid "Read me"
 msgstr "Leggimi"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:123 ../../vdms_main/main_frame.py:534
 msgid "Show configuration"
 msgstr "Visualizza configurazione"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:127 ../../vdms_main/main_frame.py:542
 msgid "Encoders"
 msgstr "Codificatori"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:131 ../../vdms_main/main_frame.py:545
 msgid "Decoders"
 msgstr "Decodificatori"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:135 ../../vdms_main/main_frame.py:538
 msgid "Muxers and Demuxers"
 msgstr "Muxer e demuxer"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:165
 msgid "help topic list"
 msgstr "elenco argomenti di aiuto"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:184
 msgid "Type the argument here and confirm with the enter key on your keyboard"
 msgstr "Digita qui l'argomento e conferma con il tasto Invio sulla tastiera"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:192
 msgid "The search function allows you to find entries in the current topic"
 msgstr "La funzione di ricerca consente di trovare voci nell'argomento corrente"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:195
 msgid "Ignore case"
 msgstr "Ignora maiuscole/minuscole"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:196
 msgid "Ignore case distinctions: characters with different case will match."
 msgstr "Ignora le distinzioni tra maiuscole e minuscole, in modo che i caratteri che differiscono solo nel caso corrispondano tra loro."
 
-#: ../../vdms_dialogs/ffmpeg_help.py:206
 msgid "FFmpeg help topics"
 msgstr "Argomenti della guida di FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:254
 msgid ""
 "This is a multifunctional search tool useful for local help searches\n"
 "on multiple FFmpeg topics and options. The search control, to\n"
@@ -342,8 +256,6 @@ msgstr ""
 "è probabile che la tua versione di FFmpeg sia troppo vecchia o non\n"
 "sia configurata con quelle funzionalità."
 
-#: ../../vdms_dialogs/ffmpeg_help.py:320 ../../vdms_dialogs/ffmpeg_help.py:345
-#: ../../vdms_dialogs/ffmpeg_help.py:371
 msgid ""
 "\n"
 "  ..Nothing available"
@@ -351,7 +263,6 @@ msgstr ""
 "\n"
 "  ..Nessun dato disponibile"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:391
 msgid ""
 "\n"
 "  ..Not found"
@@ -359,217 +270,121 @@ msgstr ""
 "\n"
 "  ..Non trovato"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:91
 msgid "Before"
 msgstr "Prima"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:97
 msgid "After"
 msgstr "Dopo"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:103
-#: ../../vdms_dialogs/filter_crop.py:239
 msgid "Search for a specific frame"
 msgstr "Cerca un fotogramma specifico"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:117
-#: ../../vdms_dialogs/filter_crop.py:253
 msgid "Load"
 msgstr "Carica"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:120
 msgid "Color EQ"
 msgstr "Equalizzazione Colore"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:126
 msgid "Contrast:"
 msgstr "Contrasto:"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:134
-#: ../../vdms_dialogs/filter_colorcorrection.py:148
 msgid "-100 to +100, default value 0"
 msgstr "Da -100 a +100, valore predefinito 0"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:139
 msgid "Brightness:"
 msgstr "Luminosità:"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:158
 msgid "Saturation:"
 msgstr "Saturazione:"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:166
 msgid "0 to 300, default value 100"
 msgstr "Da 0 a 300, valore predefinito 100"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:170
 msgid "Gamma:"
 msgstr "Gamma:"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:179
 msgid "0 to 100, default value 10"
 msgstr "Da 0 a 100, valore predefinito 10"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:187
-#: ../../vdms_dialogs/filter_crop.py:306
-#: ../../vdms_dialogs/filter_deinterlace.py:209
-#: ../../vdms_dialogs/filter_denoisers.py:110
-#: ../../vdms_dialogs/filter_scale.py:210 ../../vdms_dialogs/filter_stab.py:316
-#: ../../vdms_dialogs/filter_transpose.py:105
-#: ../../vdms_miniframes/timeline.py:262 ../../vdms_miniframes/timeline.py:281
 msgid "Reset"
 msgstr "Azzera"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:207
 msgid "Color Correction EQ Tool"
 msgstr "Strumento correzione del colore"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:343
-#: ../../vdms_dialogs/filter_colorcorrection.py:383
-#: ../../vdms_dialogs/filter_colorcorrection.py:390
-#: ../../vdms_dialogs/filter_crop.py:417 ../../vdms_dialogs/filter_scale.py:287
-#: ../../vdms_dialogs/filter_scale.py:394 ../../vdms_dialogs/filter_stab.py:473
-#: ../../vdms_dialogs/filter_stab.py:483 ../../vdms_dialogs/filter_stab.py:494
-#: ../../vdms_dialogs/filter_transpose.py:182
-#: ../../vdms_dialogs/mediainfo.py:245 ../../vdms_dialogs/mediainfo.py:265
-#: ../../vdms_dialogs/mediainfo.py:285 ../../vdms_dialogs/mediainfo.py:305
-#: ../../vdms_dialogs/setting_profiles.py:281
-#: ../../vdms_dialogs/setting_profiles.py:289 ../../vdms_io/checkup.py:45
-#: ../../vdms_io/checkup.py:93 ../../vdms_io/io_tools.py:144
-#: ../../vdms_main/main_frame.py:904 ../../vdms_main/main_frame.py:939
-#: ../../vdms_main/main_frame.py:961 ../../vdms_main/main_frame.py:979
-#: ../../vdms_main/main_frame.py:999
-#: ../../vdms_panels/audio_encoders/acodecs.py:510
-#: ../../vdms_panels/audio_encoders/acodecs.py:800
-#: ../../vdms_panels/concatenate.py:186
-#: ../../vdms_panels/long_processing_task.py:60
-#: ../../vdms_panels/presets_manager.py:426
-#: ../../vdms_panels/presets_manager.py:490
-#: ../../vdms_panels/presets_manager.py:560
-#: ../../vdms_panels/presets_manager.py:599
-#: ../../vdms_panels/presets_manager.py:619
-#: ../../vdms_panels/presets_manager.py:657
-#: ../../vdms_panels/presets_manager.py:701
-#: ../../vdms_panels/presets_manager.py:714
-#: ../../vdms_panels/presets_manager.py:721
-#: ../../vdms_panels/presets_manager.py:756
-#: ../../vdms_panels/presets_manager.py:785
-#: ../../vdms_panels/presets_manager.py:791
-#: ../../vdms_panels/sequence_to_video.py:467
-#: ../../vdms_panels/sequence_to_video.py:473
-#: ../../vdms_panels/sequence_to_video.py:561
-#: ../../vdms_panels/sequence_to_video.py:571
-#: ../../vdms_panels/sequence_to_video.py:588
-#: ../../vdms_panels/sequence_to_video.py:596
-#: ../../vdms_panels/sequence_to_video.py:602
-#: ../../vdms_panels/sequence_to_video.py:643
-#: ../../vdms_panels/sequence_to_video.py:689
-#: ../../vdms_panels/video_to_sequence.py:512
-#: ../../vdms_panels/video_to_sequence.py:583
-#: ../../vdms_threads/ffplay_file.py:43
-#: ../../vdms_utils/presets_manager_utils.py:86
-#: ../../vdms_utils/presets_manager_utils.py:95
-#: ../../vdms_utils/queue_utils.py:68 ../../vdms_utils/queue_utils.py:82
-#: ../../vdms_utils/queue_utils.py:95
 msgid "Videomass - Error!"
 msgstr "Videomass - Errore!"
 
-#: ../../vdms_dialogs/filter_crop.py:228 ../../vdms_dialogs/filter_scale.py:109
 #, python-brace-format
 msgid "Source size: {0} x {1} pixels"
 msgstr "Dimensione sorgente: {0} x {1} pixel"
 
-#: ../../vdms_dialogs/filter_crop.py:236
 msgid "Crop color"
 msgstr "Colore ritaglio"
 
-#: ../../vdms_dialogs/filter_crop.py:256
 msgid "Cropping area selection "
 msgstr "Selezione area di ritaglio "
 
-#: ../../vdms_dialogs/filter_crop.py:261 ../../vdms_dialogs/filter_scale.py:121
 msgid "Height"
 msgstr "Altezza"
 
-#: ../../vdms_dialogs/filter_crop.py:281
 msgid "Center"
 msgstr "Centro"
 
-#: ../../vdms_dialogs/filter_crop.py:292 ../../vdms_dialogs/filter_scale.py:121
 msgid "Width"
 msgstr "Larghezza"
 
-#: ../../vdms_dialogs/filter_crop.py:334
 msgid "Crop Tool"
 msgstr "Strumento ritaglio"
 
-#: ../../vdms_dialogs/filter_crop.py:335
 msgid "Choose the color to draw the cropping area"
 msgstr "Scegli il colore per disegnare l'area di ritaglio"
 
-#: ../../vdms_dialogs/filter_crop.py:337
 msgid "Crop to width"
 msgstr "Ritaglia in larghezza"
 
-#: ../../vdms_dialogs/filter_crop.py:338
 msgid "Move vertically (set to -1 to center the vertical axis)"
 msgstr "Sposta verticalmente (imposta a -1 per centrare l'asse verticale)"
 
-#: ../../vdms_dialogs/filter_crop.py:340
 msgid "Move horizontally (set to -1 to center the horizontal axis)"
 msgstr "Sposta orizzontalmente (imposta a -1 per centrare l'asse orizzontale)"
 
-#: ../../vdms_dialogs/filter_crop.py:342
 msgid "Crop to height"
 msgstr "Ritaglia all'altezza"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:56
 msgid "Advanced Options"
 msgstr "Opzioni avanzate"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:57
-#: ../../vdms_panels/av_conversions.py:351
 msgid "Deinterlace"
 msgstr "Deinterlaccia"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:59
 msgid "Interlace"
 msgstr "Interlacciamento"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:63
 msgid "Deinterlaces with w3fdif filter"
 msgstr "Deinterlaccia con il filtro w3fdif"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:77
 msgid "Deinterlaces with yadif filter"
 msgstr "Deinterlaccia con il filtro yadif"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:101
 msgid "Interlaces with interlace filter"
 msgstr "Interlaccia con il filtro interlace"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:118
 msgid "Deinterlacing and Interlacing"
 msgstr "Deinterlacciamento/interlacciamento"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:144
 msgid "Deinterlace the input video with `w3fdif` filter"
 msgstr "Deinterlaccia il video sorgente con il filtro `w3fdif`"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:146
 msgid "Set the interlacing filter coefficients."
 msgstr "Imposta i coefficienti del filtro interlacciamento."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:148
-#: ../../vdms_dialogs/filter_deinterlace.py:158
 msgid "Specify which frames to deinterlace."
 msgstr "Specifica i fotogrammi da deinterlacciare."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:150
 msgid "Deinterlace the input video with `yadif` filter. Using FFmpeg, this is the best and fastest choice"
 msgstr "Deinterlaccia il video sorgente con il filtro `yadif`, l'uso di FFmpeg è la scelta migliore e più veloce"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:153
 msgid ""
 "mode\n"
 "The interlacing mode to adopt."
@@ -577,7 +392,6 @@ msgstr ""
 "mode\n"
 "La modalità interlacciata da adottare."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:155
 msgid ""
 "parity\n"
 "The picture field parity assumed for the input interlaced video."
@@ -585,11 +399,9 @@ msgstr ""
 "parità\n"
 "La parità del campo dell'immagine presupposta per il video interlacciato sorgente."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:160
 msgid "Simple interlacing filter from progressive contents."
 msgstr "Filtro interlacciamento semplice dai contenuti progressivi."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:162
 msgid ""
 "scan:\n"
 "determines whether the interlaced frame is taken from the even (tff - default) or odd (bff) lines of the progressive frame."
@@ -598,7 +410,6 @@ msgstr ""
 "determina se il fotogramma interlacciato viene preso dalle linee pari (TFF - predefinito) o dispari (BFF) del fotogramma progressivo.\n"
 "scan=ttf è l'impostazione predefinita."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:166
 msgid ""
 "lowpass:\n"
 "Enable (default) or disable the vertical lowpass filter to avoid twitter interlacing and reduce moire patterns.\n"
@@ -608,31 +419,24 @@ msgstr ""
 "abilita (predefinito) o disabilita il filtro passa-basso verticale per evitare l'interlacciamento di twitter e ridurre i pattern di moiré.\n"
 "Non impostato."
 
-#: ../../vdms_dialogs/filter_denoisers.py:56
 msgid "Denoiser Filters"
 msgstr "Filtri denoiser"
 
-#: ../../vdms_dialogs/filter_denoisers.py:60
 msgid "Enable nlmeans denoiser"
 msgstr "Abilita denoiser nlmeans"
 
-#: ../../vdms_dialogs/filter_denoisers.py:73
 msgid "nlmeans options"
 msgstr "opzioni filtro nlmeans"
 
-#: ../../vdms_dialogs/filter_denoisers.py:82
 msgid "Enable hqdn3d denoiser"
 msgstr "Abilita denoiser hqdn3d"
 
-#: ../../vdms_dialogs/filter_denoisers.py:91
 msgid "hqdn3d options"
 msgstr "opzioni filtro hqdn3d"
 
-#: ../../vdms_dialogs/filter_denoisers.py:116
 msgid "Denoiser Tool"
 msgstr "Strumento denoiser"
 
-#: ../../vdms_dialogs/filter_denoisers.py:117
 msgid ""
 "nlmeans:\n"
 "Denoise frames using Non-Local Means algorithm is capable of restoring video sequences, even with strong noise. It is ideal for enhancing the quality of old VHS tapes."
@@ -641,7 +445,6 @@ msgstr ""
 "elimina il disturbo dai fotogrammi usando l'algoritmo Non-Local, il quale è in grado di ristrutturare sequenze video con rumore anche intenso. \n"
 "È ideale per migliorare la qualità dei vecchi nastri VHS."
 
-#: ../../vdms_dialogs/filter_denoisers.py:122
 msgid ""
 "hqdn3d:\n"
 "This is a high precision/quality 3d denoise filter. It aims to reduce image noise, producing smooth images and making still images really still. It should enhance compressibility."
@@ -651,65 +454,48 @@ msgstr ""
 "Mira a ridurre il rumore dell'immagine, a produrre immagini uniformi e a rendere ferme le immagini statiche. \n"
 "Dovrebbe migliorare comprensibilmente la qualità visiva."
 
-#: ../../vdms_dialogs/filter_scale.py:81
 msgid "View result"
 msgstr "Visualizza risultato"
 
-#: ../../vdms_dialogs/filter_scale.py:85
 msgid "New size in pixels"
 msgstr "Nuova dimensione in pixel"
 
-#: ../../vdms_dialogs/filter_scale.py:89
 msgid "Width:"
 msgstr "Larghezza:"
 
-#: ../../vdms_dialogs/filter_scale.py:99
 msgid "Height:"
 msgstr "Altezza:"
 
-#: ../../vdms_dialogs/filter_scale.py:115
 msgid "Constrain proportions (keep aspect ratio)"
 msgstr "Vincola le proporzioni (mantieni l'aspetto di origine)"
 
-#: ../../vdms_dialogs/filter_scale.py:120
 msgid "Which dimension to adjust?"
 msgstr "Quale nuova dimensione?"
 
-#: ../../vdms_dialogs/filter_scale.py:129
 msgid "Aspect Ratio"
 msgstr "Proporzioni"
 
-#: ../../vdms_dialogs/filter_scale.py:132
 msgid "Setdar filter (display aspect ratio) example 16/9, 4/3 "
 msgstr "Filtro Setdar (proporzioni visualizzazione) esempio 16/9, 4/3 "
 
-#: ../../vdms_dialogs/filter_scale.py:137
-#: ../../vdms_dialogs/filter_scale.py:171
 msgid "Numerator"
 msgstr "Numeratore"
 
-#: ../../vdms_dialogs/filter_scale.py:162
-#: ../../vdms_dialogs/filter_scale.py:196
 msgid "Denominator"
 msgstr "Denominatore"
 
-#: ../../vdms_dialogs/filter_scale.py:166
 msgid "Setsar filter (sample aspect ratio) example 1/1"
 msgstr "Filtro Setsar (rapporto di aspetto del campione) esempio 1/1"
 
-#: ../../vdms_dialogs/filter_scale.py:217
 msgid "Resize Tool"
 msgstr "Strumento ridimensionamento"
 
-#: ../../vdms_dialogs/filter_scale.py:218
 msgid "Scale filter, set to 0 to disable"
 msgstr "Filtro scala, per la disabilitazione impostare a 0"
 
-#: ../../vdms_dialogs/filter_scale.py:221
 msgid "Display Aspect Ratio. Set to 0 to disable"
 msgstr "Visualizzazione del rapporto di aspetto (proporzioni). Impostare a 0 per disabilitare"
 
-#: ../../vdms_dialogs/filter_scale.py:224
 msgid ""
 "Sample (aka Pixel) Aspect Ratio.\n"
 "Set to 0 to disable"
@@ -717,7 +503,6 @@ msgstr ""
 "Rapporto di aspetto campione (noto anche come pixel).\n"
 "Impostare a 0 per disabilitare"
 
-#: ../../vdms_dialogs/filter_scale.py:366
 msgid ""
 "If you want to keep the aspect ratio, select \"Constrain proportions\" below and\n"
 "specify only one dimension, either width or height, and set the other dimension\n"
@@ -727,156 +512,123 @@ msgstr ""
 "e specifica solo una dimensione, larghezza o altezza, e imposta l'altra dimensione\n"
 "a -1 o -2 (alcuni codec richiedono -2, quindi prima dovresti fare qualche test)."
 
-#: ../../vdms_dialogs/filter_stab.py:81
 msgid "Enable stabilizer"
 msgstr "Abilita lo stabilizzatore"
 
-#: ../../vdms_dialogs/filter_stab.py:83
 msgid "Create a side-by-side comparison video"
 msgstr "Crea un video di confronto fianco a fianco"
 
-#: ../../vdms_dialogs/filter_stab.py:88
 msgid "Create a snapshot"
 msgstr "Crea un'istantanea"
 
-#: ../../vdms_dialogs/filter_stab.py:106
-#: ../../vdms_panels/audio_encoders/acodecs.py:167
 msgid "Preview"
 msgstr "Anteprima"
 
-#: ../../vdms_dialogs/filter_stab.py:109
 msgid "Duration seconds:"
 msgstr "Durata in secondi:"
 
-#: ../../vdms_dialogs/filter_stab.py:118
 msgid "Video Detect"
 msgstr "Rilevamento"
 
-#: ../../vdms_dialogs/filter_stab.py:176
 msgid "[TRIPOD] Enable tripod mode if checked"
 msgstr "[TRIPOD] Abilita modalità treppiede"
 
-#: ../../vdms_dialogs/filter_stab.py:183
 msgid "Video transform"
 msgstr "Trasformazione"
 
-#: ../../vdms_dialogs/filter_stab.py:202
 msgid "[OPTALGO] optimization algorithm"
 msgstr "[OPTALGO] algoritmo ottimizzazione"
 
-#: ../../vdms_dialogs/filter_stab.py:224
 msgid "[CROP] Specify how to deal with borders at movement compensation"
 msgstr "[CROP] Specifica come trattare i bordi alla compensazione del movimento"
 
-#: ../../vdms_dialogs/filter_stab.py:231
 msgid "[INVERT] Invert transforms if checked"
 msgstr "[INVERT] Inverti trasformazioni se abilitato"
 
-#: ../../vdms_dialogs/filter_stab.py:234
 msgid "[RELATIVE] Consider transforms as relative to previous frame if checked, absolute if unchecked"
 msgstr "[RELATIVE] Considera le trasformazioni come relative al frame precedente se abilitato, assoluto se disabilitato"
 
-#: ../../vdms_dialogs/filter_stab.py:279
 msgid "Specify type of interpolation"
 msgstr "Specificare il tipo di interpolazione"
 
-#: ../../vdms_dialogs/filter_stab.py:287
 msgid "[TRIPOD2] virtual tripod mode, equivalent to relative=unchecked:smoothing=0"
 msgstr "[TRIPOD2] modalità treppiede virtuale, equivale a relative=disabilitato: smoothing=0"
 
-#: ../../vdms_dialogs/filter_stab.py:294
 msgid "Unsharp filter:"
 msgstr "Filtro unsharp:"
 
-#: ../../vdms_dialogs/filter_stab.py:323
 msgid "Seek to a position on the video."
 msgstr "Ricerca una posizione nel video."
 
-#: ../../vdms_dialogs/filter_stab.py:325
 msgid "Make a snapshot of the video with the settings made."
 msgstr "Crea un'istantanea del video con le impostazioni effettuate."
 
-#: ../../vdms_dialogs/filter_stab.py:327
 msgid "Set the snapshot duration from 3 to 15 seconds from the seek position, default is 5 seconds."
 msgstr "Imposta la durata dell'istantanea da 3 a 15 secondi dalla posizione di ricerca, in default sono 5 secondi."
 
-#: ../../vdms_dialogs/filter_stab.py:331
 msgid "Set how shaky the video is and how quick the camera is. A value of 1 means little shakiness, a value of 10 means strong shakiness. Default value is 5."
 msgstr "Imposta quanto è mosso il video e quanto è veloce la fotocamera. Un valore di 1 significa poco tremolio, un valore di 10 significa forte tremolio. Il valore predefinito è 5."
 
-#: ../../vdms_dialogs/filter_stab.py:335
 msgid "Set the accuracy of the detection process. A value of 1 means low accuracy, a value of 15 means high accuracy. Default value is 15."
 msgstr "Imposta la precisione del processo di rilevamento. Un valore di 1 significa bassa precisione, un valore di 15 significa alta precisione. Il valore predefinito è 15."
 
-#: ../../vdms_dialogs/filter_stab.py:339
 msgid "Set stepsize of the search process. The region around minimum is scanned with 1 pixel resolution. Default value is 6."
 msgstr "Imposta la dimensione del processo di ricerca. La regione intorno al minimo viene scansionata con una risoluzione di 1 pixel. Il valore predefinito è 6."
 
-#: ../../vdms_dialogs/filter_stab.py:343
 msgid "Set minimum contrast. Below this value a local measurement field is discarded. The range is 0-1. Default value is 0.25."
 msgstr "Imposta il contrasto minimo. Al di sotto di questo valore viene scartato un campo di misurazione locale. L'intervallo è 0-1. Il valore predefinito è 0.25."
 
-#: ../../vdms_dialogs/filter_stab.py:346
 msgid "Set reference frame number for tripod mode. If enabled, the motion of the frames is compared to a reference frame in the filtered stream, identified by the specified number. The idea is to compensate all movements in a more-or-less static scene and keep the camera view absolutely still. The frames are counted starting from 1."
 msgstr "Imposta il numero del fotogramma di riferimento per la modalità treppiede. Se abilitato, il movimento dei frame viene confrontato con un frame di riferimento nello stream filtrato, identificato dal numero specificato. L'idea è di compensare tutti i movimenti in una scena più o meno statica e mantenere la visuale della telecamera assolutamente ferma. I frame vengono conteggiati a partire da 1."
 
-#: ../../vdms_dialogs/filter_stab.py:355
-msgid "Set the number of frames (value*2 + 1) used for lowpass filtering the camera movements. Default value is 15. For example a number of 10 means that 21 frames are used (10 in the past and 10 in the future) to smoothen the motion in the video. A larger value leads to a smoother video, but limits the acceleration of the camera (pan/tilt movements). 0 is a special case where a static camera is simulated."
-msgstr "Imposta il numero di fotogrammi (valore * 2 + 1) usati per il filtraggio passa-basso dei movimenti della telecamera. Il valore predefinito è 15. Ad esempio, un numero di 10 significa che vengono usati 21 fotogrammi (10 in passato e 10 in futuro) per rendere più uniforme il movimento nel video. Un valore maggiore porta a un video più fluido, ma limita l'accelerazione della telecamera (movimenti di panoramica / inclinazione). 0 è un caso speciale in cui viene simulata una telecamera statica."
+msgid ""
+"Set the number of frames (value*2 + 1) used for lowpass filtering the camera movements. Default value is 15. For example a number of 10 means that 21 frames are used (10 in the past and 10 in the future) to smoothen the motion in the video. A larger value leads to a smoother video, but limits the acceleration of the camera (pan/tilt movements). 0 is a special case where a static camera is "
+"simulated."
+msgstr ""
+"Imposta il numero di fotogrammi (valore * 2 + 1) usati per il filtraggio passa-basso dei movimenti della telecamera. Il valore predefinito è 15. Ad esempio, un numero di 10 significa che vengono usati 21 fotogrammi (10 in passato e 10 in futuro) per rendere più uniforme il movimento nel video. Un valore maggiore porta a un video più fluido, ma limita l'accelerazione della telecamera (movimenti "
+"di panoramica / inclinazione). 0 è un caso speciale in cui viene simulata una telecamera statica."
 
-#: ../../vdms_dialogs/filter_stab.py:363
 msgid "Set the camera path optimization algorithm. Values are: `gauss`: gaussian kernel low-pass filter on camera motion (default), and `avg`: averaging on transformations"
 msgstr "Imposta l'algoritmo di ottimizzazione del percorso della fotocamera. I valori sono: \"gauss\": filtro passa-basso del kernel gaussiano sul movimento della fotocamera (predefinito), e media \"avg\" per le trasformazioni"
 
-#: ../../vdms_dialogs/filter_stab.py:367
 msgid "Set maximal angle in radians (degree*PI/180) to rotate frames. Default value is -1, meaning no limit."
 msgstr "Imposta l'angolo massimo in radianti (gradi * PI / 180) per ruotare i fotogrammi. Il valore predefinito è -1, ovvero nessun limite."
 
-#: ../../vdms_dialogs/filter_stab.py:370
 msgid "Specify how to deal with borders that may be visible due to movement compensation. Values are: `keep` keep image information from previous frame (default), `black` fill the border black"
 msgstr "Specificare come trattare i bordi che possono essere visibili a causa della compensazione del movimento. I valori sono: \"conserva\" conserva le informazioni sull'immagine dal fotogramma precedente (impostazione predefinita), \"nero\" riempie il bordo nero"
 
-#: ../../vdms_dialogs/filter_stab.py:375
 msgid "Invert transforms if checked. Default is unchecked."
 msgstr "Inverti le trasformazioni se abilitato. Per impostazione predefinita è disabilitato."
 
-#: ../../vdms_dialogs/filter_stab.py:377
 msgid "Consider transforms as relative to previous frame if checked, absolute if unchecked. Default is checked."
 msgstr "Considera le trasformazioni come relative al frame precedente se abilitato, assoluto se disabilitato. Per impostazione predefinita è abilitato."
 
-#: ../../vdms_dialogs/filter_stab.py:380
 msgid "Set percentage to zoom. A positive value will result in a zoom-in effect, a negative value in a zoom-out effect. Default value is 0 (no zoom)."
 msgstr "Imposta la percentuale per lo zoom. Un valore positivo si tradurrà in un effetto di ingrandimento, un valore negativo in un effetto di riduzione. Il valore predefinito è 0 (senza zoom)."
 
-#: ../../vdms_dialogs/filter_stab.py:384
 msgid "Set optimal zooming to avoid borders. Accepted values are: `0` disabled, `1` optimal static zoom value is determined (only very strong movements will lead to visible borders) (default), `2` optimal adaptive zoom value is determined (no borders will be visible), see zoomspeed. Note that the value given at zoom is added to the one calculated here."
-msgstr "Imposta lo zoom ottimale per evitare i bordi. I valori accettati sono: '0' disabilitato, il valore di zoom statico ottimale '1' è determinato (solo movimenti molto forti porteranno a bordi visibili) (impostazione predefinita), il valore di zoom adattivo ottimale '2' è determinato (nessun bordo sarà visibile) vedere zoomspeed. Notare che il valore fornito allo zoom viene aggiunto a quello calcolato qui."
+msgstr ""
+"Imposta lo zoom ottimale per evitare i bordi. I valori accettati sono: '0' disabilitato, il valore di zoom statico ottimale '1' è determinato (solo movimenti molto forti porteranno a bordi visibili) (impostazione predefinita), il valore di zoom adattivo ottimale '2' è determinato (nessun bordo sarà visibile) vedere zoomspeed. Notare che il valore fornito allo zoom viene aggiunto a quello "
+"calcolato qui."
 
-#: ../../vdms_dialogs/filter_stab.py:391
 msgid "Set percent to zoom maximally each frame (enabled when optzoom is set to 2). Range is from 0 to 5, default value is 0.25."
 msgstr "Imposta la percentuale per ingrandire al massimo ogni fotogramma (abilitato quando optzoom è impostato su 2). L'intervallo è compreso tra 0 e 5, il valore predefinito è 0,25."
 
-#: ../../vdms_dialogs/filter_stab.py:395
 msgid "Specify type of interpolation. Available values are: `no` no interpolation, `linear` linear only horizontal, `bilinear` linear in both directions (default), `bicubic` cubic in both directions (slow)"
 msgstr "Specificare il tipo di interpolazione. I valori disponibili sono: \"no\" nessuna interpolazione, \"linear\" lineare solo orizzontale, \"bilinear\" lineare in entrambe le direzioni (impostazione predefinita), \"bicubic\" cubica in entrambe le direzioni (lenta)"
 
-#: ../../vdms_dialogs/filter_stab.py:400
 msgid "Enable virtual tripod mode if checked, which is equivalent to relative=0:smoothing=0. Default is unchecked. Use also tripod option of vidstabdetect."
 msgstr "Abilita la modalità treppiede virtuale se selezionata, che è equivalente a relative=abilitato: smoothing=0. Per impostazione predefinita è disabilitato. Usa anche l'opzione treppiede di vidstabdetect."
 
-#: ../../vdms_dialogs/filter_stab.py:405
 msgid "Sharpen or blur the input video. Note the use of the unsharp filter which is always recommended."
 msgstr "Rende più nitido o sfocato il video in ingresso. Nota che l'uso del filtro unsharp è sempre consigliato."
 
-#: ../../vdms_dialogs/filter_stab.py:409
 msgid "Video Stabilizer Tool"
 msgstr "Strumento stabilizzatore video"
 
-#: ../../vdms_dialogs/filter_stab.py:541 ../../vdms_io/io_tools.py:73
 msgid "Videomass - Loading..."
 msgstr "Caricamento..."
 
-#: ../../vdms_dialogs/filter_stab.py:542
 msgid ""
 "Please wait,\n"
 "This process will take a few seconds."
@@ -884,135 +636,96 @@ msgstr ""
 "Attendi,\n"
 "questo processo richiederà alcuni secondi."
 
-#: ../../vdms_dialogs/filter_transpose.py:80
-#: ../../vdms_dialogs/filter_transpose.py:293
 msgid "Default position"
 msgstr "Posizione predefinita"
 
-#: ../../vdms_dialogs/filter_transpose.py:86
 msgid "Rotation setting"
 msgstr "Impostazione rotazione"
 
-#: ../../vdms_dialogs/filter_transpose.py:94
 msgid "90° (left)"
 msgstr "90° (sinistra)"
 
-#: ../../vdms_dialogs/filter_transpose.py:96
 msgid "90° (right)"
 msgstr "90° (destra)"
 
-#: ../../vdms_dialogs/filter_transpose.py:100
 msgid "180°"
 msgstr "180°"
 
-#: ../../vdms_dialogs/filter_transpose.py:115
 msgid "Transpose Tool"
 msgstr "Strumento trasponi"
 
-#: ../../vdms_dialogs/filter_transpose.py:229
 msgid "Rotate 90 degrees right"
 msgstr "Ruota di 90 gradi a destra"
 
-#: ../../vdms_dialogs/filter_transpose.py:251
 msgid "Rotate 180 degrees"
 msgstr "Ruota di 180 gradi"
 
-#: ../../vdms_dialogs/filter_transpose.py:272
 msgid "Rotate 90 degrees left"
 msgstr "Ruota di 90 gradi a sinistra"
 
-#: ../../vdms_dialogs/mediainfo.py:82
 msgid "Format"
 msgstr "Formato"
 
-#: ../../vdms_dialogs/mediainfo.py:96
 msgid "Video Stream"
 msgstr "Flusso video"
 
-#: ../../vdms_dialogs/mediainfo.py:109
 msgid "Audio Streams"
 msgstr "Flussi audio"
 
-#: ../../vdms_dialogs/mediainfo.py:122
 msgid "Subtitle Streams"
 msgstr "Flussi sottotitoli"
 
-#: ../../vdms_dialogs/mediainfo.py:126
 msgid "Copy to clipboard"
 msgstr "Copia negli appunti"
 
-#: ../../vdms_dialogs/mediainfo.py:137
 msgid "FILE SELECTION"
 msgstr "SELEZIONE FILE"
 
-#: ../../vdms_dialogs/mediainfo.py:139 ../../vdms_dialogs/mediainfo.py:142
-#: ../../vdms_dialogs/mediainfo.py:145 ../../vdms_dialogs/mediainfo.py:148
-#: ../../vdms_main/main_frame.py:1318
 msgid "Properties"
 msgstr "Proprietà"
 
-#: ../../vdms_dialogs/mediainfo.py:140 ../../vdms_dialogs/mediainfo.py:143
-#: ../../vdms_dialogs/mediainfo.py:146 ../../vdms_dialogs/mediainfo.py:149
 msgid "Values"
 msgstr "Valori"
 
-#: ../../vdms_dialogs/mediainfo.py:152
 msgid "Streams Properties"
 msgstr "Proprietà flussi"
 
-#: ../../vdms_dialogs/mediainfo.py:244
 msgid "Unable to open the clipboard on Format tab"
 msgstr "Impossibile aprire gli appunti nella scheda Formato"
 
-#: ../../vdms_dialogs/mediainfo.py:263
 msgid "Unable to open the clipboard on Video Streams tab"
 msgstr "Impossibile aprire gli appunti nella scheda Flussi Video"
 
-#: ../../vdms_dialogs/mediainfo.py:283
 msgid "Unable to open the clipboard on Audio Streams tab"
 msgstr "Impossibile aprire gli appunti nella scheda \"Flussi audio\""
 
-#: ../../vdms_dialogs/mediainfo.py:303
 msgid "Unable to open the clipboard on Subtitle Streams tab"
 msgstr "Impossibile aprire gli appunti nella scheda \"Flussi sottotitoli\""
 
-#: ../../vdms_dialogs/preferences.py:90
 msgid "Where do you prefer to save your transcodes?"
 msgstr "Dove preferisci salvare le conversioni?"
 
-#: ../../vdms_dialogs/preferences.py:101 ../../vdms_dialogs/preferences.py:128
-#: ../../vdms_dialogs/preferences.py:149 ../../vdms_dialogs/preferences.py:161
-#: ../../vdms_dialogs/preferences.py:173 ../../vdms_panels/filedrop.py:284
 msgid "Change"
 msgstr "Modifica"
 
-#: ../../vdms_dialogs/preferences.py:103
-#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:602
-#: ../../vdms_panels/presets_manager.py:1050
 msgid "Same destination paths as source files"
 msgstr "Stessi percorsi per file destinazione e sorgente"
 
-#: ../../vdms_dialogs/preferences.py:108
 msgid "Assign optional suffix to destination file names:"
 msgstr "Assegna un suffisso opzionale ai nomi file destinazione:"
 
-#: ../../vdms_dialogs/preferences.py:114
 msgid "File removal preferences"
 msgstr "Impostazioni rimozione file"
 
-#: ../../vdms_dialogs/preferences.py:118
 msgid "Trash the source files after successful encoding"
 msgstr "Elimina i file sorgente dopo aver eseguito correttamente la codifica"
 
-#: ../../vdms_dialogs/preferences.py:131
 msgid "File Preferences"
 msgstr "Impostazioni file"
 
-#: ../../vdms_dialogs/preferences.py:138
 msgid "Location of executables"
 msgstr "Individuazione eseguibili"
 
-#: ../../vdms_dialogs/preferences.py:140
 msgid ""
 "FFmpeg can be built by enabling/disabling its options and this depends on your needs.\n"
 "For some use cases it is possible to provide a custom build of FFmpeg where you can specify\n"
@@ -1022,109 +735,83 @@ msgstr ""
 "tue necessità. Per alcuni casi d'uso è possibile fornire una build personalizzata di FFmpeg dove\n"
 "puoi specificarla in questa tabella delle preferenze."
 
-#: ../../vdms_dialogs/preferences.py:147
 msgid "Enable a custom location to run FFmpeg"
 msgstr "Abilita percorso personalizzato esecuzione FFmpeg"
 
-#: ../../vdms_dialogs/preferences.py:159
 msgid "Enable a custom location to run FFprobe"
 msgstr "Abilita percorso personalizzato esecuzione FFprobe"
 
-#: ../../vdms_dialogs/preferences.py:171
 msgid "Enable a custom location to run FFplay"
 msgstr "Abilita percorso personalizzato esecuzione FFplay"
 
-#: ../../vdms_dialogs/preferences.py:183
 msgid "FFmpeg"
 msgstr "FFmpeg"
 
-#: ../../vdms_dialogs/preferences.py:189
 msgid "Look and Feel (requires application restart)"
 msgstr "Aspetto (richiede il riavvio dell'applicazione)"
 
-#: ../../vdms_dialogs/preferences.py:194
 msgid "Icon themes"
 msgstr "Temi icona"
 
-#: ../../vdms_dialogs/preferences.py:208
 msgid "At the top of window (default)"
 msgstr "Sopra alla finestra (predefinito)"
 
-#: ../../vdms_dialogs/preferences.py:209
 msgid "At the bottom of window"
 msgstr "Sotto alla finestra"
 
-#: ../../vdms_dialogs/preferences.py:210
 msgid "At the right of window"
 msgstr "A destra della finestra"
 
-#: ../../vdms_dialogs/preferences.py:211
 msgid "At the left of window"
 msgstr "A sinistra della finestra"
 
-#: ../../vdms_dialogs/preferences.py:213
 msgid "Place the toolbar"
 msgstr "Posiziona barra strumenti"
 
-#: ../../vdms_dialogs/preferences.py:222
 msgid "Toolbar's icons size:"
 msgstr "Dimensioni icone barra strumenti:"
 
-#: ../../vdms_dialogs/preferences.py:236
 msgid "Application Language (requires application restart)"
 msgstr "Lingua applicazione (richiede il riavvio dell'applicazione)"
 
-#: ../../vdms_dialogs/preferences.py:248
 msgid "Look and Language"
 msgstr "Aspetto e lingua"
 
-#: ../../vdms_dialogs/preferences.py:254
 msgid "Upon exiting the application"
 msgstr "All'uscita dall'applicazione"
 
-#: ../../vdms_dialogs/preferences.py:259
 msgid "Always ask me to confirm"
 msgstr "Chiedimi sempre di confermare"
 
-#: ../../vdms_dialogs/preferences.py:261
 msgid "Clean the log files"
 msgstr "Pulisci i file registro"
 
-#: ../../vdms_dialogs/preferences.py:264
 msgid "Remove cached files"
 msgstr "Rimuovi i file memorizzati nella cache"
 
-#: ../../vdms_dialogs/preferences.py:268
 msgid "On operations completion"
 msgstr "Al termine delle operazioni"
 
-#: ../../vdms_dialogs/preferences.py:271
 msgid "These settings will remain active until the application is closed, If necessary, remember to reactivate them."
 msgstr ""
 "Queste impostazioni saranno attive fino alla chiusura dell'applicazione. \n"
 "Se necessario, ricordati di riattivarle."
 
-#: ../../vdms_dialogs/preferences.py:276
 msgid "Exit the application"
 msgstr "Esci dall'applicazione"
 
-#: ../../vdms_dialogs/preferences.py:279
 msgid "Shutdown the system"
 msgstr "Spegni il sistema"
 
-#: ../../vdms_dialogs/preferences.py:283
 msgid "SUDO password:"
 msgstr "Password SUDO:"
 
-#: ../../vdms_dialogs/preferences.py:292
 msgid "Exit and Shutdown"
 msgstr "Uscita e spegnimento"
 
-#: ../../vdms_dialogs/preferences.py:298
 msgid "Specify the character encoding format"
 msgstr "Specifica il formato di codifica dei caratteri"
 
-#: ../../vdms_dialogs/preferences.py:301
 msgid ""
 "Although UTF-8 is the default and most widely used standard encoding format, it is not the only encoding format available.\n"
 "Some file metadata may still contain non-UTF-8 character encodings resulting in the error \"'utf-8' codec can't decode bytes...\".\n"
@@ -1135,31 +822,24 @@ msgstr ""
 "l'errore \"'utf-8' codec can't decode bytes...\". \n"
 "Se conosci il formato di codifica in cui è stato scritto il file, puoi provare a specificarlo qui."
 
-#: ../../vdms_dialogs/preferences.py:311
 msgid "Character encoding:"
 msgstr "Codifica caratteri:"
 
-#: ../../vdms_dialogs/preferences.py:320
 msgid "Default application directories"
 msgstr "Cartelle predefinite applicazione"
 
-#: ../../vdms_dialogs/preferences.py:324
 msgid "Configuration directory"
 msgstr "Cartella configurazione"
 
-#: ../../vdms_dialogs/preferences.py:337
 msgid "Cache directory"
 msgstr "Cartella cache"
 
-#: ../../vdms_dialogs/preferences.py:349
 msgid "Log directory"
 msgstr "Cartella registro eventi"
 
-#: ../../vdms_dialogs/preferences.py:363
 msgid "Advanced"
 msgstr "Avanzate"
 
-#: ../../vdms_dialogs/preferences.py:369
 msgid ""
 "The following settings affect output messages and the log messages during transcoding processes.\n"
 "Be careful, by changing these settings some functions of the application may not work correctly,\n"
@@ -1169,121 +849,73 @@ msgstr ""
 "di transcodifica. Fai attenzione, modificando queste impostazioni alcune funzioni dell'applicazione \n"
 "potrebbero non funzionare correttamente, modificale solo se sai cosa stai facendo.\n"
 
-#: ../../vdms_dialogs/preferences.py:376
 msgid "Set logging level flags used by FFmpeg"
 msgstr "Imposta flag livello registro eventi usati da FFmpeg"
 
-#: ../../vdms_dialogs/preferences.py:383
 msgid "Set logging level flags used by FFplay"
 msgstr "Imposta flag livello registrazione FFplay"
 
-#: ../../vdms_dialogs/preferences.py:391
 msgid "FFmpeg logging levels"
 msgstr "Livelli registri FFmpeg"
 
-#: ../../vdms_dialogs/preferences.py:437
 msgid "By assigning an additional suffix you could avoid overwriting files"
 msgstr "Assegnando un suffisso aggiuntivo è possibile evitare di sovrascrivere i file"
 
-#: ../../vdms_dialogs/preferences.py:440
 msgid "Type sudo password here, only for Unix-like operating systems, not for MS Windows"
 msgstr "Digita qui la password sudo, solo per i sistemi operativi Unix-like, non per MS Windows"
 
-#: ../../vdms_dialogs/preferences.py:443
 msgid "Preferences"
 msgstr "Impostazioni"
 
-#: ../../vdms_dialogs/preferences.py:596 ../../vdms_dialogs/preferences.py:676
-#: ../../vdms_main/main_frame.py:879 ../../vdms_main/main_frame.py:1060
 msgid "Choose Destination"
 msgstr "Scegli la Destinazione"
 
-#: ../../vdms_dialogs/preferences.py:627
 msgid "Enter only alphanumeric characters. You can also use the hyphen (\"-\") and the underscore (\"_\"). Spaces are not allowed."
 msgstr "Immettere solo caratteri alfanumerici. È inoltre possibile usare il trattino (\"-\") e il trattino basso (\"_\"). Non sono ammessi spazi vuoti."
 
-#: ../../vdms_dialogs/preferences.py:642
-#: ../../vdms_dialogs/setting_profiles.py:257
-#: ../../vdms_dialogs/setting_profiles.py:264
-#: ../../vdms_dialogs/setting_profiles.py:286
-#: ../../vdms_dialogs/setting_profiles.py:309 ../../vdms_main/main_frame.py:399
-#: ../../vdms_main/main_frame.py:421 ../../vdms_panels/av_conversions.py:605
-#: ../../vdms_panels/av_conversions.py:612
-#: ../../vdms_panels/sequence_to_video.py:352
-#: ../../vdms_panels/video_to_sequence.py:399
 msgid "Videomass - Warning!"
 msgstr "Videomass - Attenzione!"
 
-#: ../../vdms_dialogs/preferences.py:731 ../../vdms_dialogs/preferences.py:771
-#: ../../vdms_dialogs/preferences.py:811 ../../vdms_dialogs/wizard_dlg.py:365
-#: ../../vdms_dialogs/wizard_dlg.py:384 ../../vdms_dialogs/wizard_dlg.py:403
 #, python-brace-format
 msgid "{} location"
 msgstr "Percorso {}"
 
-#: ../../vdms_dialogs/queue_edit.py:36
-#: ../../vdms_dialogs/setting_profiles.py:38
 msgid "One-Pass, Do not start with `ffmpeg -i filename`; do not end with `output-filename`"
 msgstr "Singolo passaggio, Non iniziare con `ffmpeg -i nomefile`; Non finire con `nomefile_in_uscita`"
 
-#: ../../vdms_dialogs/queue_edit.py:40
-#: ../../vdms_dialogs/setting_profiles.py:42
 msgid "Two-Pass (optional), Do not start with `ffmpeg -i filename`; do not end with `output-filename`"
 msgstr "Doppio passaggio (opzionale), Non iniziare con `ffmpeg -i nomefile`; Non finire con `nomefile_in_uscita`"
 
-#: ../../vdms_dialogs/queue_edit.py:59
 msgid "Videomass - Edit the selected item in the queue"
 msgstr "Videomass - Modifica l'elemento selezionato nella coda"
 
-#: ../../vdms_dialogs/queue_edit.py:71
-#: ../../vdms_dialogs/setting_profiles.py:92
 msgid "Pre-input arguments for One-Pass (optional)"
 msgstr "Argomenti pre-input per il singolo passaggio (opzionale)"
 
-#: ../../vdms_dialogs/queue_edit.py:82
-#: ../../vdms_dialogs/setting_profiles.py:151
-#: ../../vdms_panels/presets_manager.py:255
 msgid "FFmpeg arguments for one-pass encoding"
 msgstr "Argomenti FFmpeg per la codifica a passaggio singolo"
 
-#: ../../vdms_dialogs/queue_edit.py:88
-#: ../../vdms_dialogs/setting_profiles.py:158
-#: ../../vdms_panels/presets_manager.py:259
 msgid "Any optional arguments to add before input file on the one-pass encoding, e.g required names of some hardware accelerations like -hwaccel to use with CUDA."
 msgstr "Eventuali argomenti facoltativi da aggiungere prima del file sorgente codifica a singolo, ad esempio i nomi richiesti di alcune accelerazioni hardware come -hwaccel da usare con CUDA."
 
-#: ../../vdms_dialogs/queue_edit.py:102
-#: ../../vdms_dialogs/setting_profiles.py:98
 msgid "Pre-input arguments for Two-Pass (optional)"
 msgstr "Argomenti pre-input doppio passaggio (opzionale)"
 
-#: ../../vdms_dialogs/queue_edit.py:113
-#: ../../vdms_dialogs/setting_profiles.py:152
-#: ../../vdms_panels/presets_manager.py:257
 msgid "FFmpeg arguments for two-pass encoding"
 msgstr "Argomenti FFmpeg per la codifica a doppio passaggio"
 
-#: ../../vdms_dialogs/queue_edit.py:120
-#: ../../vdms_dialogs/setting_profiles.py:162
-#: ../../vdms_panels/presets_manager.py:263
 msgid "Any optional arguments to add before input file on the two-pass encoding, e.g required names of some hardware accelerations like -hwaccel to use with CUDA."
 msgstr "Eventuali argomenti facoltativi da aggiungere prima del file sorgente nella codifica a due passaggi, ad esempio i nomi richiesti di alcune accelerazioni hardware come -hwaccel da usare con CUDA."
 
-#: ../../vdms_dialogs/queuedlg.py:65 ../../vdms_main/main_frame.py:508
-#: ../../vdms_panels/presets_manager.py:189
-#: ../../vdms_panels/video_to_sequence.py:171
 msgid "Edit"
 msgstr "Modifica"
 
-#: ../../vdms_dialogs/queuedlg.py:68
 msgid "Remove"
 msgstr "Rimuovi"
 
-#: ../../vdms_dialogs/queuedlg.py:71
 msgid "Remove all"
 msgstr "Rimuovi tutto"
 
-#: ../../vdms_dialogs/queuedlg.py:74
 msgid ""
 "Export\n"
 "queue file"
@@ -1291,7 +923,6 @@ msgstr ""
 "Esporta\n"
 "file della coda"
 
-#: ../../vdms_dialogs/queuedlg.py:77
 msgid ""
 "Import\n"
 "queue file"
@@ -1299,29 +930,21 @@ msgstr ""
 "Importa\n"
 "file della coda"
 
-#: ../../vdms_dialogs/queuedlg.py:85 ../../vdms_panels/filedrop.py:273
 msgid "Destination file name"
 msgstr "Nome file destinazione"
 
-#: ../../vdms_dialogs/queuedlg.py:137
 msgid "Remove all items in the queue"
 msgstr "Rimuovi tutti gli elementi in coda"
 
-#: ../../vdms_dialogs/queuedlg.py:151
 msgid "Videomass - Queue"
 msgstr "Videomass - Coda"
 
-#: ../../vdms_dialogs/queuedlg.py:228
 msgid "Export queue file"
 msgstr "Esporta file della coda"
 
-#: ../../vdms_dialogs/queuedlg.py:296 ../../vdms_panels/av_conversions.py:1192
-#: ../../vdms_panels/presets_manager.py:1044
-#: ../../vdms_panels/video_to_sequence.py:600
 msgid "Same as source"
 msgstr "Uguale all'origine"
 
-#: ../../vdms_dialogs/queuedlg.py:301
 msgid ""
 "Source\n"
 "File destination\n"
@@ -1339,81 +962,60 @@ msgstr ""
 "Inizio segmento\n"
 "Durata clip"
 
-#: ../../vdms_dialogs/renamer.py:76
 msgid "# will be replaced by ascending numbers starting with:"
 msgstr "# sarà sostituito da numeri ascendenti che iniziano con:"
 
-#: ../../vdms_dialogs/set_timestamp.py:87
 msgid "Font Size"
 msgstr "Dimensione font"
 
-#: ../../vdms_dialogs/set_timestamp.py:111
 msgid "Font Color"
 msgstr "Colore font"
 
-#: ../../vdms_dialogs/set_timestamp.py:121
 msgid "Shadow Color"
 msgstr "Colore ombra"
 
-#: ../../vdms_dialogs/set_timestamp.py:132
 msgid "Show text box"
 msgstr "Visualizza casella testo"
 
-#: ../../vdms_dialogs/set_timestamp.py:136
 msgid "Box Color"
 msgstr "Colore riquadro"
 
-#: ../../vdms_dialogs/set_timestamp.py:156
 msgid "The timestamp size does not auto-adjust to the video size, you have to set the size here"
 msgstr "La dimensione della marca temporale non si adatta automaticamente alla dimensione del video, devi impostare la dimensione qui"
 
-#: ../../vdms_dialogs/set_timestamp.py:160 ../../vdms_main/main_frame.py:559
 msgid "Timestamp settings"
 msgstr "Impostazioni marca temporale"
 
-#: ../../vdms_dialogs/setting_profiles.py:46
 msgid "Supported Formats list (optional). Do not include the `.`"
 msgstr "Elenco formati supportati (opzionale). Non includere `.`"
 
-#: ../../vdms_dialogs/setting_profiles.py:47
 msgid "Output Format. Empty to copy format and codec. Do not include the `.`"
 msgstr "Formato destinazione. Vuoto per copiare formato e codec. Non includere `.`"
 
-#: ../../vdms_dialogs/setting_profiles.py:70
 msgid "Profile Name"
 msgstr "Nome profilo"
 
-#: ../../vdms_dialogs/setting_profiles.py:74
-#: ../../vdms_panels/presets_manager.py:404
 msgid "Description"
 msgstr "Descrizione"
 
-#: ../../vdms_dialogs/setting_profiles.py:149
 msgid "A short profile name"
 msgstr "Un nome profilo breve"
 
-#: ../../vdms_dialogs/setting_profiles.py:150
 msgid "A long description of the profile"
 msgstr "Una lunga descrizione per il profilo"
 
-#: ../../vdms_dialogs/setting_profiles.py:153
 msgid "One or more comma-separated format names compatible with this profile"
 msgstr "Uno o più nomi di formato separati da virgole compatibili con questo profilo"
 
-#: ../../vdms_dialogs/setting_profiles.py:155
 msgid "Output format extension. Leave empty to copy codec and format"
 msgstr "Estensione del formato destinazione. Lascia vuoto per copiare codec e formato"
 
-#: ../../vdms_dialogs/setting_profiles.py:256
 msgid "Incomplete profile assignments"
 msgstr "Le assegnazioni del profilo sono incomplete"
 
-#: ../../vdms_dialogs/setting_profiles.py:263
 msgid "Formats must be comma-separated"
 msgstr "I formati devono essere separati da una virgola"
 
-#: ../../vdms_dialogs/setting_profiles.py:279
-#: ../../vdms_utils/queue_utils.py:80
 #, python-brace-format
 msgid ""
 "ERROR: Keys mismatched for requested data.\n"
@@ -1422,105 +1024,69 @@ msgstr ""
 "ERRORE: chiavi non corrispondenti per i dati richiesti.\n"
 "File invalido: «{0}»"
 
-#: ../../vdms_dialogs/setting_profiles.py:285
-#: ../../vdms_dialogs/setting_profiles.py:308
 msgid "Profile already stored with same name"
 msgstr "È già stato salvato un profilo con lo stesso nome"
 
-#: ../../vdms_dialogs/setting_profiles.py:293
 msgid "Profile stored successfully!"
 msgstr "Memorizzazione profilo completata!"
 
-#: ../../vdms_dialogs/setting_profiles.py:311
 msgid "Profile change successful!"
 msgstr "Modifica profilo completata!"
 
-#: ../../vdms_dialogs/showlogs.py:80
 msgid "Log file list"
 msgstr "Elenco file registro"
 
-#: ../../vdms_dialogs/showlogs.py:82 ../../vdms_dialogs/showlogs.py:116
 msgid "Log messages"
 msgstr "Messaggi di registro"
 
-#: ../../vdms_dialogs/showlogs.py:105
 msgid "Refresh log messages"
 msgstr "Aggiorna i messaggi di registro"
 
-#: ../../vdms_dialogs/showlogs.py:107
 msgid "Clear log messages"
 msgstr "Cancella messaggi di registro"
 
-#: ../../vdms_dialogs/showlogs.py:160
 msgid "Select a log file"
 msgstr "Seleziona un file registro"
 
-#: ../../vdms_dialogs/showlogs.py:167
 msgid "Are you sure you want to clear the selected log file?"
 msgstr "Sei sicuro di voler eliminare il file registro selezionato?"
 
-#: ../../vdms_dialogs/showlogs.py:168 ../../vdms_dialogs/wizard_dlg.py:251
-#: ../../vdms_io/checkup.py:68 ../../vdms_main/main_frame.py:205
-#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1685
-#: ../../vdms_panels/presets_manager.py:349
-#: ../../vdms_panels/presets_manager.py:550
-#: ../../vdms_panels/presets_manager.py:590
-#: ../../vdms_panels/presets_manager.py:649
-#: ../../vdms_panels/presets_manager.py:684
-#: ../../vdms_panels/presets_manager.py:749
-#: ../../vdms_panels/presets_manager.py:775
-#: ../../vdms_panels/presets_manager.py:874
-#: ../../vdms_panels/presets_manager.py:904
 msgid "Please confirm"
 msgstr "Conferma"
 
-#: ../../vdms_dialogs/shownormlist.py:83
 msgid "File name"
 msgstr "Nome file"
 
-#: ../../vdms_dialogs/shownormlist.py:84
 msgid "Max volume dBFS"
 msgstr "Volume massimo dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:85
 msgid "Mean volume dBFS"
 msgstr "Volume medio dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:86
 msgid "Offset dBFS"
 msgstr "Offset dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:87
 msgid "Result dBFS"
 msgstr "Risultato dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:92
 msgid "Post-normalization references:"
 msgstr "Riferimenti post-normalizzazione:"
 
-#: ../../vdms_dialogs/shownormlist.py:102
 msgid "=  Clipped peaks"
 msgstr "=  Picchi in clip"
 
-#: ../../vdms_dialogs/shownormlist.py:111
 msgid "=  No changes"
 msgstr "=  Non cambia"
 
-#: ../../vdms_dialogs/shownormlist.py:121
 msgid "=  Below max peak"
 msgstr "=  Sotto il picco max"
 
-#: ../../vdms_dialogs/shownormlist.py:166
-#: ../../vdms_panels/audio_encoders/acodecs.py:841
 msgid "RMS-based volume statistics"
 msgstr "Statistiche del volume basate su RMS"
 
-#: ../../vdms_dialogs/shownormlist.py:191
-#: ../../vdms_panels/audio_encoders/acodecs.py:839
 msgid "PEAK-based volume statistics"
 msgstr "Statistiche del volume basate sul PICCO"
 
-#: ../../vdms_dialogs/shownormlist.py:216
 msgid ""
 "...It means the resulting audio will be clipped,\n"
 "because its volume is higher than the maximum 0 db\n"
@@ -1532,7 +1098,6 @@ msgstr ""
 "Ciò comporterà la perdita di dati nel segnale audio e\n"
 "il suono potrebbe risultare distorto."
 
-#: ../../vdms_dialogs/shownormlist.py:242
 msgid ""
 "...It means the resulting audio will not change,\n"
 "because it's equal to the source."
@@ -1540,7 +1105,6 @@ msgstr ""
 "..Significa che il segnale audio non cambierà,\n"
 "perché uguale a quello di origine."
 
-#: ../../vdms_dialogs/shownormlist.py:266
 msgid ""
 "...It means an audio signal will be produced with\n"
 "a lower volume than the source."
@@ -1548,15 +1112,12 @@ msgstr ""
 "...Significa che verrà prodotto un segnale audio con\n"
 "un volume inferiore a quello originale."
 
-#: ../../vdms_dialogs/videomass_check_version.py:63
 msgid "Get Latest Version"
 msgstr "Ottieni l'ultima versione"
 
-#: ../../vdms_dialogs/videomass_check_version.py:67
 msgid "Checking for newer version"
 msgstr "Controllo della versione più recente"
 
-#: ../../vdms_dialogs/videomass_check_version.py:95
 msgid ""
 "\n"
 "\n"
@@ -1566,7 +1127,6 @@ msgstr ""
 "\n"
 "Le nuove versioni risolvono bug e offrono nuove funzionalità."
 
-#: ../../vdms_dialogs/videomass_check_version.py:96
 #, python-brace-format
 msgid ""
 "\n"
@@ -1579,7 +1139,6 @@ msgstr ""
 "Questo è Videomass v. {0}\n"
 "\n"
 
-#: ../../vdms_dialogs/while_playing.py:37
 msgid ""
 "q, ESC\n"
 "f\n"
@@ -1621,41 +1180,32 @@ msgstr ""
 "click destro del mouse\n"
 "click sinistro del mouse"
 
-#: ../../vdms_dialogs/while_playing.py:92
 msgid "Shortcut keys while playing with FFplay"
 msgstr "Scorciatoie da tastiera durante la riproduzione con FFplay"
 
-#: ../../vdms_dialogs/widget_utils.py:120 ../../vdms_main/main_frame.py:1326
 msgid "Stop"
 msgstr "Stop"
 
-#: ../../vdms_dialogs/wizard_dlg.py:63
 msgid "Please take a moment to set up the application"
 msgstr "Dedica qualche istante alla configurazione dell'applicazione"
 
-#: ../../vdms_dialogs/wizard_dlg.py:64
 msgid "Click the \"Next\" button to get started"
 msgstr "Per iniziare seleziona \"Avanti\""
 
-#: ../../vdms_dialogs/wizard_dlg.py:79
 msgid "Welcome to the Videomass Wizard!"
 msgstr "Benvenuto nell'assistente di Videomass!"
 
-#: ../../vdms_dialogs/wizard_dlg.py:123
 msgid "Videomass is an application based on FFmpeg\n"
 msgstr "Videomass è un'applicazione basata su FFmpeg\n"
 
-#: ../../vdms_dialogs/wizard_dlg.py:125
 msgid "If FFmpeg is not on your computer, this application will be unusable"
 msgstr "Se FFmpeg non è disponibile nel computer, questa applicazione non potrà essere usata"
 
-#: ../../vdms_dialogs/wizard_dlg.py:128
 msgid ""
 "If you have already installed FFmpeg on your operating system,\n"
 "click the \"Auto-detection\" button."
 msgstr "Se hai già installato FFmpeg nel sistema operativo, seleziona \"Rileva automaticamente\"."
 
-#: ../../vdms_dialogs/wizard_dlg.py:131
 msgid ""
 "If you want to use a version of FFmpeg located on your filesystem\n"
 "but not installed on your operating system,\n"
@@ -1664,26 +1214,21 @@ msgstr ""
 "Se vuoi usare una versione di FFmpeg presente ma non installata nel sistema operativo,\n"
 "seleziona \"Individua\"."
 
-#: ../../vdms_dialogs/wizard_dlg.py:162
 msgid "Auto-detection"
 msgstr "Rileva automaticamente"
 
-#: ../../vdms_dialogs/wizard_dlg.py:164
 msgid "Locate"
 msgstr "Individua"
 
-#: ../../vdms_dialogs/wizard_dlg.py:214
 msgid "Click the \"Next\" button"
 msgstr "Seleziona \"Avanti\""
 
-#: ../../vdms_dialogs/wizard_dlg.py:235
 #, python-brace-format
 msgid "'{}' is not installed on your computer. Install it or indicate another location by clicking the 'Locate' button."
 msgstr ""
 "\"{}\" non è installato nel computer. \n"
 "Installalo o indica un altro percorso selezionando \"Individua\"."
 
-#: ../../vdms_dialogs/wizard_dlg.py:249
 msgid ""
 "Videomass already seems to include FFmpeg.\n"
 "\n"
@@ -1693,11 +1238,9 @@ msgstr ""
 "\n"
 "Vuoi usare quello?"
 
-#: ../../vdms_dialogs/wizard_dlg.py:275
 msgid "Locating FFmpeg executables\n"
 msgstr "Individuazione eseguibili FFmpeg\n"
 
-#: ../../vdms_dialogs/wizard_dlg.py:277
 msgid ""
 "\"ffmpeg\", \"ffprobe\" and \"ffplay\" are required. Complete all\n"
 "the text boxes below by clicking on the respective buttons."
@@ -1705,40 +1248,30 @@ msgstr ""
 "Sono richiesti \"ffmpeg\", \"ffprobe\" ed \" ffplay\". \n"
 "Completa tutti i campi di testo sottostanti selezionando i rispettivi pulsanti."
 
-#: ../../vdms_dialogs/wizard_dlg.py:437
 msgid "Wizard completed successfully!\n"
 msgstr "Procedura guidata completata correttamente!\n"
 
-#: ../../vdms_dialogs/wizard_dlg.py:438
 msgid "Remember that you can always change these settings later, through the Preferences dialog."
 msgstr "Ricorda che puoi sempre modificare più tardi queste impostazioni attraverso le preferenze globali."
 
-#: ../../vdms_dialogs/wizard_dlg.py:440
 msgid "Thank You!"
 msgstr "Grazie!"
 
-#: ../../vdms_dialogs/wizard_dlg.py:441
 msgid "To exit click the \"Finish\" button"
 msgstr "Per uscire seleziona \"Fine\""
 
-#: ../../vdms_dialogs/wizard_dlg.py:527
 msgid "< Previous"
 msgstr "< Indietro"
 
-#: ../../vdms_dialogs/wizard_dlg.py:530 ../../vdms_dialogs/wizard_dlg.py:613
 msgid "Next >"
 msgstr "Avanti >"
 
-#: ../../vdms_dialogs/wizard_dlg.py:535
 msgid "Videomass Wizard"
 msgstr "Procedura guidata Videomass"
 
-#: ../../vdms_dialogs/wizard_dlg.py:563 ../../vdms_dialogs/wizard_dlg.py:586
-#: ../../vdms_dialogs/wizard_dlg.py:591
 msgid "Finish"
 msgstr "Fine"
 
-#: ../../vdms_io/checkup.py:44 ../../vdms_io/checkup.py:92
 #, python-brace-format
 msgid ""
 "Output folder does not exist:\n"
@@ -1749,32 +1282,25 @@ msgstr ""
 "\n"
 "\"{}\"\n"
 
-#: ../../vdms_io/checkup.py:65
 msgid "Files already exist, do you want to overwrite them?"
 msgstr "File già esistenti, vuoi sovrascriverli?"
 
-#: ../../vdms_io/checkup.py:67
 msgid "Already exist"
 msgstr "Già esistente"
 
-#: ../../vdms_io/checkup.py:81
 msgid "Not found"
 msgstr "Non trovato"
 
-#: ../../vdms_io/checkup.py:82 ../../vdms_panels/filedrop.py:196
 msgid "Error list"
 msgstr "Elenco errori"
 
-#: ../../vdms_io/checkup.py:83
 msgid "File(s) not found"
 msgstr "File non trovati"
 
-#: ../../vdms_io/io_tools.py:56
 #, python-format
 msgid "File does not exist or is invalid:  %s"
 msgstr "File invalido o non esistente:  %s"
 
-#: ../../vdms_io/io_tools.py:74
 msgid ""
 "Wait....\n"
 "Audio peak analysis."
@@ -1782,16 +1308,12 @@ msgstr ""
 "Attendi....\n"
 "Analisi livello di picco."
 
-#: ../../vdms_io/io_tools.py:179
 msgid "Videomass - Downloading..."
 msgstr "Download in corso..."
 
-#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1409
-#: ../../vdms_main/main_frame.py:1441
 msgid "Ready"
 msgstr "Pronto"
 
-#: ../../vdms_main/main_frame.py:203
 msgid ""
 "Not all items in the queue were completed.\n"
 "\n"
@@ -1801,344 +1323,257 @@ msgstr ""
 "\n"
 "Vorresti tenerli in coda?"
 
-#: ../../vdms_main/main_frame.py:224
 #, python-brace-format
 msgid "Queue ({0})"
 msgstr "Coda ({0})"
 
-#: ../../vdms_main/main_frame.py:229 ../../vdms_main/main_frame.py:1334
 msgid "Queue"
 msgstr "Coda"
 
-#: ../../vdms_main/main_frame.py:396 ../../vdms_main/main_frame.py:418
 msgid "There are still active windows with running processes, make sure you finish your work before exit."
 msgstr "Ci sono ancora finestre attive con processi in esecuzione, assicurati di finire il lavoro prima di uscire."
 
-#: ../../vdms_main/main_frame.py:403
 msgid "Are you sure you want to exit the application?"
 msgstr "Sei sicuro di voler uscire dall'applicazione?"
 
-#: ../../vdms_main/main_frame.py:405
 msgid "Exit"
 msgstr "Uscita dall'applicazione"
 
-#: ../../vdms_main/main_frame.py:463
 msgid "Import files\tCtrl+O"
 msgstr "Importa file\tCtrl+O"
 
-#: ../../vdms_main/main_frame.py:466
 msgid "Open destination folder of encodings\tCtrl+D"
 msgstr "Apri cartella destinazione codifiche\tCtrl+D"
 
-#: ../../vdms_main/main_frame.py:469
 msgid "Load queue file"
 msgstr "Carica file coda"
 
-#: ../../vdms_main/main_frame.py:470
 msgid "Load a previously exported queue file"
 msgstr "Carica un file della coda precedentemente esportato"
 
-#: ../../vdms_main/main_frame.py:473
 msgid "Open trash"
 msgstr "Apri cestino"
 
-#: ../../vdms_main/main_frame.py:474
 msgid "Open the Videomass trash folder"
 msgstr "Apri cartella del cestino di Videomass"
 
-#: ../../vdms_main/main_frame.py:476
 msgid "Empty trash"
 msgstr "Svuota cestino"
 
-#: ../../vdms_main/main_frame.py:477
 msgid "Delete all files in the Videomass trash folder"
 msgstr "Elimina tutti i file nella cartella cestino di Videomass"
 
-#: ../../vdms_main/main_frame.py:480
 msgid "Exit\tCtrl+Q"
 msgstr "Esci\tCtrl+Q"
 
-#: ../../vdms_main/main_frame.py:481
 msgid "Completely exit the application"
 msgstr "Esci completamente dall'applicazione"
 
-#: ../../vdms_main/main_frame.py:482
 msgid "File"
 msgstr "File"
 
-#: ../../vdms_main/main_frame.py:486 ../../vdms_panels/filedrop.py:340
-#: ../../vdms_panels/filedrop.py:381
 msgid "Rename selected file\tCtrl+R"
 msgstr "Rinomina il file selezionato\tCtrl+R"
 
-#: ../../vdms_main/main_frame.py:487
 msgid "Rename the destination of the selected file"
 msgstr "Rinomina la destinazione del file selezionato"
 
-#: ../../vdms_main/main_frame.py:490 ../../vdms_panels/filedrop.py:341
-#: ../../vdms_panels/filedrop.py:384
 msgid "Batch rename files\tCtrl+B"
 msgstr "Rinomina i file in batch\tCtrl+B"
 
-#: ../../vdms_main/main_frame.py:491
 msgid "Numerically renames the destination of all items in the list"
 msgstr "Rinomina numericamente la destinazione di tutti gli elementi nell'elenco"
 
 # Warning: DEL refers to the "Del" or "Canc" button on the keyboard. This may
 # depends on your country. This button is an accelerator used as a shortcut.
-#: ../../vdms_main/main_frame.py:496 ../../vdms_panels/filedrop.py:343
-#: ../../vdms_panels/filedrop.py:388
 msgid "Remove selected entry\tDEL"
 msgstr "Rimuovi voce selezionata\tDEL"
 
-#: ../../vdms_main/main_frame.py:497
 msgid "Remove the selected file from the list"
 msgstr "Rimuovi dall'elenco il file selezionato"
 
-#: ../../vdms_main/main_frame.py:500 ../../vdms_panels/filedrop.py:344
-#: ../../vdms_panels/filedrop.py:391
 msgid "Clear list\tShift+DEL"
 msgstr "Azzera elenco\tShift+DEL"
 
-#: ../../vdms_main/main_frame.py:501
 msgid "Clear the file list"
 msgstr "Cancella l'intero elenco dei file"
 
-#: ../../vdms_main/main_frame.py:506
 msgid "Preferences\tCtrl+P"
 msgstr "Impostazioni\tCtrl+P"
 
-#: ../../vdms_main/main_frame.py:507
 msgid "Application preferences"
 msgstr "Impostazioni applicazione"
 
-#: ../../vdms_main/main_frame.py:512
 msgid "Find FFmpeg topics"
 msgstr "Guida argomenti FFmpeg"
 
-#: ../../vdms_main/main_frame.py:513
 msgid "A useful tool to search for FFmpeg help topics and options"
 msgstr "Uno strumento utile per cercare argomenti e opzioni della guida FFmpeg"
 
-#: ../../vdms_main/main_frame.py:518
 msgid "Check for preset updates"
 msgstr "Controlla aggiornamenti profili"
 
-#: ../../vdms_main/main_frame.py:519
 #, python-brace-format
 msgid "Check for new presets updates from {0}"
 msgstr "Controlla nuovi aggiornamenti profili da {0}"
 
-#: ../../vdms_main/main_frame.py:521
 msgid "Get latest presets"
 msgstr "Scarica profili aggiornati"
 
-#: ../../vdms_main/main_frame.py:522
 #, python-brace-format
 msgid "Get the latest presets from {0}"
 msgstr "Scarica profili aggiornati da {0}"
 
-#: ../../vdms_main/main_frame.py:525
 msgid "Work notes\tCtrl+N"
 msgstr "Note di lavoro\tCtrl+N"
 
-#: ../../vdms_main/main_frame.py:526
 msgid "Read and write useful notes and reminders."
 msgstr "Leggi e scrivi utili note e promemoria."
 
-#: ../../vdms_main/main_frame.py:528
 msgid "Tools"
 msgstr "Strumenti"
 
-#: ../../vdms_main/main_frame.py:535
 msgid "Show FFmpeg's built-in configuration capabilities"
 msgstr "Visualizza funzionalità configurazione integrate in FFmpeg"
 
-#: ../../vdms_main/main_frame.py:539
 msgid "Muxers and demuxers available on your version of FFmpeg"
 msgstr "Muxer e demuxer disponibili sulla tua versione di FFmpeg"
 
-#: ../../vdms_main/main_frame.py:543
 msgid "Encoders available on your version of FFmpeg"
 msgstr "Codificatori disponibili sulla tua versione di FFmpeg"
 
-#: ../../vdms_main/main_frame.py:546
 msgid "Decoders available on your version of FFmpeg"
 msgstr "Codificatori disponibili sulla tua versione di FFmpeg"
 
-#: ../../vdms_main/main_frame.py:550
 msgid "Enable timestamps on playback"
 msgstr "Abilita marca temporale durante la riproduzione"
 
-#: ../../vdms_main/main_frame.py:551
 msgid "Displays timestamp when playing media with FFplay"
 msgstr "Visualizza la marca temporale durante la riproduzione dei media con FFplay"
 
-#: ../../vdms_main/main_frame.py:554
 msgid "Auto-exit after playback"
 msgstr "Uscita automatica dopo la riproduzione"
 
-#: ../../vdms_main/main_frame.py:555
 msgid "If checked, the FFplay window will auto-close when playback is complete"
 msgstr "Se abilitato, la finestra FFplay si chiuderà automaticamente alla fine della riproduzione"
 
-#: ../../vdms_main/main_frame.py:559
 msgid "Customize the timestamp style"
 msgstr "Personalizza lo stile della marca temporale"
 
-#: ../../vdms_main/main_frame.py:562
 msgid "While playing..."
 msgstr "Durante la riproduzione..."
 
-#: ../../vdms_main/main_frame.py:563
 msgid "Show useful shortcut keys when playing or previewing using FFplay"
 msgstr "Visualizza tasti scelta rapida utili durante la riproduzione o l'anteprima usando FFplay"
 
-#: ../../vdms_main/main_frame.py:567
 msgid "Show timeline editor\tCtrl+T"
 msgstr "Editor sequenza temporale\tCtrl+T"
 
-#: ../../vdms_main/main_frame.py:568
 msgid "Set duration or trim slices of time to remove unwanted parts from your files"
 msgstr "Imposta la durata o ritaglia intervalli di tempo per rimuovere parti indesiderate dai file"
 
-#: ../../vdms_main/main_frame.py:572
 msgid "View"
 msgstr "Visualizza"
 
-#: ../../vdms_main/main_frame.py:579
 msgid "Home panel\tCtrl+Shift+H"
 msgstr "Pannello principale\tCtrl+Shift+H"
 
-#: ../../vdms_main/main_frame.py:580
 msgid "Go to the «Home» panel"
 msgstr "Vai al pannello «Home»"
 
-#: ../../vdms_main/main_frame.py:583
 msgid "Presets Manager\tCtrl+Shift+P"
 msgstr "Gestione profili\tCtrl+Shift+P"
 
-#: ../../vdms_main/main_frame.py:584
 msgid "Go to the «Presets Manager» panel"
 msgstr "Vai al pannello «Gestione profili»"
 
-#: ../../vdms_main/main_frame.py:586
 msgid "A/V Conversions\tCtrl+Shift+V"
 msgstr "Conversioni audio/video\tCtrl+Shift+V"
 
-#: ../../vdms_main/main_frame.py:587
 msgid "Go to the «A/V Conversions» panel"
 msgstr "Vai al pannello «Conversione audio/video»"
 
-#: ../../vdms_main/main_frame.py:589
 msgid "Concatenate Demuxer\tCtrl+Shift+D"
 msgstr "Unione con demuxer\tCtrl+Shift+D"
 
-#: ../../vdms_main/main_frame.py:590
 msgid "Go to the «Concatenate Demuxer» panel"
 msgstr "Vai al pannello «Unione con demuxer»"
 
-#: ../../vdms_main/main_frame.py:593
 msgid "Still Image Maker\tCtrl+Shift+I"
 msgstr "Crea presentazioni\tCtrl+Shift+I"
 
-#: ../../vdms_main/main_frame.py:594
 msgid "Go to the «Still Image Maker» panel"
 msgstr "Vai al pannello «Crea presentazione»"
 
-#: ../../vdms_main/main_frame.py:596
 msgid "From Movie to Pictures\tCtrl+Shift+S"
 msgstr "Converti filmato in immagini\tCtrl+Shift+S"
 
-#: ../../vdms_main/main_frame.py:597
 msgid "Go to the «From Movie to Pictures» panel"
 msgstr "Vai al pannello «Converti filmato in immagini»"
 
-#: ../../vdms_main/main_frame.py:600
 msgid "Output monitor\tCtrl+Shift+O"
 msgstr "Monitor file destinazione\tCtrl+Shift+O"
 
-#: ../../vdms_main/main_frame.py:601
 msgid "Keeps track of the output for debugging errors"
 msgstr "Tiene traccia dell'output per gli errori di debug"
 
-#: ../../vdms_main/main_frame.py:603
 msgid "Go"
 msgstr "Vai"
 
-#: ../../vdms_main/main_frame.py:607
 msgid "User guide"
 msgstr "Guida utente"
 
-#: ../../vdms_main/main_frame.py:611
 msgid "System version"
 msgstr "Versione sistema"
 
-#: ../../vdms_main/main_frame.py:612
 msgid "Get version about your operating system, version of Python and wxPython."
 msgstr "Ottieni la versione del sistema operativo, la versione di Python e wxPython."
 
-#: ../../vdms_main/main_frame.py:616
 msgid "Show log files\tCtrl+L"
 msgstr "Visualizza file registro eventi\tCtrl+L"
 
-#: ../../vdms_main/main_frame.py:617
 msgid "Viewing log messages"
 msgstr "Visualizzazione dei messaggi di registro"
 
-#: ../../vdms_main/main_frame.py:620
 msgid "Issue tracker"
 msgstr "Segnala problema"
 
-#: ../../vdms_main/main_frame.py:624
 msgid "Contribute to the project"
 msgstr "Contribuisci al progetto"
 
-#: ../../vdms_main/main_frame.py:627
 msgid "Sponsor this project"
 msgstr "Sponsorizza questo progetto"
 
-#: ../../vdms_main/main_frame.py:628
 msgid "Become a developer supporter"
 msgstr "Diventa un supporter dello sviluppatore"
 
-#: ../../vdms_main/main_frame.py:629
 msgid "Donate"
 msgstr "Dona"
 
-#: ../../vdms_main/main_frame.py:630
 msgid "Donate to the app developer"
 msgstr "Dona allo sviluppatore dell'app"
 
-#: ../../vdms_main/main_frame.py:634
 msgid "Other projects by the developer"
 msgstr "Altri progetti dello sviluppatore"
 
-#: ../../vdms_main/main_frame.py:650
 msgid "About Videomass"
 msgstr "Info su Videomass"
 
-#: ../../vdms_main/main_frame.py:651
 msgid "Check for newer version"
 msgstr "Controlla aggiornamenti programma"
 
-#: ../../vdms_main/main_frame.py:652
 msgid "Check for the latest Videomass version"
 msgstr "Verifica ultima versione di Videomass"
 
-#: ../../vdms_main/main_frame.py:654
 msgid "Help"
 msgstr "Aiuto"
 
-#: ../../vdms_main/main_frame.py:729
 msgid "Import files"
 msgstr "Importa file"
 
-#: ../../vdms_main/main_frame.py:752
 msgid "No default folder has been set for the destination of the encodings. The current setting is \"Same destination paths as source files\"."
 msgstr "Nessuna cartella predefinita è stata impostata per la destinazione delle codifiche. L'impostazione corrente è \"Stessi percorsi per file destinazione e sorgente\"."
 
-#: ../../vdms_main/main_frame.py:784 ../../vdms_main/main_frame.py:809
 #, python-brace-format
 msgid ""
 "'{}':\n"
@@ -2147,11 +1582,9 @@ msgstr ""
 "'{}':\n"
 "Nessun file o cartella con questo nome"
 
-#: ../../vdms_main/main_frame.py:797
 msgid "Are you sure to empty trash folder?"
 msgstr "Sei sicuro di voler svuotare la cartella cestino?"
 
-#: ../../vdms_main/main_frame.py:805
 #, python-brace-format
 msgid ""
 "'{}':\n"
@@ -2160,21 +1593,18 @@ msgstr ""
 "'{}':\n"
 "Non ci sono file da cancellare."
 
-#: ../../vdms_main/main_frame.py:862
 #, python-brace-format
 msgid "Installed release v{0}. A new presets release is available {1}"
 msgstr ""
 "Versione profili installata v. {0}. \n"
 "È disponibile una nuova versione dei profili {1}"
 
-#: ../../vdms_main/main_frame.py:866
 #, python-brace-format
 msgid "Installed release v{0}. No new updates found."
 msgstr ""
 "Versione profili installata v{0}. \n"
 "Nessun nuovo aggiornamento trovato."
 
-#: ../../vdms_main/main_frame.py:896
 msgid ""
 "Wait....\n"
 "The archive is being downloaded"
@@ -2182,16 +1612,13 @@ msgstr ""
 "Attendi....\n"
 "L'archivio è in fase di download"
 
-#: ../../vdms_main/main_frame.py:908
 #, python-brace-format
 msgid "Successfully downloaded to \"{0}\""
 msgstr "Scaricato correttamente in \"{0}\""
 
-#: ../../vdms_main/main_frame.py:1120
 msgid "Some changes require restarting the application."
 msgstr "Alcune modifiche richiedono il riavvio dell'applicazione."
 
-#: ../../vdms_main/main_frame.py:1126
 #, python-brace-format
 msgid ""
 "{0}\n"
@@ -2202,116 +1629,85 @@ msgstr ""
 "\n"
 "Vuoi riavviare l'applicazione adesso?"
 
-#: ../../vdms_main/main_frame.py:1128
 msgid "Restart Videomass?"
 msgstr "Vuoi riavviare Videomass?"
 
-#: ../../vdms_main/main_frame.py:1207
 #, python-brace-format
 msgid "A new release is available - v.{0}\n"
 msgstr "È disponibile una nuovo versione - v.{0}\n"
 
-#: ../../vdms_main/main_frame.py:1210
 msgid "You are using a development version that has not yet been released!\n"
 msgstr "Stai usando una versione di sviluppo che non è ancora stata rilasciata!\n"
 
-#: ../../vdms_main/main_frame.py:1213
 msgid "Congratulation! You are already using the latest version.\n"
 msgstr "Congratulazioni! L'applicazione è aggiornata.\n"
 
-#: ../../vdms_main/main_frame.py:1301
 msgid "Previous panel"
 msgstr "Pannello precedente"
 
-#: ../../vdms_main/main_frame.py:1302
 msgid "Back"
 msgstr "Indietro"
 
-#: ../../vdms_main/main_frame.py:1305
 msgid "Next panel"
 msgstr "Pannello successivo"
 
-#: ../../vdms_main/main_frame.py:1306
 msgid "Next"
 msgstr "Avanti"
 
-#: ../../vdms_main/main_frame.py:1309
 msgid "Home panel"
 msgstr "Pannello principale"
 
-#: ../../vdms_main/main_frame.py:1310
 msgid "Home"
 msgstr "Principale"
 
-#: ../../vdms_main/main_frame.py:1313
 msgid "Play the selected imput file"
 msgstr "Riproduci il file sorgente selezionato"
 
-#: ../../vdms_main/main_frame.py:1314
 msgid "Play"
 msgstr "Riproduci"
 
-#: ../../vdms_main/main_frame.py:1317
 msgid "Get informative data about imported media streams"
 msgstr "Ottieni dati informativi sui flussi dei media importati"
 
-#: ../../vdms_main/main_frame.py:1321
 msgid "Start batch processing"
 msgstr "Avvia l'elaborazione batch"
 
-#: ../../vdms_main/main_frame.py:1325
 msgid "Stops current process"
 msgstr "Interrompi il processo corrente"
 
-#: ../../vdms_main/main_frame.py:1329
 msgid "Add an item to Queue"
 msgstr "Aggiungi un elemento alla Coda"
 
-#: ../../vdms_main/main_frame.py:1330
 msgid "Add to Queue"
 msgstr "Aggiungi a coda"
 
-#: ../../vdms_main/main_frame.py:1333
 msgid "Show queue"
 msgstr "Visualizza coda"
 
-#: ../../vdms_main/main_frame.py:1408 ../../vdms_panels/presets_manager.py:569
 msgid "Videomass"
 msgstr "Videomass"
 
-#: ../../vdms_main/main_frame.py:1442
 msgid "Videomass - File List"
 msgstr "Videomass - Lista dei File"
 
-#: ../../vdms_main/main_frame.py:1459
 msgid "Videomass - AV Conversions"
 msgstr "Videomass - Conversioni AV"
 
-#: ../../vdms_main/main_frame.py:1488
 msgid "Videomass - Presets Manager"
 msgstr "Videomass - Gestione profili"
 
-#: ../../vdms_main/main_frame.py:1518
 msgid "Videomass - Concatenate Demuxer"
 msgstr "Videomass - Unione con demuxer"
 
-#: ../../vdms_main/main_frame.py:1547
 msgid "Videomass - From Movie to Pictures"
 msgstr "Videomass - Converti filmato in immagini"
 
-#: ../../vdms_main/main_frame.py:1576
 msgid "Videomass - Still Image Maker"
 msgstr "Videomass - Crea presentazioni"
 
-#: ../../vdms_main/main_frame.py:1660 ../../vdms_panels/av_conversions.py:577
-#: ../../vdms_panels/filedrop.py:500 ../../vdms_panels/filedrop.py:616
-#: ../../vdms_panels/sequence_to_video.py:322
-#: ../../vdms_panels/video_to_sequence.py:369
-#: ../../vdms_panels/video_to_sequence.py:501
 msgid "Have to select an item in the file list first"
 msgstr "Prima dovresti selezionare un elemento nella lista dei file"
 
-#: ../../vdms_main/main_frame.py:1682
 msgid ""
 "An item with the same destination file already exists.\n"
 "\n"
@@ -2321,86 +1717,65 @@ msgstr ""
 "\n"
 "Vuoi sostituirlo aggiungendo il nuovo elemento alla coda?"
 
-#: ../../vdms_main/main_frame.py:1703
 msgid "Videomass - FFmpeg Message Monitoring"
 msgstr "Videomass - Monitoraggio dei messaggi FFmpeg"
 
-#: ../../vdms_main/main_frame.py:1828
 #, python-brace-format
 msgid "The system will turn off in {0} seconds"
 msgstr "Il sistema si spegnerà tra {0} secondi"
 
-#: ../../vdms_main/main_frame.py:1829
 msgid "Videomass - Shutdown!"
 msgstr "Videomass - Spegnimento!"
 
-#: ../../vdms_main/main_frame.py:1836
 msgid "Error while shutting down. Please see file log for details."
 msgstr ""
 "Errore durante lo spegnimento. \n"
 "Per i dettagli consultare il file registro."
 
-#: ../../vdms_main/main_frame.py:1848
 #, python-brace-format
 msgid "Exiting the application in {0} seconds"
 msgstr "Chiusura dell'applicazione tra {0} secondi"
 
-#: ../../vdms_main/main_frame.py:1849
 msgid "Videomass - Exiting!"
 msgstr "Videomass - Uscita dall'applicazione!"
 
-#: ../../vdms_miniframes/timeline.py:46
 msgid "Start point adjustment"
 msgstr "Regola posizione Iniziale"
 
-#: ../../vdms_miniframes/timeline.py:48
 msgid "End point adjustment"
 msgstr "Regola posizione Finale"
 
-#: ../../vdms_miniframes/timeline.py:105
 msgid "Hours"
 msgstr "Ore"
 
-#: ../../vdms_miniframes/timeline.py:106
 msgid "Minutes"
 msgstr "Minuti"
 
-#: ../../vdms_miniframes/timeline.py:107
 msgid "Seconds"
 msgstr "Secondi"
 
-#: ../../vdms_miniframes/timeline.py:108
 msgid "Milliseconds"
 msgstr "Millisecondi"
 
-#: ../../vdms_miniframes/timeline.py:189 ../../vdms_miniframes/timeline.py:312
 msgid "No source duration:"
 msgstr "Nessuna durata sorgente:"
 
-#: ../../vdms_miniframes/timeline.py:208 ../../vdms_miniframes/timeline.py:298
-#: ../../vdms_miniframes/timeline.py:333 ../../vdms_miniframes/timeline.py:338
-#: ../../vdms_miniframes/timeline.py:441
 #, python-brace-format
 msgid "{0} {1}  |  Segment Duration: {2}"
 msgstr "{0} {1}  |  Durata Segmento: {2}"
 
-#: ../../vdms_miniframes/timeline.py:260 ../../vdms_miniframes/timeline.py:277
 msgid "End adjustment"
 msgstr "Regola Fine"
 
-#: ../../vdms_miniframes/timeline.py:261 ../../vdms_miniframes/timeline.py:279
 msgid "Start adjustment"
 msgstr "Regola Inizio"
 
-#: ../../vdms_miniframes/timeline.py:320
 msgid "Source duration:"
 msgstr "Durata sorgente:"
 
-#: ../../vdms_miniframes/timeline.py:387
 msgid "WARNING: Invalid selection, out of range."
 msgstr "ATTENZIONE: Selezione non valida, fuori intervallo."
 
-#: ../../vdms_miniframes/timeline.py:461
 msgid ""
 "Start by dragging the bottom left handle,\n"
 "or right-click for options."
@@ -2408,15 +1783,12 @@ msgstr ""
 "Inizia trascinando la maniglia in basso a sinistra o fai clic\n"
 "con il pulsante destro del mouse per le opzioni."
 
-#: ../../vdms_miniframes/timeline.py:497
 msgid "Start"
 msgstr "Inizio"
 
-#: ../../vdms_miniframes/timeline.py:498
 msgid "End"
 msgstr "Fine"
 
-#: ../../vdms_miniframes/timeline.py:548
 msgid ""
 "The timeline editor is a tool that allows you to trim slices of time on selected imported media (see File List panel).\n"
 "\n"
@@ -2438,39 +1810,30 @@ msgstr ""
 "\n"
 "I valori di durata \"Inizio\"/\"Fine\" fanno sempre riferimento alla posizione iniziale della timeline: 00:00:00.000. Le altre informazioni come la durata del segmento e gli avvisi, saranno visualizzati sui messaggi della barra di stato di questo editor."
 
-#: ../../vdms_miniframes/timeline.py:565
 msgid "Timeline Editor Usage"
 msgstr "Uso editor timeline"
 
-#: ../../vdms_panels/av_conversions.py:153
 msgid "Media:"
 msgstr "Media:"
 
-#: ../../vdms_panels/av_conversions.py:169
 msgid "Container:"
 msgstr "Contenitore:"
 
-#: ../../vdms_panels/av_conversions.py:180
 msgid "Save profile"
 msgstr "Salva profilo"
 
-#: ../../vdms_panels/av_conversions.py:183
 msgid "Target"
 msgstr "Obiettivo"
 
-#: ../../vdms_panels/av_conversions.py:316
 msgid "Miscellaneous"
 msgstr "Varie"
 
-#: ../../vdms_panels/av_conversions.py:323
 msgid "Save as a new profile of the Presets Manager."
 msgstr "Salva come nuovo profilo in Gestione profili."
 
-#: ../../vdms_panels/av_conversions.py:325
 msgid "Available video encoders. \"Copy\" means that the video stream will not be re-encoded and will allow you (depending on the encoder) to change the container, audio codec and a few other parameters."
 msgstr "Codec video disponibili. \"Copia\" significa che il flusso video non verrà ricodificato e ti consentirà (a seconda del codificatore) di modificare il contenitore, il codec audio e alcuni altri parametri."
 
-#: ../../vdms_panels/av_conversions.py:330
 msgid ""
 "Container format. It is usually represented by the file extension (output format).\n"
 "\n"
@@ -2484,7 +1847,6 @@ msgstr ""
 "\n"
 "Se l'obiettivo media è impostato su \"Audio\", puoi estrarre solo i flussi audio dai video o semplicemente convertire sorgenti di tipo audio."
 
-#: ../../vdms_panels/av_conversions.py:338
 msgid ""
 "Set output files target: \"Video\" to save output files as video files; \"Audio\" to save files using an audio encoder and format.\n"
 "\n"
@@ -2494,45 +1856,33 @@ msgstr ""
 "\n"
 "Tieni presente che usando \"Audio\" come obiettivo, sarai comunque in grado di lavorare su sorgenti video ma potrai solo estrarre i flussi audio, convertirli e applicare filtri come la normalizzazione."
 
-#: ../../vdms_panels/av_conversions.py:346
 msgid "Preview video filters"
 msgstr "Anteprima dei filtri video"
 
-#: ../../vdms_panels/av_conversions.py:347
 msgid "Disable active filters"
 msgstr "Disabilita i filtri attivi"
 
-#: ../../vdms_panels/av_conversions.py:348
-#: ../../vdms_panels/sequence_to_video.py:156
-#: ../../vdms_panels/video_to_sequence.py:113
 msgid "Resize"
 msgstr "Ridimensiona"
 
-#: ../../vdms_panels/av_conversions.py:349
 msgid "Crop"
 msgstr "Ritaglia"
 
-#: ../../vdms_panels/av_conversions.py:350
 msgid "Transpose"
 msgstr "Trasponi"
 
-#: ../../vdms_panels/av_conversions.py:352
 msgid "Denoise"
 msgstr "Elimina rumore"
 
-#: ../../vdms_panels/av_conversions.py:353
 msgid "Stabilize"
 msgstr "Stabilizza"
 
-#: ../../vdms_panels/av_conversions.py:354
 msgid "Equalize"
 msgstr "Equalizza"
 
-#: ../../vdms_panels/av_conversions.py:517
 msgid "Unable to preview Video Stabilizer filter"
 msgstr "Impossibile visualizzare in anteprima il filtro stabilizzatore video"
 
-#: ../../vdms_panels/av_conversions.py:602
 msgid ""
 "Unsupported file:\n"
 "Missing decoder or library? Check FFmpeg configuration."
@@ -2541,24 +1891,17 @@ msgstr ""
 "Decoder o libreria mancante? \n"
 "Controlla la configurazione di FFmpeg."
 
-#: ../../vdms_panels/av_conversions.py:611
-#: ../../vdms_panels/sequence_to_video.py:351
-#: ../../vdms_panels/video_to_sequence.py:398
 msgid "The file is not a frame or a video file"
 msgstr "Il file non è un frame o un file video"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:434
-#: ../../vdms_panels/av_conversions.py:861
 msgid "Undetected volume values! Click the \"Volume detect\" button to analyze audio volume data."
 msgstr ""
 "Valori del volume non rilevati!\n"
 "Per analizzare i dati sul volume audio seleziona \"Rilevazione volume\"."
 
-#: ../../vdms_panels/av_conversions.py:1186
 msgid "Off"
 msgstr "Spento"
 
-#: ../../vdms_panels/av_conversions.py:1203
 msgid ""
 "Batch processing items\n"
 "Destination\n"
@@ -2584,111 +1927,83 @@ msgstr ""
 "Inizio segmento\n"
 "Durata clip"
 
-#: ../../vdms_panels/av_conversions.py:1246
-#: ../../vdms_panels/presets_manager.py:814
 #, python-brace-format
 msgid "Write profile on «{0}»"
 msgstr "Scrivi il profilo su «{0}»"
 
-#: ../../vdms_panels/av_conversions.py:1266
-#: ../../vdms_panels/presets_manager.py:513
 msgid "Enter name for new preset"
 msgstr "Inserisci il nome per la nuova pre-impostazione"
 
-#: ../../vdms_panels/av_conversions.py:1276
-#: ../../vdms_panels/presets_manager.py:524
 msgid "Invalid file name, make sure to provide a valid name including the «.json» extension"
 msgstr "Nome file non valido, assicurati di fornire un nome valido includendo l'estensione «.json»"
 
-#: ../../vdms_panels/av_conversions.py:1284
 #, python-brace-format
 msgid "Cannot save current data in file «{}»."
 msgstr "Impossibile salvare i dati correnti nel file «{}»."
 
-#: ../../vdms_panels/av_conversions.py:1289
 msgid "Open Videomass preset"
 msgstr "Apri pre-impostazione Videomass"
 
-#: ../../vdms_panels/av_conversions.py:1307
 msgid "Videomass - Save new profile"
 msgstr "Videomass - Salva nuovo profilo"
 
-#: ../../vdms_panels/av_conversions.py:1308
 msgid "Where do you want to save this profile?"
 msgstr "Dove preferisci salvare questo profilo?"
 
-#: ../../vdms_panels/av_conversions.py:1309
 msgid "Save the profile to a new preset"
 msgstr "Salva il profilo in una nuova pre-impostazione"
 
-#: ../../vdms_panels/av_conversions.py:1310
 msgid "Save the profile to an existing preset"
 msgstr "Salva il profilo in una pre-impostazione esistente"
 
-#: ../../vdms_panels/choose_topic.py:69
 msgid "Welcome to Videomass"
 msgstr "Benvenuto in Videomass"
 
-#: ../../vdms_panels/choose_topic.py:71
 #, python-brace-format
 msgid "Version {}"
 msgstr "Versione {}"
 
-#: ../../vdms_panels/choose_topic.py:82
 msgid "Presets Manager"
 msgstr "Gestione profili"
 
-#: ../../vdms_panels/choose_topic.py:85
 msgid "AV-Conversions"
 msgstr "Conversioni audio/video"
 
-#: ../../vdms_panels/choose_topic.py:88
 msgid "Concatenate media files"
 msgstr "Unisci file multimediali"
 
-#: ../../vdms_panels/choose_topic.py:91
 msgid "Still Image Maker"
 msgstr "Crea presentazioni"
 
-#: ../../vdms_panels/choose_topic.py:94
 msgid "From Movie to Pictures"
 msgstr "Converti filmato in immagini"
 
-#: ../../vdms_panels/choose_topic.py:123
 msgid "Create, edit and use quickly your favorite FFmpeg presets and profiles with full formats support and codecs."
 msgstr "Crea, modifica o usa subito i profili con supporto completo ai formati e codec di FFmpeg."
 
-#: ../../vdms_panels/choose_topic.py:127
 msgid "A set of useful tools for audio and video conversions. Save your profiles and reuse them with Presets Manager."
 msgstr ""
 "Un set di strumenti utili per le conversioni audio e video. \n"
 "Salva i profili e riusali con \"Gestione profili\"."
 
-#: ../../vdms_panels/choose_topic.py:131
 msgid "Concatenate multiple media files based on import order without re-encoding"
 msgstr "Unisci più file multimediali in base all'ordine di importazione senza ricodificarli"
 
-#: ../../vdms_panels/choose_topic.py:134
 msgid "Create video from a sequence of images, based on import order, with the ability to add an audio file."
 msgstr "Crea un video da una sequenza di immagini, in base all'ordine di importazione, con la possibilità di aggiungere un file audio."
 
-#: ../../vdms_panels/choose_topic.py:137
 msgid "Extract images (frames) from your movies in JPG, PNG, BMP, GIF formats."
 msgstr "Estrai immagini (fotogrammi) dai filmati e salvali in formato JPG, PNG, BMP, GIF."
 
-#: ../../vdms_panels/concatenate.py:47
 msgid "At least two files are required to perform concatenation."
 msgstr "Sono necessari almeno due file per eseguire l'unione."
 
-#: ../../vdms_panels/concatenate.py:63
 msgid "Invalid data found"
 msgstr "Trovati dati non validi"
 
-#: ../../vdms_panels/concatenate.py:68
 msgid "The files do not have the same \"codec_types\", same \"sample_rate\" or same \"width\" or \"height\". Unable to proceed."
 msgstr "I file non hanno gli stessi parametri come \"codec_types\", \"sample_rate\" , \"larghezza\" o \"altezza\". Impossibile procedere."
 
-#: ../../vdms_panels/concatenate.py:84
 msgid ""
 "\n"
 "- The concatenation function is performed only with Audio files or only with Video files.\n"
@@ -2718,17 +2033,12 @@ msgstr ""
 "- I file audio devono avere esattamente gli stessi formati, la stessa frequenza di\n"
 "  campionamento e gli stessi codec."
 
-#: ../../vdms_panels/concatenate.py:125
 msgid "Videomass Documentation:"
 msgstr "Documentazione Videomass:"
 
-#: ../../vdms_panels/concatenate.py:136
-#: ../../vdms_panels/sequence_to_video.py:212
-#: ../../vdms_panels/video_to_sequence.py:181
 msgid "Official FFmpeg documentation:"
 msgstr "Documentazione ufficiale FFmpeg:"
 
-#: ../../vdms_panels/concatenate.py:253
 msgid ""
 "Items to concatenate\n"
 "File destination\n"
@@ -2742,250 +2052,188 @@ msgstr ""
 "Tipo media destinazione\n"
 "Durata"
 
-#: ../../vdms_panels/filedrop.py:45
 msgid "File has illegal characters like:"
 msgstr "Il file ha caratteri non validi come:"
 
-#: ../../vdms_panels/filedrop.py:46
 msgid "Invalid character found in path name: (\")"
 msgstr "Trovato carattere non valido nel nome del percorso: (\")"
 
-#: ../../vdms_panels/filedrop.py:47
 msgid "Directories are not allowed, just add files, please."
 msgstr "Le cartelle non sono ammesse, aggiungi solo file."
 
-#: ../../vdms_panels/filedrop.py:48
 msgid "File without format extension: please give an appropriate extension to the file name, example '.mkv', '.avi', '.mp3', etc."
 msgstr "File senza estensione di formato: fornire un'estensione appropriata al nome del file, ad esempio '.mkv', '.avi', '.mp3', ecc."
 
-#: ../../vdms_panels/filedrop.py:84
 #, python-brace-format
 msgid "Name has illegal characters like: {0}"
 msgstr "Il nome ha caratteri non validi come: {0}"
 
-#: ../../vdms_panels/filedrop.py:85
 msgid "Name already in use:"
 msgstr "Nome già in uso:"
 
-#: ../../vdms_panels/filedrop.py:185
 msgid "Duplicate file, it has already been added to the list."
 msgstr "File duplicato, è già stato aggiunto all'elenco."
 
-#: ../../vdms_panels/filedrop.py:197
 msgid "Rejected files"
 msgstr "File rifiutati"
 
-#: ../../vdms_panels/filedrop.py:269
 msgid "Source file"
 msgstr "File sorgente"
 
-#: ../../vdms_panels/filedrop.py:270
 msgid "Duration"
 msgstr "Durata"
 
-#: ../../vdms_panels/filedrop.py:271
 msgid "Media type"
 msgstr "Tipo di media"
 
-#: ../../vdms_panels/filedrop.py:272
 msgid "Size"
 msgstr "Dimensione"
 
-#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:405
 msgid "Drag one or more files below"
 msgstr "Trascina uno o più file qui sotto"
 
-#: ../../vdms_panels/filedrop.py:282
 msgid "Save to:"
 msgstr "Salva in:"
 
-#: ../../vdms_panels/filedrop.py:306
 msgid "Set a new destination folder for encodings"
 msgstr "Imposta nuova cartella di destinazione codifiche"
 
-#: ../../vdms_panels/filedrop.py:308
 msgid "Encodings destination folder"
 msgstr "Cartella di destinazione delle codifiche"
 
-#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:394
 msgid "Play file"
 msgstr "Riproduci file"
 
-#: ../../vdms_panels/filedrop.py:408
 msgid "Drag two or more Audio/Video files below"
 msgstr "Trascina due o più file audio/video qui sotto"
 
-#: ../../vdms_panels/filedrop.py:412
 msgid "Drag one or more Image files below"
 msgstr "Trascina uno o più file immagine qui sotto"
 
-#: ../../vdms_panels/filedrop.py:415
 msgid "Drag one or more Video files below"
 msgstr "Trascina uno o più file video qui sotto"
 
-#: ../../vdms_panels/filedrop.py:623
 msgid "Rename the file destination"
 msgstr "Rinomina destinazione del file"
 
-#: ../../vdms_panels/filedrop.py:624
 msgid "Rename the selected file to:"
 msgstr "Rinomina il file selezionato in:"
 
-#: ../../vdms_panels/filedrop.py:638 ../../vdms_panels/filedrop.py:648
-#: ../../vdms_panels/filedrop.py:679
 msgid "Add Files"
 msgstr "Aggiungi file"
 
-#: ../../vdms_panels/filedrop.py:655
 msgid "Rename in batch"
 msgstr "Rinomina in batch"
 
-#: ../../vdms_panels/filedrop.py:656
 #, python-brace-format
 msgid "Rename the {0} items to:"
 msgstr "Rinominare i {0} elementi in:"
 
-#: ../../vdms_panels/filedrop.py:658
 msgid "New Name #"
 msgstr "Nuovo Nome #"
 
-#: ../../vdms_panels/long_processing_task.py:114
 msgid "Sorry, all task failed !"
 msgstr "Spiacente, tutte le attività sono fallite !"
 
-#: ../../vdms_panels/long_processing_task.py:115
 msgid "The process was stopped due to a fatal error."
 msgstr "Il processo è stato interrotto a causa di un errore irreversibile."
 
-#: ../../vdms_panels/long_processing_task.py:116
 msgid "Interrupted Process !"
 msgstr "Processo Interrotto !"
 
-#: ../../vdms_panels/long_processing_task.py:117
 msgid "Successfully completed !"
 msgstr "Completato correttamente!"
 
-#: ../../vdms_panels/long_processing_task.py:118
 msgid "Not everything was successful."
 msgstr "Non tutto è stato effettuato correttamente."
 
-#: ../../vdms_panels/long_processing_task.py:148
 msgid "Encoding Status"
 msgstr "Stato della codifica"
 
-#: ../../vdms_panels/long_processing_task.py:152
 msgid "Current Log"
 msgstr "Registro Corrente"
 
-#: ../../vdms_panels/long_processing_task.py:354
 msgid "Fatal Error !"
 msgstr "Errore Fatale !"
 
-#: ../../vdms_panels/long_processing_task.py:363
 msgid "Get your files at the destination you specified"
 msgstr "Ottieni i file nella destinazione che hai specificato"
 
-#: ../../vdms_panels/long_processing_task.py:377
 msgid "For more details please read the Current Log."
 msgstr "Per maggiori dettagli leggere il Registro Corrente."
 
-#: ../../vdms_panels/long_processing_task.py:380
 msgid "...Finished"
 msgstr "...Terminato"
 
-#: ../../vdms_panels/long_processing_task.py:399
 msgid "Please wait... interruption in progress"
 msgstr "Attendere... interruzione in corso"
 
-#: ../../vdms_panels/long_processing_task.py:402
 msgid "...Interrupted"
 msgstr "...Interrotto"
 
-#: ../../vdms_panels/presets_manager.py:166
 msgid "Presets"
 msgstr "Pre-impostazioni"
 
-#: ../../vdms_panels/presets_manager.py:180
 msgid "Write"
 msgstr "Scrivi"
 
-#: ../../vdms_panels/presets_manager.py:184
 msgid "Delete"
 msgstr "Cancella"
 
-#: ../../vdms_panels/presets_manager.py:194
 msgid "Duplicate"
 msgstr "Duplica"
 
-#: ../../vdms_panels/presets_manager.py:199
 msgid "Profiles"
 msgstr "Profili"
 
-#: ../../vdms_panels/presets_manager.py:206
 msgid "One-Pass Encoding"
 msgstr "Codifica a passaggio singolo"
 
-#: ../../vdms_panels/presets_manager.py:218
 msgid "Two-Pass Encoding"
 msgstr "Codifica a due passaggi"
 
-#: ../../vdms_panels/presets_manager.py:232
 msgid "Choose a preset and view its profiles"
 msgstr "Scegli una pre-impostazione e visualizza i suoi profili"
 
-#: ../../vdms_panels/presets_manager.py:233
 msgid "Write a new profile and save it in the selected preset"
 msgstr "Scrivi un nuovo profilo e salvalo nella pre-impostazione selezionata"
 
-#: ../../vdms_panels/presets_manager.py:235
 msgid "Delete the selected profile"
 msgstr "Cancella il profilo selezionato"
 
-#: ../../vdms_panels/presets_manager.py:236
 msgid "Edit the selected profile"
 msgstr "Modifica il profilo selezionato"
 
-#: ../../vdms_panels/presets_manager.py:237
 msgid "Duplicate the selected profile"
 msgstr "Duplica il profilo selezionato"
 
-#: ../../vdms_panels/presets_manager.py:238
 msgid "Create new preset"
 msgstr "Crea nuova pre-impostazione"
 
-#: ../../vdms_panels/presets_manager.py:240
 msgid "Remove selected preset"
 msgstr "Rimuovi la pre-impostazione selezionata"
 
-#: ../../vdms_panels/presets_manager.py:242
 msgid "Backup selected preset"
 msgstr "Effettua il backup della pre-impostazione selezionata"
 
-#: ../../vdms_panels/presets_manager.py:244
 msgid "Backup the presets folder"
 msgstr "Esegui il backup della cartella dei profili"
 
-#: ../../vdms_panels/presets_manager.py:246
 msgid "Restore a preset"
 msgstr "Ripristina una pre-impostazione"
 
-#: ../../vdms_panels/presets_manager.py:248
 msgid "Restore a presets folder"
 msgstr "Ripristina cartella profili"
 
-#: ../../vdms_panels/presets_manager.py:250
 msgid "Resets the selected preset to default values"
 msgstr "Ripristina la pre-impostazione selezionata ai valori predefiniti"
 
-#: ../../vdms_panels/presets_manager.py:252
 msgid "Reset all presets to default values"
 msgstr "Ripristina tutte i profili ai valori predefiniti"
 
-#: ../../vdms_panels/presets_manager.py:254
 msgid "Refresh the presets list"
 msgstr "Ricarica elenco profili"
 
-#: ../../vdms_panels/presets_manager.py:338
 #, python-brace-format
 msgid ""
 "Outdated presets version found: v{1}\n"
@@ -3008,28 +2256,22 @@ msgstr ""
 "\n"
 "Vuoi eseguire questo aggiornamento adesso?"
 
-#: ../../vdms_panels/presets_manager.py:403
 msgid "Name"
 msgstr "Nome"
 
-#: ../../vdms_panels/presets_manager.py:405
 msgid "Output Format"
 msgstr "Formato destinazione"
 
-#: ../../vdms_panels/presets_manager.py:406
 msgid "Supported Format List"
 msgstr "Elenco formati supportati"
 
-#: ../../vdms_panels/presets_manager.py:531
 #, python-brace-format
 msgid "Cannot save current data in file '{}'."
 msgstr "Impossibile salvare i dati correnti nel file '{}'."
 
-#: ../../vdms_panels/presets_manager.py:535
 msgid "You just successfully created a new preset!"
 msgstr "Hai appena creato correttamente un nuovo profilo!"
 
-#: ../../vdms_panels/presets_manager.py:547
 #, python-brace-format
 msgid ""
 "Are you sure you want to remove \"{}\" preset?\n"
@@ -3040,7 +2282,6 @@ msgstr ""
 "\n"
 "Sarà spostata nella sotto-cartella \"Removals\" dentro la cartella dei profili."
 
-#: ../../vdms_panels/presets_manager.py:558
 #, python-brace-format
 msgid ""
 "{}\n"
@@ -3051,30 +2292,22 @@ msgstr ""
 "\n"
 "Spiacente, rimozione non riuscita, impossibile procedere.."
 
-#: ../../vdms_panels/presets_manager.py:568
 #, python-brace-format
 msgid "The preset \"{0}\" was successfully removed"
 msgstr "La pre-impostazione \"{0}\" è stata correttamente rimossa"
 
-#: ../../vdms_panels/presets_manager.py:583
-#: ../../vdms_panels/presets_manager.py:612
 msgid "Open a destination folder"
 msgstr "Apri una cartella di destinazione"
 
-#: ../../vdms_panels/presets_manager.py:588
 msgid "A file with this name already exists, do you want to overwrite it?"
 msgstr "Esiste già un file con lo stesso nome, vuoi sovrascriverlo?"
 
-#: ../../vdms_panels/presets_manager.py:602
-#: ../../vdms_panels/presets_manager.py:622
 msgid "Backup completed successfully"
 msgstr "Backup completato correttamente"
 
-#: ../../vdms_panels/presets_manager.py:631
 msgid "Open the preset you want to restore"
 msgstr "Apri pre-impostazione da ripristinare"
 
-#: ../../vdms_panels/presets_manager.py:645
 msgid ""
 "This preset already exists and is about to be updated. Don't worry, it will keep all your saved profiles.\n"
 "\n"
@@ -3084,11 +2317,9 @@ msgstr ""
 "\n"
 "Vuoi continuare?"
 
-#: ../../vdms_panels/presets_manager.py:663
 msgid "Restore successful"
 msgstr "Ripristino completato"
 
-#: ../../vdms_panels/presets_manager.py:681
 msgid ""
 "This will update the presets database. Don't worry, it will keep all your saved profiles.\n"
 "\n"
@@ -3098,19 +2329,15 @@ msgstr ""
 "Non preoccuparti, manterrà tutti i profili salvati.\n"
 "Vuoi continuare?"
 
-#: ../../vdms_panels/presets_manager.py:689
 msgid "Open the presets folder to restore"
 msgstr "Apri cartella profili da ripristinare"
 
-#: ../../vdms_panels/presets_manager.py:725
 msgid "The presets database has been successfully updated"
 msgstr "Il database profili è stato aggiornato correttamente"
 
-#: ../../vdms_panels/presets_manager.py:740
 msgid "The selected preset is not part of Videomass's default presets."
 msgstr "Il profilo selezionato non è parte dei profili predefiniti di Videomass."
 
-#: ../../vdms_panels/presets_manager.py:745
 msgid ""
 "Be careful! The selected preset will be overwritten with the default one. Your profiles may be deleted!\n"
 "\n"
@@ -3120,12 +2347,9 @@ msgstr ""
 "\n"
 "Vuoi continuare?"
 
-#: ../../vdms_panels/presets_manager.py:760
-#: ../../vdms_panels/presets_manager.py:794
 msgid "Successful recovery"
 msgstr "Ripristino completato"
 
-#: ../../vdms_panels/presets_manager.py:769
 msgid ""
 "Be careful! This action will restore all presets to default ones. Your profiles may be deleted!\n"
 "\n"
@@ -3139,20 +2363,16 @@ msgstr ""
 "In ogni caso, per evitare perdite di dati, verrà effettuato il backup della cartella dei profili nella cartella di configurazione del programma.\n"
 "Vuoi continuare?"
 
-#: ../../vdms_panels/presets_manager.py:833
 #, python-brace-format
 msgid "Edit profile on «{0}»"
 msgstr "Modifica il profilo su «{0}»"
 
-#: ../../vdms_panels/presets_manager.py:872
 msgid "Are you sure you want to delete the selected profile? It will no longer be possible to recover it."
 msgstr "Sei sicuro di voler eliminare il profilo selezionato? non sarà più possibile recuperarlo."
 
-#: ../../vdms_panels/presets_manager.py:891
 msgid "First select a profile in the list"
 msgstr "Dovresti selezionare un profilo nella lista"
 
-#: ../../vdms_panels/presets_manager.py:899
 msgid ""
 "The selected profile command has been changed manually.\n"
 "Do you want to apply it during the conversion process?"
@@ -3160,11 +2380,9 @@ msgstr ""
 "Il comando del profilo selezionato è stato cambiato manualmente.\n"
 "Vuoi applicarlo durante il processo di conversione?"
 
-#: ../../vdms_panels/presets_manager.py:909
 msgid "Don't show this dialog again"
 msgstr "Non visualizzare più questa finestra"
 
-#: ../../vdms_panels/presets_manager.py:1054
 msgid ""
 "Batch processing items\n"
 "Destination\n"
@@ -3184,11 +2402,9 @@ msgstr ""
 "Inizio segmento\n"
 "Durata clip"
 
-#: ../../vdms_panels/sequence_to_video.py:54
 msgid "Images need to be resized, please use Resize function."
 msgstr "Le immagini devono essere ridimensionate, usa la funzione ridimensiona."
 
-#: ../../vdms_panels/sequence_to_video.py:73
 msgid ""
 "\n"
 "1. Import one or more image files such as JPG, PNG and BMP formats, then select one.\n"
@@ -3221,11 +2437,9 @@ msgstr ""
 "in una cartella denominata 'Still_Images' con l'aggiunta di una cifra progressiva, nel percorso\n"
 "da te specificato."
 
-#: ../../vdms_panels/sequence_to_video.py:129
 msgid "Enable a single still image"
 msgstr "Abilita un fermo immagine singolo"
 
-#: ../../vdms_panels/sequence_to_video.py:162
 msgid ""
 "Force original aspect ratio using\n"
 "padding rather than stretching"
@@ -3233,28 +2447,21 @@ msgstr ""
 "Forza le proporzioni originali usando\n"
 "il riempimento anziché lo stretching"
 
-#: ../../vdms_panels/sequence_to_video.py:170
 msgid "Include audio file"
 msgstr "Includi file audio"
 
-#: ../../vdms_panels/sequence_to_video.py:173
 msgid "Play the video until audio track finishes"
 msgstr "Riproduci il video fino al termine della traccia audio"
 
-#: ../../vdms_panels/sequence_to_video.py:180
-#: ../../vdms_panels/sequence_to_video.py:439
 msgid "Open audio file"
 msgstr "Apri file audio"
 
-#: ../../vdms_panels/sequence_to_video.py:199
 msgid "Additional arguments"
 msgstr "Argomenti aggiuntivi"
 
-#: ../../vdms_panels/sequence_to_video.py:454
 msgid "Open Audio File"
 msgstr "Apri File Audio"
 
-#: ../../vdms_panels/sequence_to_video.py:466
 #, python-brace-format
 msgid ""
 "Invalid file: '{}'\n"
@@ -3265,7 +2472,6 @@ msgstr ""
 "\n"
 "{}"
 
-#: ../../vdms_panels/sequence_to_video.py:471
 #, python-brace-format
 msgid ""
 "Invalid file: '{}'\n"
@@ -3276,21 +2482,14 @@ msgstr ""
 "\n"
 "Non sembra essere un file audio."
 
-#: ../../vdms_panels/sequence_to_video.py:560
-#: ../../vdms_panels/sequence_to_video.py:587
-#: ../../vdms_panels/video_to_sequence.py:511
 #, python-brace-format
 msgid "Invalid file: '{}'"
 msgstr "File non valido: '{}'"
 
-#: ../../vdms_panels/sequence_to_video.py:570
-#: ../../vdms_panels/sequence_to_video.py:595
 #, python-brace-format
 msgid "Unsupported format '{}'"
 msgstr "Formato non supportato '{}'"
 
-#: ../../vdms_panels/sequence_to_video.py:576
-#: ../../vdms_panels/sequence_to_video.py:600
 #, python-brace-format
 msgid ""
 "File does not exist:\n"
@@ -3301,15 +2500,9 @@ msgstr ""
 "\n"
 "\"{}\"\n"
 
-#: ../../vdms_panels/sequence_to_video.py:577
 msgid "ERROR"
 msgstr "ERRORE"
 
-#: ../../vdms_panels/sequence_to_video.py:707
-msgid "Shortest"
-msgstr "Più breve"
-
-#: ../../vdms_panels/sequence_to_video.py:715
 msgid ""
 "Items to concatenate\n"
 "Output filename\n"
@@ -3337,7 +2530,6 @@ msgstr ""
 "Durata immagine fissa\n"
 "Durata totale video"
 
-#: ../../vdms_panels/video_to_sequence.py:50
 msgid ""
 "\n"
 "1. Import one or more video files, then select one.\n"
@@ -3367,51 +2559,39 @@ msgstr ""
 "Le immagini prodotte verranno salvate in una cartella denominata 'Movie_to_Pictures'\n"
 "con l'aggiunta  di una cifra progressiva, nel percorso da te specificato."
 
-#: ../../vdms_panels/video_to_sequence.py:86
 msgid "Create thumbnails"
 msgstr "Crea miniature"
 
-#: ../../vdms_panels/video_to_sequence.py:87
 msgid "Create tiled mosaics"
 msgstr "Crea mosaici piastrellati"
 
-#: ../../vdms_panels/video_to_sequence.py:88
 msgid "Create animated GIF"
 msgstr "Crea GIF animato"
 
-#: ../../vdms_panels/video_to_sequence.py:90
 msgid "Options"
 msgstr "Opzioni"
 
-#: ../../vdms_panels/video_to_sequence.py:119
 msgid "Output format:"
 msgstr "Formato in uscita:"
 
-#: ../../vdms_panels/video_to_sequence.py:131
 msgid "Rows:"
 msgstr "Righe:"
 
-#: ../../vdms_panels/video_to_sequence.py:141
 msgid "Columns:"
 msgstr "Colonne:"
 
-#: ../../vdms_panels/video_to_sequence.py:205
 msgid "Other unofficial resources:"
 msgstr "Altre risorse non ufficiali:"
 
-#: ../../vdms_panels/video_to_sequence.py:229
 msgid "Set FPS control from 0.1 to 30.0 fps. The higher this value, the more images will be extracted."
 msgstr "Imposta il controllo FPS da 0,1 a 30,0 fps. Più alto è questo valore, più immagini verranno estratte."
 
-#: ../../vdms_panels/video_to_sequence.py:232
 msgid "Spaces around the mosaic tiles. From 0 to 32 pixels"
 msgstr "Spazi intorno alle tessere del mosaico. Da 0 a 32 pixel"
 
-#: ../../vdms_panels/video_to_sequence.py:234
 msgid "Spaces around the mosaic borders. From 0 to 32 pixels"
 msgstr "Spazi intorno ai bordi del mosaico. Da 0 a 32 pixel"
 
-#: ../../vdms_panels/video_to_sequence.py:626
 msgid ""
 "Selected File\n"
 "Output Format\n"
@@ -3439,51 +2619,39 @@ msgstr ""
 "Inizio segmento\n"
 "Durata"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:118
 msgid "Audio encoder settings, mapping and filters"
 msgstr "Impostazioni, mappatura e filtri del codificatore audio"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:128
 msgid "Audio Encoder"
 msgstr "Codificatore Audio"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:137
 msgid "Settings"
 msgstr "Impostazioni"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:148
 msgid "Index Selection:"
 msgstr "Selezione Indice:"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:157
 msgid "Map:"
 msgstr "Mappa:"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:180
 msgid "Normalization"
 msgstr "Normalizzazione"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:191
 msgid "Volume detect"
 msgstr "Rilevazione volume"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:195
 msgid "Volume Statistics"
 msgstr "Statistiche Volume"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:199
 msgid "Target level:"
 msgstr "Livello target:"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:264
 msgid "Gets maximum volume and average volume data in dBFS, then calculates the offset amount for audio normalization."
 msgstr "Ottiene i dati di volume massimo e volume medio in dBFS, quindi calcola la quantità di offset per la normalizzazione audio."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:267
 msgid "Limiter for the maximum peak level or the mean level (when switch to RMS) in dBFS. From -99.0 to +0.0; default for PEAK level is -1.0; default for RMS is -20.0"
 msgstr "Limitatore per il livello massimo di picco o il livello medio (quando si passa a RMS) in dBFS. Da -99,0 a +0,0; il valore predefinito per il livello PEAK è -1,0; il valore predefinito per RMS è -20,0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:271
 msgid ""
 "Normally on a video with correctly indexed streams and having one or more audio streams, the first audio stream should be indexed at \"1\", the second at \"2\" and so on (the video stream on the other hand is always indexed at \"0\"). In this case it is recommended to select the desired stream by setting a specific index, e.g \"1\" for for the first available audio stream.\n"
 "\n"
@@ -3493,7 +2661,6 @@ msgstr ""
 "\n"
 "Imposta questo controllo su \"Auto\" se il file sorgente è semplicemente una traccia audio."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:280
 msgid ""
 "\"Auto\" keeps all audio streams and processes only the one selected by the \"Index Selection\" control.\n"
 "\n"
@@ -3507,27 +2674,21 @@ msgstr ""
 "\n"
 "\"Solo indice\" elabora solo il flusso audio selezionato dal controllo \"Selezione indice\" e rimuove tutti gli altri dal video"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:288
 msgid "Integrated Loudness Target in LUFS. From -70.0 to -5.0, default is -16.0"
 msgstr "Target loudness integrato in LUFS. Da -70.0 a -5.0, il valore predefinito è -16.0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:291
 msgid "Maximum True Peak in dBTP. From -1.5 to +0.0, default is -2.0"
 msgstr "Picco reale massimo in dBTP. Da -1,5 a +0,0, il valore predefinito è -2,0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:294
 msgid "Loudness Range Target in LUFS. From +1.0 to +20.0, default is +11.0"
 msgstr "Target dell'intervallo loudness in LUFS. Da +1.0 a +20.0, il valore predefinito è +11.0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:297
 msgid "Play the audio stream selected in the \"Index Selection\" control. Using this function you can test the result of audio normalization."
 msgstr "Riproduci il flusso audio selezionato nel controllo \"Selezione indice\". Utilizzando questa funzione è possibile testare il risultato della normalizzazione audio."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:503
 msgid "Selected index does not exist or does not contain any audio streams"
 msgstr "L'indice selezionato non esiste o non contiene alcun flusso audio"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:508
 #, python-brace-format
 msgid ""
 "ERROR: Missing audio stream:\n"
@@ -3536,15 +2697,12 @@ msgstr ""
 "ERRORE: flusso audio mancante:\n"
 "\"{}\""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:726
 msgid "PEAK level normalization, which will produce a maximum peak level equal to the set target level."
 msgstr "Normalizzazione del livello di picco, il quale produrrà un livello di picco massimo pari al livello target impostato."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:729
 msgid "RMS-based normalization, which according to mean volume calculates the amount of gain to reach same average power signal."
 msgstr "Normalizzazione basata su RMS. In base al volume medio viene calcolata la quantità di guadagno per raggiungere lo stesso segnale di potenza medio."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:733
 msgid ""
 "Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements the EBU R128 algorithm.\n"
 "Ideal for live normalization. It produces worse results than the High-quality two-pass Loudnorm normalization, but is faster."
@@ -3552,7 +2710,6 @@ msgstr ""
 "Normalizzazione Loudnorm. Normalizza il volume percepito usando il filtro \"loudnorm\", il quale implementa l'algoritmo EBU R128.\n"
 "Ideale per la normalizzazione dal vivo. Produce risultati meno precisi della normalizzazione ad alta qualità Loudnorm a due passaggi, ma è più veloce."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:740
 msgid ""
 "High-quality two-pass Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements\n"
 "the EBU R128 algorithm. Ideal for postprocessing."
@@ -3560,23 +2717,18 @@ msgstr ""
 "Normalizzazione Loudnorm a due passaggi di alta qualità. Normalizza il volume percepito usando il filtro \"loudnorm\", il quale\n"
 "implementa l'algoritmo EBU R128. Ideale per la post-elaborazione."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:789
 msgid "You need to import at least one file"
 msgstr "Importa almeno un file"
 
-#: ../../vdms_panels/miscellaneous/miscell.py:63
 msgid "Subtitle Mapping:"
 msgstr "Mappatura dei sottotitoli:"
 
-#: ../../vdms_panels/miscellaneous/miscell.py:77
 msgid "Copy Chapters"
 msgstr "Copia i Capitoli"
 
-#: ../../vdms_panels/miscellaneous/miscell.py:79
 msgid "Copy Metadata"
 msgstr "Copia i Metadati"
 
-#: ../../vdms_panels/miscellaneous/miscell.py:85
 msgid ""
 "Select \"All\" to include any source file subtitles in the output video.\n"
 "\n"
@@ -3590,89 +2742,39 @@ msgstr ""
 "\n"
 "Questa opzione viene automaticamente ignorata per i file audio di output."
 
-#: ../../vdms_panels/miscellaneous/miscell.py:90
 msgid "Copy the chapter markers as is from source file. This option is automatically ignored for output audio files."
 msgstr "Copia i marcatori di capitolo così come sono dal file sorgente. Questa opzione viene automaticamente ignorata per i file audio di output."
 
-#: ../../vdms_panels/miscellaneous/miscell.py:93
 msgid "Copy all incoming metadata from source file, such as audio/video tags, titles, unique marks, and so on."
 msgstr "Copia tutti i metadati in entrata dal file sorgente, come tag audio/video, titoli, contrassegni univoci e così via."
 
-#: ../../vdms_panels/miscellaneous/miscell.py:108
 msgid "Additional options"
 msgstr "Opzioni aggiuntive"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:89
-#: ../../vdms_panels/video_encoders/av1_svt.py:120
-#: ../../vdms_panels/video_encoders/avc_x264.py:90
-#: ../../vdms_panels/video_encoders/hevc_x265.py:98
-#: ../../vdms_panels/video_encoders/mpeg4.py:71
-#: ../../vdms_panels/video_encoders/vp9_webm.py:131
 msgid "Reload"
 msgstr "Ricarica"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:101
-#: ../../vdms_panels/video_encoders/av1_svt.py:129
-#: ../../vdms_panels/video_encoders/avc_x264.py:101
-#: ../../vdms_panels/video_encoders/hevc_x265.py:109
-#: ../../vdms_panels/video_encoders/mpeg4.py:82
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:97
-#: ../../vdms_panels/video_encoders/vp9_webm.py:141
 msgid "Optimize for Web"
 msgstr "Ottimizza per il Web"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:247
-#: ../../vdms_panels/video_encoders/av1_svt.py:313
-#: ../../vdms_panels/video_encoders/avc_x264.py:242
-#: ../../vdms_panels/video_encoders/hevc_x265.py:250
-#: ../../vdms_panels/video_encoders/mpeg4.py:198
-#: ../../vdms_panels/video_encoders/vp9_webm.py:288
 msgid "Reloads the selected video encoder settings. Changes will be discarded."
 msgstr "Ricarica le impostazioni del codificatore video selezionato. Le modifiche verranno ignorate."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:250
-#: ../../vdms_panels/video_encoders/avc_x264.py:273
-#: ../../vdms_panels/video_encoders/hevc_x265.py:277
-#: ../../vdms_panels/video_encoders/vp9_webm.py:291
 msgid "Constant rate factor. Lower values correspond to higher quality and greater file size. Set to -1 to disable this control."
 msgstr "Fattore di tasso costante. I valori più bassi corrispondono a una qualità superiore e a una dimensione del file maggiore. Imposta -1 per disabilitare questo controllo."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:254
-#: ../../vdms_panels/video_encoders/av1_svt.py:357
-#: ../../vdms_panels/video_encoders/vp9_webm.py:295
 msgid "Number of tile rows to use, default changes per resolution"
 msgstr "Numero righe anteprime da usare, modifiche predefinite per risoluzione"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:256
-#: ../../vdms_panels/video_encoders/av1_svt.py:359
-#: ../../vdms_panels/video_encoders/vp9_webm.py:297
 msgid "Number of tile columns to use, default changes per resolution"
 msgstr "Numero colonne anteprime da usare, modifiche predefinite per risoluzione"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:259
-#: ../../vdms_panels/video_encoders/av1_svt.py:368
-#: ../../vdms_panels/video_encoders/avc_x264.py:253
-#: ../../vdms_panels/video_encoders/hevc_x265.py:261
-#: ../../vdms_panels/video_encoders/mpeg4.py:201
-#: ../../vdms_panels/video_encoders/vp9_webm.py:300
 msgid "Set the Group Of Picture (GOP). Set to -1 to disable this control."
 msgstr "Imposta la dimensione del gruppo di immagini (GOP). Imposta -1 per disabilitare questo controllo."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:262
-#: ../../vdms_panels/video_encoders/av1_svt.py:371
-#: ../../vdms_panels/video_encoders/avc_x264.py:256
-#: ../../vdms_panels/video_encoders/hevc_x265.py:264
-#: ../../vdms_panels/video_encoders/mpeg4.py:204
-#: ../../vdms_panels/video_encoders/vp9_webm.py:303
 msgid "It can reduce the file size, but takes longer."
 msgstr "Può ridurre le dimensioni del file , ma richiede più tempo."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:264
-#: ../../vdms_panels/video_encoders/av1_svt.py:373
-#: ../../vdms_panels/video_encoders/avc_x264.py:258
-#: ../../vdms_panels/video_encoders/hevc_x265.py:266
-#: ../../vdms_panels/video_encoders/mpeg4.py:206
-#: ../../vdms_panels/video_encoders/vp9_webm.py:305
 msgid "Set minimum bitrate tolerance. Most useful in setting up a CBR encode. It is of little use otherwise. Set to -1 to disable this control."
 msgstr ""
 "Imposta la tolleranza minima del bitrate. \n"
@@ -3680,58 +2782,26 @@ msgstr ""
 "Altrimenti serve a poco. \n"
 "Impostalo a -1 per disabilitare questo controllo."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:268
-#: ../../vdms_panels/video_encoders/av1_svt.py:377
-#: ../../vdms_panels/video_encoders/avc_x264.py:262
-#: ../../vdms_panels/video_encoders/hevc_x265.py:270
-#: ../../vdms_panels/video_encoders/mpeg4.py:210
-#: ../../vdms_panels/video_encoders/vp9_webm.py:309
 msgid "Specifies a maximum tolerance. Requires bufsize to be set. Set to -1 to disable this control."
 msgstr ""
 "Specifica una tolleranza massima. \n"
 "Richiede l'impostazione della dimensione del buffer. \n"
 "Impostalo a -1 per disabilitare questo controllo."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:271
-#: ../../vdms_panels/video_encoders/av1_svt.py:380
-#: ../../vdms_panels/video_encoders/avc_x264.py:265
-#: ../../vdms_panels/video_encoders/hevc_x265.py:273
-#: ../../vdms_panels/video_encoders/mpeg4.py:213
-#: ../../vdms_panels/video_encoders/vp9_webm.py:312
 msgid "Set ratecontrol buffer size, which determines the variability of the output bitrate. Set to -1 to disable this control."
 msgstr ""
 "Imposta la dimensione del buffer di controllo della velocità, che determina la variabilità del bitrate destinazione. \n"
 "Impostalo a -1 per disabilitare questo controllo."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:275
-#: ../../vdms_panels/video_encoders/av1_svt.py:384
-#: ../../vdms_panels/video_encoders/avc_x264.py:277
-#: ../../vdms_panels/video_encoders/hevc_x265.py:281
-#: ../../vdms_panels/video_encoders/mpeg4.py:231
-#: ../../vdms_panels/video_encoders/vp9_webm.py:316
 msgid "Specifies the target (average) bit rate for the encoder to use. Higher value = higher quality. Set -1 to disable this control."
 msgstr "Specifica l'obiettivo (in media) del bit rate per il codificatore da usare. Valore alto = alta qualità. Impostare a -1 per disabilitare il controllo."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:279
-#: ../../vdms_panels/video_encoders/av1_svt.py:388
-#: ../../vdms_panels/video_encoders/avc_x264.py:281
-#: ../../vdms_panels/video_encoders/hevc_x265.py:285
-#: ../../vdms_panels/video_encoders/mpeg4.py:235
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:131
-#: ../../vdms_panels/video_encoders/vp9_webm.py:320
 msgid "Video width and video height ratio."
 msgstr "Rapporto larghezza e altezza video."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:281
-#: ../../vdms_panels/video_encoders/av1_svt.py:390
-#: ../../vdms_panels/video_encoders/avc_x264.py:283
-#: ../../vdms_panels/video_encoders/hevc_x265.py:287
-#: ../../vdms_panels/video_encoders/mpeg4.py:237
-#: ../../vdms_panels/video_encoders/vp9_webm.py:322
 msgid "Frame rate (frames per second). Frames repeat a given number of times per second. In some countries this is 30 for NTSC, other countries (like Italy) use 25 for PAL"
 msgstr "Frequenza fotogrammi (fotogrammi al secondo). I fotogrammi si ripetono un determinato numero di volte al secondo. In alcuni paesi sono 30 NTSC, in altri paesi PAL (come l'Italia) sono 25"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:285
 msgid "Quality/Speed ratio modifier. CPU Used sets how efficient the compression will be. Lower values mean slower encoding with better quality, and vice-versa. Valid values are from 0 to 8 inclusive."
 msgstr ""
 "Modifica rapporto qualità/velocità. \n"
@@ -3739,7 +2809,6 @@ msgstr ""
 "Valori più bassi indicano una codifica più lenta con una qualità migliore e viceversa. \n"
 "I valori validi sono compresi tra 0 e 8 inclusi."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:290
 msgid "Quality and compression efficiency vs speed trade-off. \"good\" is the default and recommended for most applications; \"realtime\" is recommended for live/fast encoding (live streaming, video conferencing, etc); \"allintra\" for All Intra encoding."
 msgstr ""
 "Qualità ed efficienza compressione rispetto alla velocità. \n"
@@ -3747,7 +2816,6 @@ msgstr ""
 "\"Tempo reale\" è consigliata per la codifica live/veloce (streaming live, videoconferenze, ecc.); \n"
 "\"Allintra\" per la codifica All Intra."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:297
 msgid ""
 "Row Multi-Threading enables row-based multi-threading which maximizes CPU usage.\n"
 "\n"
@@ -3761,7 +2829,6 @@ msgstr ""
 "\n"
 "L'abilitazione di Row Multi-Threading è più veloce solo quando la CPU ha più thread rispetto al numero di Tile codificati."
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:316
 msgid ""
 "presets 1-3 represent extremely high efficiency, for use when encode time is not important and quality/size of the resulting video file is critical.\n"
 "\n"
@@ -3780,7 +2847,6 @@ msgstr ""
 "Il profilo 13 è ancora più veloce ma non è destinato all'utente consumer: può essere usato, ad esempio, come metrica di qualità per scena nelle applicazioni VOD.\n"
 "Si dovrebbe usare il profilo più basso tollerabile."
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:327
 msgid ""
 "Constant rate factor. This parameter governs the quality/size trade-off.\n"
 "\n"
@@ -3800,7 +2866,6 @@ msgstr ""
 "\n"
 "Impostalo a -1 per disabilitare questo controllo."
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:334
 msgid ""
 "The \"Film Grain\" parameter allows SVT-AV1 to detect and delete film grain from the source video, and replace it with synthetic grain of the same character, resulting in significant bitrate savings.\n"
 "\n"
@@ -3822,7 +2887,6 @@ msgstr ""
 "\n"
 "Se il video sorgente non ha grana naturale, questo parametro può essere impostato a -1 per disabilitarlo o impostarlo almeno a 0."
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:346
 msgid ""
 "If enabled, the \"Film Grain Denoiser\" option can mitigate the detail removal caused by high \"Film Grain\" values required to preserve the look of very grainy films\n"
 "\n"
@@ -3832,60 +2896,41 @@ msgstr ""
 "\n"
 "Per impostazione predefinita, i fotogrammi denoizzati vengono passati per essere codificati come immagini finali, abilitando questa funzione si otterranno invece i fotogrammi originali da usare. "
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:353
 msgid "Enables encoder optimization to produce faster (less CPU intensive) bit streams to decode, similar to the fastdecode tuning in x264 and x265."
 msgstr "Consente l'ottimizzazione dell'encoder per produrre flussi da decodificare più veloci (meno impegnativi per la CPU), in modo simile all'ottimizzazione della decodifica rapida in x264 e x265."
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:362
-#: ../../vdms_panels/video_encoders/avc_x264.py:247
-#: ../../vdms_panels/video_encoders/hevc_x265.py:255
 msgid "Set profile restrictions"
 msgstr "Imposta le restrizioni del profilo"
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:364
-#: ../../vdms_panels/video_encoders/avc_x264.py:249
-#: ../../vdms_panels/video_encoders/hevc_x265.py:257
 msgid "Specify level for a selected profile"
 msgstr "Specificare il livello per un profilo selezionato"
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:366
-#: ../../vdms_panels/video_encoders/avc_x264.py:251
-#: ../../vdms_panels/video_encoders/hevc_x265.py:259
 msgid "Tune the encoding params"
 msgstr "Metti a punto i parametri di codifica"
 
-#: ../../vdms_panels/video_encoders/avc_x264.py:245
-#: ../../vdms_panels/video_encoders/hevc_x265.py:253
 msgid "Set the encoding preset (default \"medium\")"
 msgstr "Imposta il preset di codifica (in default è \"medio\")"
 
-#: ../../vdms_panels/video_encoders/avc_x264.py:269
 msgid "specifies the target (average) bit rate for the encoder to use. Higher value = higher quality. Set -1 to disable this control."
 msgstr "specifica l'obiettivo (in media) del bit rate per il codificatore da usare. Valore alto = alta qualità. Impostare a -1 per disabilitare il controllo."
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:217
 msgid "Variable Bit Rate. From 0-30, with 1 being highest quality/largest filesize and 30 being the lowest quality/smallest filesize. Set to -1 to disable this control."
 msgstr ""
 "Velocità variabile in bit. \n"
 "Da 0 a 30, dove 1 indica la qualità più alta/la dimensione del file più grande e 30 la qualità più bassa/la dimensione del file più piccola. \n"
 "Imposta a -1 per disabilitare questo controllo."
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:222
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:133
 msgid "Frames repeat a given number of times per second. In some countries this is 30 for NTSC, other countries (like Italy) use 25 for PAL"
 msgstr "I frame si ripetono un determinato numero di volte al secondo. In alcuni paesi sono 30 NTSC, in paesi PAL come l'Italia sono 25"
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:226
 msgid "The default FourCC stored in an MPEG-4-coded file will be FMP4. If you want a different FourCC, set this option to xvid to force the FourCC xvid to be stored as the video FourCC rather than the default."
 msgstr ""
 "FourCC predefinito memorizzato in un file con codifica MPEG-4 sarà FMP4. \n"
 "Se vuoi usare un FourCC diverso, imposta questa opzione su xvid per forzare la memorizzazione di xvid FourCC come FourCC video anziché come predefinito."
 
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:162
 msgid "Copy Video Codec"
 msgstr "Copia codec video"
 
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:163
 msgid ""
 "This will just copy the video track as is, without any video re-encoding.\n"
 "You will only be able to change output format, select other audio encoders and\n"
@@ -3895,11 +2940,9 @@ msgstr ""
 "Potrai solo modificare il formato destinazione, selezionare altri codec audio e alcune\n"
 "altre opzioni."
 
-#: ../../vdms_panels/video_encoders/video_no_enc.py:74
 msgid "Video export disabled"
 msgstr "Esportazione video disabilitata"
 
-#: ../../vdms_panels/video_encoders/video_no_enc.py:75
 msgid ""
 "The Media target you just selected will only allow you to export files as audio tracks.\n"
 "You can then process audio source files only or extract indexed audio streams on\n"
@@ -3909,7 +2952,6 @@ msgstr ""
 "È quindi possibile elaborare solo i file sorgenti audio o estrarre flussi audio indicizzati in\n"
 "file video."
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:326
 msgid ""
 "Speed sets how efficient the compression will be.\n"
 "\n"
@@ -3931,7 +2973,6 @@ msgstr ""
 "\n"
 "Quando la qualità è impostata su \"Tempo reale\", i valori disponibili per la velocità sono compresi tra 0 e 8."
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:335
 msgid ""
 "Time to spend encoding.\n"
 "\n"
@@ -3949,27 +2990,24 @@ msgstr ""
 "\n"
 "\"Realtime\" è consigliato per la codifica live/veloce."
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:341
-msgid "If enabled, adds support for row based multithreading which greatly enhances the number of threads the encoder can utilise. This improves encoding speed significantly on systems that are otherwise underutilised when encoding VP9. Since the amount of additional threads depends on the number of \"tiles\", which itself depends on the video resolution, encoding higher resolution videos will see a larger performance improvement."
+msgid ""
+"If enabled, adds support for row based multithreading which greatly enhances the number of threads the encoder can utilise. This improves encoding speed significantly on systems that are otherwise underutilised when encoding VP9. Since the amount of additional threads depends on the number of \"tiles\", which itself depends on the video resolution, encoding higher resolution videos will see a "
+"larger performance improvement."
 msgstr ""
 "Se abilitato, aggiunge il supporto per il multi threading basato su righe che aumenta notevolmente il numero di thread che il codificatore può usare. \n"
 "Ciò migliora significativamente la velocità di codifica su sistemi che altrimenti sarebbero sotto usati durante la codifica VP9. \n"
 "Poiché la quantità di thread aggiuntivi dipende dal numero di \"riquadri\", che a sua volta dipende dalla risoluzione video, la codifica di video a risoluzione più elevata vedrà un maggiore miglioramento delle prestazioni."
 
-#: ../../vdms_utils/presets_manager_utils.py:46
 #, python-brace-format
 msgid "Supports ({0}) formats only, not ({1})"
 msgstr "Supporta solo i formati ({0}) , non ({1})"
 
-#: ../../vdms_utils/presets_manager_utils.py:49
 msgid "File formats not supported by the selected profile"
 msgstr "Formato di file non supportati dal profilo selezionato"
 
-#: ../../vdms_utils/presets_manager_utils.py:52
 msgid "Warning"
 msgstr "Avvertimento"
 
-#: ../../vdms_utils/presets_manager_utils.py:90
 msgid ""
 "No presets found.\n"
 "\n"
@@ -3979,11 +3017,9 @@ msgstr ""
 "\n"
 "Possibile soluzione: apri il pannello \"Gestione profili\", vai alla colonna \"Profili\" e prova a seleziona \"Ripristina tutto ...\""
 
-#: ../../vdms_utils/queue_utils.py:54
 msgid "Import queue file"
 msgstr "Importa file della coda"
 
-#: ../../vdms_utils/queue_utils.py:89
 #, python-brace-format
 msgid ""
 "ERROR: invalid data found loading queue file.\n"
@@ -3996,11 +3032,9 @@ msgstr ""
 "\n"
 "Non può contenere più occorrenze nel valore delle chiavi \"destinazione\"."
 
-#: ../../vdms_utils/queue_utils.py:118
 msgid "Videomass - Add Items to Queue"
 msgstr "Videomass - Aggiungi elementi alla Coda"
 
-#: ../../vdms_utils/queue_utils.py:119
 msgid ""
 "Multiple items with identical names and destination paths cannot coexist.\n"
 "Please choose one of the following actions:"
@@ -4008,15 +3042,12 @@ msgstr ""
 "Più elementi con nomi e percorsi di destinazione identici non possono coesistere.\n"
 "Scegli una delle seguenti azioni:"
 
-#: ../../vdms_utils/queue_utils.py:123
 msgid "Replace occurrences with items from the imported queue."
 msgstr "Sostituisci le occorrenze con gli elementi della coda importata."
 
-#: ../../vdms_utils/queue_utils.py:124
 msgid "Add only the currently missing items to the queue."
 msgstr "Aggiungi solo gli elementi attualmente mancanti alla coda."
 
-#: ../../vdms_utils/queue_utils.py:125
 msgid "Remove the current queue and replace it with the imported one."
 msgstr "Rimuovi la coda corrente e sostituiscila con quella importata."
 
@@ -4028,3 +3059,7 @@ msgstr "Rimuovi la coda corrente e sostituiscila con quella importata."
 
 #~ msgid "Subtitle Mapping"
 #~ msgstr "Mappatura dei sottotitoli"
+
+#~ msgid "Shortest"
+#~ msgstr "Più breve"
+

--- a/videomass/data/locale/it_IT/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/it_IT/LC_MESSAGES/videomass.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Videomass - IT - 12.07.2025\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-30 11:02+0200\n"
+"POT-Creation-Date: 2025-07-30 15:28+0200\n"
 "PO-Revision-Date: 2025-07-26 15:07+0200\n"
 "Last-Translator: bovirus <bovirus@gmail.comn>\n"
 "Language: it_IT\n"
@@ -3050,16 +3050,4 @@ msgstr "Aggiungi solo gli elementi attualmente mancanti alla coda."
 
 msgid "Remove the current queue and replace it with the imported one."
 msgstr "Rimuovi la coda corrente e sostituiscila con quella importata."
-
-#~ msgid "Some text boxes are still incomplete"
-#~ msgstr "Alcune caselle di testo non sono complete"
-
-#~ msgid "FFplay"
-#~ msgstr "FFplay"
-
-#~ msgid "Subtitle Mapping"
-#~ msgstr "Mappatura dei sottotitoli"
-
-#~ msgid "Shortest"
-#~ msgstr "Più breve"
 

--- a/videomass/data/locale/nl_NL/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/nl_NL/LC_MESSAGES/videomass.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Videomass 5.0.18\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-30 11:02+0200\n"
+"POT-Creation-Date: 2025-07-30 15:28+0200\n"
 "PO-Revision-Date: 2024-07-03 18:48+0200\n"
 "Last-Translator: johannesdedoper <https://github.com/johannesdedoper>\n"
 "Language: nl_NL\n"
@@ -3015,16 +3015,4 @@ msgstr ""
 
 msgid "Remove the current queue and replace it with the imported one."
 msgstr ""
-
-#~ msgid "Some text boxes are still incomplete"
-#~ msgstr "Enkele tekstkaders zijn nog onvolledig"
-
-#~ msgid "FFplay"
-#~ msgstr "FFplay"
-
-#~ msgid "Subtitle Mapping"
-#~ msgstr "Ondertitel Map"
-
-#~ msgid "Shortest"
-#~ msgstr ""
 

--- a/videomass/data/locale/nl_NL/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/nl_NL/LC_MESSAGES/videomass.po
@@ -1,13 +1,13 @@
-# Dutch translation for Videomass.
-# Copyleft -  2023 Gianluca Pernigotto
-# This file is distributed under the same license as the Videomass package
-# FIRST AUTHOR Gianluca Pernigotto <jeanlucperni@gmail.com>, 2021
+# Dutch (Netherlands) translations for Videomass.
+# Copyright (C) 2025 ORGANIZATION
+# This file is distributed under the same license as the Videomass project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Videomass 5.0.18\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-26 15:04+0200\n"
+"POT-Creation-Date: 2025-07-30 11:02+0200\n"
 "PO-Revision-Date: 2024-07-03 18:48+0200\n"
 "Last-Translator: johannesdedoper <https://github.com/johannesdedoper>\n"
 "Language: nl_NL\n"
@@ -18,7 +18,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
-#: ../../gui_app.py:196
 #, python-brace-format
 msgid ""
 "Unexpected error while deleting file contents:\n"
@@ -29,168 +28,117 @@ msgstr ""
 "\n"
 "{0}"
 
-#: ../../vdms_dialogs/about_dialog.py:52
 msgid "Cross-platform graphical user interface for FFmpeg\n"
 msgstr ""
 
-#: ../../vdms_dialogs/audioproperties.py:224
 msgid "Videomass supports mono and stereo audio channels. If you are not sure set to \"Auto\" and source values will be copied."
 msgstr "Videomass ondersteunt mono en stereo audiokanalen. Als u niet zeker bent, kies \"Auto\" en de bronwaarden zullen worden gekopiëerd."
 
-#: ../../vdms_dialogs/audioproperties.py:228
 msgid "The audio Rate (or sample-rate) is the sound sampling frequency and is measured in Hertz. The higher the frequency, the more true it will be to the sound source and the more the file will increase in size. For audio CD playback, set a sampling frequency of 44100 kHz. If you are not sure, set to \"Auto\" and source values will be copied."
 msgstr "De audio rate (of sample rate) is de geluid-sampling frequentie, gemeten in Hertz. Hoe hoger deze frequentie, hoe meer het audiosignaal overeen zal komen met de geluidsbron en hoe groter het bestand zal worden. Zet de sample frequentie op 44100 kHz om een audio CD normaal af te spelen. Als u niet zeker bent, kies \"Auto\" en de bronwaarden worden gekopiëerd."
 
-#: ../../vdms_dialogs/audioproperties.py:237
 msgid "The audio bitrate affects the file compression and thus the quality of listening. The higher the value, the higher the quality."
 msgstr "De audio bitrate beïnvloedt de bestandscompressie en daarom de geluidskwaliteit. Hoe hoger de waarde, hoe hoger de kwaliteit."
 
-#: ../../vdms_dialogs/audioproperties.py:241
 msgid "Bit depth is the number of bits of information in each sample, and it directly corresponds to the resolution of each sample. Bit depth is only meaningful in reference to a PCM digital signal. Non-PCM formats, such as lossy compression formats, do not have associated bit depths."
 msgstr "Bit depth is het aantal informatie-bits in elke sample en heeft direct betrekking op de resolutie ervan. Bit depth is alleen relevant bij een digitaal PCM signaal. Niet-PCM formaten, zoals lossy compressie formaten, hebben geen bit depth."
 
-#: ../../vdms_dialogs/epilogue.py:74 ../../vdms_dialogs/queuedlg.py:120
 msgid "When finished, once the operations have been completed successfully:"
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:80 ../../vdms_dialogs/queuedlg.py:126
 #, fuzzy
 msgid "Trash the source files"
 msgstr "Verwijder het geselecteerde profiel"
 
-#: ../../vdms_dialogs/epilogue.py:84 ../../vdms_dialogs/queuedlg.py:130
 #, fuzzy
 msgid "Clear the File List"
 msgstr "Log bestanden lijst"
 
-#: ../../vdms_dialogs/epilogue.py:91 ../../vdms_dialogs/queuedlg.py:142
-#: ../../vdms_main/main_frame.py:1322
 msgid "Run"
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:97
 #, fuzzy
 msgid "Videomass - Batch Mode"
 msgstr "Videomass - Presets Manager"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:47
 msgid "FFmpeg encoders"
 msgstr "FFmpeg encoders"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:48
 #, fuzzy
 msgid "supported encoders"
 msgstr "FFmpeg encoders"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:50
 msgid "FFmpeg decoders"
 msgstr "FFmpeg decoders"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:51
 #, fuzzy
 msgid "supported decoders"
 msgstr "FFmpeg decoders"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:77
-#: ../../vdms_panels/av_conversions.py:293
 msgid "Video"
 msgstr "Video"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:87
-#: ../../vdms_panels/av_conversions.py:305
 msgid "Audio"
 msgstr "Audio"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:97
 msgid "Subtitle"
 msgstr "Ondertitel"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:114
-#: ../../vdms_dialogs/ffmpeg_codecs.py:123
-#: ../../vdms_dialogs/ffmpeg_codecs.py:132
-#: ../../vdms_dialogs/ffmpeg_formats.py:112
-#: ../../vdms_dialogs/ffmpeg_formats.py:115
-#: ../../vdms_dialogs/ffmpeg_formats.py:118
 msgid "description"
 msgstr "beschrijving"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:72
 msgid "Informations"
 msgstr "Informatie"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:83
 msgid "Flags settings"
 msgstr "Markeer instellingen"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:93
 msgid "Flags enabled"
 msgstr "Markeringen geactiveerd"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:103
 msgid "Flags disabled"
 msgstr "Markeringen gedeactiveerd"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:116
 msgid "FFmpeg configuration"
 msgstr "FFmpeg configuratie"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:124
 msgid "flags"
 msgstr "markeringen"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:125 ../../vdms_dialogs/ffmpeg_conf.py:129
-#: ../../vdms_dialogs/ffmpeg_conf.py:133
 msgid "options"
 msgstr "opties"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:128 ../../vdms_dialogs/ffmpeg_conf.py:132
 msgid "status"
 msgstr "status"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:167
 msgid "FFprobe   ...not found !"
 msgstr "FFprobe   ...niet gevonden !"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:175
 msgid "FFplay   ...not found !"
 msgstr "FFplay   ...niet gevonden !"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:205
-#: ../../vdms_panels/sequence_to_video.py:706
-#: ../../vdms_panels/video_to_sequence.py:606
 msgid "Enabled"
 msgstr "Geactiveerd"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:216
-#: ../../vdms_panels/sequence_to_video.py:706
-#: ../../vdms_panels/video_to_sequence.py:610
 msgid "Disabled"
 msgstr "Uitgezet"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:71
 msgid "Demuxing only"
 msgstr "Alleen Demuxen"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:82
 msgid "Muxing only"
 msgstr "Alleen Muxen"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:93
 msgid "Demuxing/Muxing support"
 msgstr "Demux/Mux ondersteuning"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:104
 msgid "FFmpeg file formats"
 msgstr "FFmpeg bestandsformaten"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:111
-#: ../../vdms_dialogs/ffmpeg_formats.py:114
-#: ../../vdms_dialogs/ffmpeg_formats.py:117
 #, fuzzy
 msgid "supported formats"
 msgstr "Lijst Ondersteunde Formaten"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:46
 msgid ""
 "Contextual help based on the argument entered in the additional text field.\n"
 "Each argument consists of the type and a type-specific name.\n"
@@ -205,132 +153,99 @@ msgid ""
 "Some examples:"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:68 ../../vdms_dialogs/ffmpeg_help.py:301
-#: ../../vdms_dialogs/ffmpeg_help.py:315
 #, fuzzy
 msgid "Help topic"
 msgstr "lijst help-onderwerpen"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:69
 #, fuzzy
 msgid "List basic options"
 msgstr "print basis opties"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:70
 #, fuzzy
 msgid "List more options"
 msgstr "print meer opties"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:71
 #, fuzzy
 msgid "List all options (very long)"
 msgstr "print alle opties (erg lang)"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:72
 #, fuzzy
 msgid "Show available devices"
 msgstr "toon beschikbare randapparaten"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:73
 #, fuzzy
 msgid "Show available bit stream filters"
 msgstr "toon beschikbare bit stream filters"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:74
 #, fuzzy
 msgid "Show available protocols"
 msgstr "toon beschikbare protocollen"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:75
 #, fuzzy
 msgid "Show available filters"
 msgstr "toon beschikbare filters"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:76
 #, fuzzy
 msgid "Show available pixel formats"
 msgstr "toon beschikbare pixel formaten"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:77
 #, fuzzy
 msgid "Show available audio sample formats"
 msgstr "toon beschikbare audio sample formaten"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:78
 #, fuzzy
 msgid "Show available color names"
 msgstr "toon beschikbare kleurnamen"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:79
 #, fuzzy
 msgid "List sources of the input device"
 msgstr "geef lijst van sources voor het input randapparaat"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:80
 #, fuzzy
 msgid "List sinks of the output device"
 msgstr "geef lijst van sinks voor het input randapparaat"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:81
 #, fuzzy
 msgid "Show available HW acceleration methods"
 msgstr "toon beschikbare HW acceleratie methodes"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:82
 msgid "Show license"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:117 ../../vdms_dialogs/filter_scale.py:76
-#: ../../vdms_dialogs/shownormlist.py:98 ../../vdms_dialogs/shownormlist.py:107
-#: ../../vdms_dialogs/shownormlist.py:116 ../../vdms_miniframes/timeline.py:263
-#: ../../vdms_miniframes/timeline.py:283 ../../vdms_panels/concatenate.py:117
-#: ../../vdms_panels/sequence_to_video.py:117
-#: ../../vdms_panels/video_to_sequence.py:81
 #, fuzzy
 msgid "Read me"
 msgstr "Gereed"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:123 ../../vdms_main/main_frame.py:534
 msgid "Show configuration"
 msgstr "Toon configuratie"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:127 ../../vdms_main/main_frame.py:542
 msgid "Encoders"
 msgstr "Encoders"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:131 ../../vdms_main/main_frame.py:545
 msgid "Decoders"
 msgstr "Decoders"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:135 ../../vdms_main/main_frame.py:538
 msgid "Muxers and Demuxers"
 msgstr "Muxers en Demuxers"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:165
 msgid "help topic list"
 msgstr "lijst help-onderwerpen"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:184
 msgid "Type the argument here and confirm with the enter key on your keyboard"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:192
 msgid "The search function allows you to find entries in the current topic"
 msgstr "Met de zoekfunctie vind u items van het huidige onderwerp"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:195
 msgid "Ignore case"
 msgstr "Geen onderscheid hoofd-/kleine letters"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:196
 msgid "Ignore case distinctions: characters with different case will match."
 msgstr "Maak geen onderscheid tussen hoofd- en kleine letters."
 
-#: ../../vdms_dialogs/ffmpeg_help.py:206
 msgid "FFmpeg help topics"
 msgstr "FFmpeg help-onderwerpen"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:254
 msgid ""
 "This is a multifunctional search tool useful for local help searches\n"
 "on multiple FFmpeg topics and options. The search control, to\n"
@@ -343,8 +258,6 @@ msgid ""
 "with those features."
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:320 ../../vdms_dialogs/ffmpeg_help.py:345
-#: ../../vdms_dialogs/ffmpeg_help.py:371
 msgid ""
 "\n"
 "  ..Nothing available"
@@ -352,7 +265,6 @@ msgstr ""
 "\n"
 "  ..Niets beschikbaar"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:391
 #, fuzzy
 msgid ""
 "\n"
@@ -361,224 +273,128 @@ msgstr ""
 "\n"
 "  ...Niet gevonden"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:91
 msgid "Before"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:97
 msgid "After"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:103
-#: ../../vdms_dialogs/filter_crop.py:239
 msgid "Search for a specific frame"
 msgstr "Zoek naar een specifiek frame"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:117
-#: ../../vdms_dialogs/filter_crop.py:253
 msgid "Load"
 msgstr "Laad"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:120
 msgid "Color EQ"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:126
 #, fuzzy
 msgid "Contrast:"
 msgstr "Container:"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:134
-#: ../../vdms_dialogs/filter_colorcorrection.py:148
 msgid "-100 to +100, default value 0"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:139
 msgid "Brightness:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:158
 #, fuzzy
 msgid "Saturation:"
 msgstr "Duur:"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:166
 msgid "0 to 300, default value 100"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:170
 msgid "Gamma:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:179
 msgid "0 to 100, default value 10"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:187
-#: ../../vdms_dialogs/filter_crop.py:306
-#: ../../vdms_dialogs/filter_deinterlace.py:209
-#: ../../vdms_dialogs/filter_denoisers.py:110
-#: ../../vdms_dialogs/filter_scale.py:210 ../../vdms_dialogs/filter_stab.py:316
-#: ../../vdms_dialogs/filter_transpose.py:105
-#: ../../vdms_miniframes/timeline.py:262 ../../vdms_miniframes/timeline.py:281
 msgid "Reset"
 msgstr "Reset"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:207
 msgid "Color Correction EQ Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:343
-#: ../../vdms_dialogs/filter_colorcorrection.py:383
-#: ../../vdms_dialogs/filter_colorcorrection.py:390
-#: ../../vdms_dialogs/filter_crop.py:417 ../../vdms_dialogs/filter_scale.py:287
-#: ../../vdms_dialogs/filter_scale.py:394 ../../vdms_dialogs/filter_stab.py:473
-#: ../../vdms_dialogs/filter_stab.py:483 ../../vdms_dialogs/filter_stab.py:494
-#: ../../vdms_dialogs/filter_transpose.py:182
-#: ../../vdms_dialogs/mediainfo.py:245 ../../vdms_dialogs/mediainfo.py:265
-#: ../../vdms_dialogs/mediainfo.py:285 ../../vdms_dialogs/mediainfo.py:305
-#: ../../vdms_dialogs/setting_profiles.py:281
-#: ../../vdms_dialogs/setting_profiles.py:289 ../../vdms_io/checkup.py:45
-#: ../../vdms_io/checkup.py:93 ../../vdms_io/io_tools.py:144
-#: ../../vdms_main/main_frame.py:904 ../../vdms_main/main_frame.py:939
-#: ../../vdms_main/main_frame.py:961 ../../vdms_main/main_frame.py:979
-#: ../../vdms_main/main_frame.py:999
-#: ../../vdms_panels/audio_encoders/acodecs.py:510
-#: ../../vdms_panels/audio_encoders/acodecs.py:800
-#: ../../vdms_panels/concatenate.py:186
-#: ../../vdms_panels/long_processing_task.py:60
-#: ../../vdms_panels/presets_manager.py:426
-#: ../../vdms_panels/presets_manager.py:490
-#: ../../vdms_panels/presets_manager.py:560
-#: ../../vdms_panels/presets_manager.py:599
-#: ../../vdms_panels/presets_manager.py:619
-#: ../../vdms_panels/presets_manager.py:657
-#: ../../vdms_panels/presets_manager.py:701
-#: ../../vdms_panels/presets_manager.py:714
-#: ../../vdms_panels/presets_manager.py:721
-#: ../../vdms_panels/presets_manager.py:756
-#: ../../vdms_panels/presets_manager.py:785
-#: ../../vdms_panels/presets_manager.py:791
-#: ../../vdms_panels/sequence_to_video.py:467
-#: ../../vdms_panels/sequence_to_video.py:473
-#: ../../vdms_panels/sequence_to_video.py:561
-#: ../../vdms_panels/sequence_to_video.py:571
-#: ../../vdms_panels/sequence_to_video.py:588
-#: ../../vdms_panels/sequence_to_video.py:596
-#: ../../vdms_panels/sequence_to_video.py:602
-#: ../../vdms_panels/sequence_to_video.py:643
-#: ../../vdms_panels/sequence_to_video.py:689
-#: ../../vdms_panels/video_to_sequence.py:512
-#: ../../vdms_panels/video_to_sequence.py:583
-#: ../../vdms_threads/ffplay_file.py:43
-#: ../../vdms_utils/presets_manager_utils.py:86
-#: ../../vdms_utils/presets_manager_utils.py:95
-#: ../../vdms_utils/queue_utils.py:68 ../../vdms_utils/queue_utils.py:82
-#: ../../vdms_utils/queue_utils.py:95
 #, fuzzy
 msgid "Videomass - Error!"
 msgstr "Videomass - Laden..."
 
-#: ../../vdms_dialogs/filter_crop.py:228 ../../vdms_dialogs/filter_scale.py:109
 #, python-brace-format
 msgid "Source size: {0} x {1} pixels"
 msgstr "Bron grootte: {0} x {1} pixels"
 
-#: ../../vdms_dialogs/filter_crop.py:236
 #, fuzzy
 msgid "Crop color"
 msgstr "Bijsnij Filter"
 
-#: ../../vdms_dialogs/filter_crop.py:256
 msgid "Cropping area selection "
 msgstr "Gebied-selectie bijsnijden "
 
-#: ../../vdms_dialogs/filter_crop.py:261 ../../vdms_dialogs/filter_scale.py:121
 msgid "Height"
 msgstr "Hoogte"
 
-#: ../../vdms_dialogs/filter_crop.py:281
 msgid "Center"
 msgstr "Centrum"
 
-#: ../../vdms_dialogs/filter_crop.py:292 ../../vdms_dialogs/filter_scale.py:121
 msgid "Width"
 msgstr "Breedte"
 
-#: ../../vdms_dialogs/filter_crop.py:334
 #, fuzzy
 msgid "Crop Tool"
 msgstr "Bijsnij Filter"
 
-#: ../../vdms_dialogs/filter_crop.py:335
 msgid "Choose the color to draw the cropping area"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:337
 msgid "Crop to width"
 msgstr "Snij breedte bij"
 
-#: ../../vdms_dialogs/filter_crop.py:338
 #, fuzzy
 msgid "Move vertically (set to -1 to center the vertical axis)"
 msgstr "Verplaats verticaal - zet op -1 om de verticale as te centreren"
 
-#: ../../vdms_dialogs/filter_crop.py:340
 #, fuzzy
 msgid "Move horizontally (set to -1 to center the horizontal axis)"
 msgstr "Verplaats horizontaal - zet op -1 om de horizontale as te centreren"
 
-#: ../../vdms_dialogs/filter_crop.py:342
 msgid "Crop to height"
 msgstr "Snij hoogte bij"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:56
 msgid "Advanced Options"
 msgstr "Geavanceerde Opties"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:57
-#: ../../vdms_panels/av_conversions.py:351
 msgid "Deinterlace"
 msgstr "Interlace ongedaan maken"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:59
 msgid "Interlace"
 msgstr "Interlace"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:63
 msgid "Deinterlaces with w3fdif filter"
 msgstr "Maakt interlace ongedaan met w3fdif filter"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:77
 msgid "Deinterlaces with yadif filter"
 msgstr "Maakt interlace ongedaan met yadif filter"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:101
 msgid "Interlaces with interlace filter"
 msgstr "Doet interlace met interlace filter"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:118
 msgid "Deinterlacing and Interlacing"
 msgstr "Interlacen en ont-Interlacen"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:144
 msgid "Deinterlace the input video with `w3fdif` filter"
 msgstr "Maak interlace van input video ongedaan met `w3fdif` filter"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:146
 msgid "Set the interlacing filter coefficients."
 msgstr "Stel coëfficiënten van interlace filter in."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:148
-#: ../../vdms_dialogs/filter_deinterlace.py:158
 msgid "Specify which frames to deinterlace."
 msgstr "Specificeer frames waarvan u interlace ongedaan wilt maken."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:150
 msgid "Deinterlace the input video with `yadif` filter. Using FFmpeg, this is the best and fastest choice"
 msgstr "Maak interlace van input video ongedaan met `yadif` filter. Voor FFmpeg de beste en snelste keuze"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:153
 msgid ""
 "mode\n"
 "The interlacing mode to adopt."
@@ -586,7 +402,6 @@ msgstr ""
 "modus\n"
 "De interlacing modus die overnomen wordt."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:155
 msgid ""
 "parity\n"
 "The picture field parity assumed for the input interlaced video."
@@ -594,11 +409,9 @@ msgstr ""
 "pariteit\n"
 "De picture field parity voor de interlaced input video."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:160
 msgid "Simple interlacing filter from progressive contents."
 msgstr "Simpel interlacing filter voor progressieve beelden."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:162
 msgid ""
 "scan:\n"
 "determines whether the interlaced frame is taken from the even (tff - default) or odd (bff) lines of the progressive frame."
@@ -606,7 +419,6 @@ msgstr ""
 "scan:\n"
 "bepaalt of de interlaced frame genomen wordt van de even (tff - standaard) of oneven (bff) lijnen van de progressieve frame."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:166
 msgid ""
 "lowpass:\n"
 "Enable (default) or disable the vertical lowpass filter to avoid twitter interlacing and reduce moire patterns.\n"
@@ -616,33 +428,26 @@ msgstr ""
 "Aanzetten (standaard) of uitzetten van het verticale lowpass filter om twitter interlacing te voorkomen en moire patronen te verminderen.\n"
 "Geen instelling is de standaard."
 
-#: ../../vdms_dialogs/filter_denoisers.py:56
 #, fuzzy
 msgid "Denoiser Filters"
 msgstr "Denoiser filters"
 
-#: ../../vdms_dialogs/filter_denoisers.py:60
 msgid "Enable nlmeans denoiser"
 msgstr "Zet nlmeans denoiser aan"
 
-#: ../../vdms_dialogs/filter_denoisers.py:73
 msgid "nlmeans options"
 msgstr "nlmeans opties"
 
-#: ../../vdms_dialogs/filter_denoisers.py:82
 msgid "Enable hqdn3d denoiser"
 msgstr "Zet hqdn3d denoiser aan"
 
-#: ../../vdms_dialogs/filter_denoisers.py:91
 msgid "hqdn3d options"
 msgstr "hqdn3d opties"
 
-#: ../../vdms_dialogs/filter_denoisers.py:116
 #, fuzzy
 msgid "Denoiser Tool"
 msgstr "Denoiser"
 
-#: ../../vdms_dialogs/filter_denoisers.py:117
 msgid ""
 "nlmeans:\n"
 "Denoise frames using Non-Local Means algorithm is capable of restoring video sequences, even with strong noise. It is ideal for enhancing the quality of old VHS tapes."
@@ -650,7 +455,6 @@ msgstr ""
 "nlmeans:\n"
 "Ruis-reductie van frames door het Non-Local Means algoritme, kan een beeldenreeks herstellen, zelfs bij sterke ruis. Het is ideaal voor verbetering van de kwaliteit van oude VHS banden."
 
-#: ../../vdms_dialogs/filter_denoisers.py:122
 msgid ""
 "hqdn3d:\n"
 "This is a high precision/quality 3d denoise filter. It aims to reduce image noise, producing smooth images and making still images really still. It should enhance compressibility."
@@ -658,65 +462,48 @@ msgstr ""
 "hqdn3d:\n"
 "Dit is een 3d denoise filter met hoge nauwkeurigheid / kwaliteit. Het beoogt beeldruis te verminderen, wat resulteert in vloeiende beelden, waarbij stilstaande beelden echt stil staan. Compressie zal hierdoor verbeteren."
 
-#: ../../vdms_dialogs/filter_scale.py:81
 msgid "View result"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:85
 msgid "New size in pixels"
 msgstr "Nieuwe afmeting in pixels"
 
-#: ../../vdms_dialogs/filter_scale.py:89
 msgid "Width:"
 msgstr "Breedte:"
 
-#: ../../vdms_dialogs/filter_scale.py:99
 msgid "Height:"
 msgstr "Hoogte:"
 
-#: ../../vdms_dialogs/filter_scale.py:115
 msgid "Constrain proportions (keep aspect ratio)"
 msgstr "Beperk verhouding (behoud beeldverhouding)"
 
-#: ../../vdms_dialogs/filter_scale.py:120
 msgid "Which dimension to adjust?"
 msgstr "Welke dimensie aanpassen?"
 
-#: ../../vdms_dialogs/filter_scale.py:129
 msgid "Aspect Ratio"
 msgstr "Beeldverhouding"
 
-#: ../../vdms_dialogs/filter_scale.py:132
 msgid "Setdar filter (display aspect ratio) example 16/9, 4/3 "
 msgstr "Setdar filter (toon beeldverhouding) bijvoorbeeld 16/9, 4/3 "
 
-#: ../../vdms_dialogs/filter_scale.py:137
-#: ../../vdms_dialogs/filter_scale.py:171
 msgid "Numerator"
 msgstr "Teller"
 
-#: ../../vdms_dialogs/filter_scale.py:162
-#: ../../vdms_dialogs/filter_scale.py:196
 msgid "Denominator"
 msgstr "Noemer"
 
-#: ../../vdms_dialogs/filter_scale.py:166
 msgid "Setsar filter (sample aspect ratio) example 1/1"
 msgstr "Setsar filter (sample beeldverhouding) bijvoorbeeld 1/1"
 
-#: ../../vdms_dialogs/filter_scale.py:217
 msgid "Resize Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:218
 msgid "Scale filter, set to 0 to disable"
 msgstr "Schaling filter, zet uit door 0"
 
-#: ../../vdms_dialogs/filter_scale.py:221
 msgid "Display Aspect Ratio. Set to 0 to disable"
 msgstr "Toon beeldverhouding. Zet uit door 0"
 
-#: ../../vdms_dialogs/filter_scale.py:224
 msgid ""
 "Sample (aka Pixel) Aspect Ratio.\n"
 "Set to 0 to disable"
@@ -724,7 +511,6 @@ msgstr ""
 "Sample Beeldverhouding (of Pixel Beeldverhouding).\n"
 "Zet uit door 0"
 
-#: ../../vdms_dialogs/filter_scale.py:366
 msgid ""
 "If you want to keep the aspect ratio, select \"Constrain proportions\" below and\n"
 "specify only one dimension, either width or height, and set the other dimension\n"
@@ -734,459 +520,354 @@ msgstr ""
 "geef slechts 1 dimensie aan, dus breedte of hoogte, en zet de andere dimensie\n"
 "op -1 of -2 (sommige codecs vereisen -2, dus u zou dit eerst moeten testen)."
 
-#: ../../vdms_dialogs/filter_stab.py:81
 msgid "Enable stabilizer"
 msgstr "Activeer stabilisatie filter"
 
-#: ../../vdms_dialogs/filter_stab.py:83
 msgid "Create a side-by-side comparison video"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:88
 #, fuzzy
 msgid "Create a snapshot"
 msgstr "Maak een nieuwe preset"
 
-#: ../../vdms_dialogs/filter_stab.py:106
-#: ../../vdms_panels/audio_encoders/acodecs.py:167
 msgid "Preview"
 msgstr "Voorvertoning"
 
-#: ../../vdms_dialogs/filter_stab.py:109
 #, fuzzy
 msgid "Duration seconds:"
 msgstr "Duur"
 
-#: ../../vdms_dialogs/filter_stab.py:118
 msgid "Video Detect"
 msgstr "Video Detecteren"
 
-#: ../../vdms_dialogs/filter_stab.py:176
 msgid "[TRIPOD] Enable tripod mode if checked"
 msgstr "[TRIPOD] Activeer tripod modus wanneer geselecteerd"
 
-#: ../../vdms_dialogs/filter_stab.py:183
 msgid "Video transform"
 msgstr "Video transformatie"
 
-#: ../../vdms_dialogs/filter_stab.py:202
 msgid "[OPTALGO] optimization algorithm"
 msgstr "[OPTALGO] optimalisatie algoritme"
 
-#: ../../vdms_dialogs/filter_stab.py:224
 msgid "[CROP] Specify how to deal with borders at movement compensation"
 msgstr "[CROP] Specificeer hoe om te gaan met randen bij bewegings-compensatie"
 
-#: ../../vdms_dialogs/filter_stab.py:231
 msgid "[INVERT] Invert transforms if checked"
 msgstr "[INVERT] Inverteer transformaties wanneer geselecteerd"
 
-#: ../../vdms_dialogs/filter_stab.py:234
 msgid "[RELATIVE] Consider transforms as relative to previous frame if checked, absolute if unchecked"
 msgstr "[RELATIVE] Beschouw transformaties als relatief tot vorige frame wanneer geselecteerd, absoluut wanneer niet geselecteerd"
 
-#: ../../vdms_dialogs/filter_stab.py:279
 msgid "Specify type of interpolation"
 msgstr "Specificeer interpolatie type"
 
-#: ../../vdms_dialogs/filter_stab.py:287
 msgid "[TRIPOD2] virtual tripod mode, equivalent to relative=unchecked:smoothing=0"
 msgstr "[TRIPOD2] virtuele tripod modus, gelijk aan relative=unchecked:smoothing=0"
 
-#: ../../vdms_dialogs/filter_stab.py:294
 msgid "Unsharp filter:"
 msgstr "Ont-scherp filter:"
 
-#: ../../vdms_dialogs/filter_stab.py:323
 msgid "Seek to a position on the video."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:325
 msgid "Make a snapshot of the video with the settings made."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:327
 #, fuzzy
 msgid "Set the snapshot duration from 3 to 15 seconds from the seek position, default is 5 seconds."
 msgstr "Bepaald de weergave duur van elke afbeelding in seconden (from 1 to 100 sec.), standaard is 1 seconde"
 
-#: ../../vdms_dialogs/filter_stab.py:331
 msgid "Set how shaky the video is and how quick the camera is. A value of 1 means little shakiness, a value of 10 means strong shakiness. Default value is 5."
 msgstr "Stel in hoe bibberig de video is en hoe snel de camera is. Een waarde van 1 betekent weinig bibbering, een waarde van 10 betekent veel bibbering. Standaard waarde is 5."
 
-#: ../../vdms_dialogs/filter_stab.py:335
 msgid "Set the accuracy of the detection process. A value of 1 means low accuracy, a value of 15 means high accuracy. Default value is 15."
 msgstr "Stel de nauwkeurigheid in van het detectie-proces. Een waarde van 1 betekent lage nauwkeurigheid, een waarde van 15 betekent hoge nauwkeurigheid. Standaard waarde is 15."
 
-#: ../../vdms_dialogs/filter_stab.py:339
 msgid "Set stepsize of the search process. The region around minimum is scanned with 1 pixel resolution. Default value is 6."
 msgstr "Stel de stapgrootte in van het zoek-proces. De regio rond het minimum is ge-scan-d met 1 pixel resolutie. Standaard waarde is 6."
 
-#: ../../vdms_dialogs/filter_stab.py:343
 msgid "Set minimum contrast. Below this value a local measurement field is discarded. The range is 0-1. Default value is 0.25."
 msgstr "Stel minimum contrast in. Onder deze waarde wordt een lokaal meting-veld verwijderd. Het bereik is 0-1. Standaard waarde is 0.25."
 
-#: ../../vdms_dialogs/filter_stab.py:346
 msgid "Set reference frame number for tripod mode. If enabled, the motion of the frames is compared to a reference frame in the filtered stream, identified by the specified number. The idea is to compensate all movements in a more-or-less static scene and keep the camera view absolutely still. The frames are counted starting from 1."
 msgstr "Stel frame-nummer referentie in voor tripod modus. Wanneer geselecteerd, wordt de beweging van de frames vergeleken met een referentie-frame in de gefilterde stream, naar aanleiding van het opgegeven nummer. De bedoeling is om alle bewegingen in een min of meer statische scene te compenseren en het camera-beeld absoluut stil te houden. De frames worden geteld vanaf 1."
 
-#: ../../vdms_dialogs/filter_stab.py:355
-msgid "Set the number of frames (value*2 + 1) used for lowpass filtering the camera movements. Default value is 15. For example a number of 10 means that 21 frames are used (10 in the past and 10 in the future) to smoothen the motion in the video. A larger value leads to a smoother video, but limits the acceleration of the camera (pan/tilt movements). 0 is a special case where a static camera is simulated."
-msgstr "Stel het aantal frames in (waarde*2 + 1) dat gebruikt wordt voor lowpass filtering van de camera-bewegingen. Standaard is 15. Bijvoorbeeld een aantal van 10 betekent dat 21 frames gebruikt worden (10 in het verleden en 10 in de toekomst) om de bewegingen in de video te versoepelen. Een hoge waarde geeft soepeler video-beelden, maar beperkt de pan/tilt bewegings-versnellingen van de camera. Waarde 0 is een speciaal geval waarbij een statische camera gesimuleerd wordt."
+msgid ""
+"Set the number of frames (value*2 + 1) used for lowpass filtering the camera movements. Default value is 15. For example a number of 10 means that 21 frames are used (10 in the past and 10 in the future) to smoothen the motion in the video. A larger value leads to a smoother video, but limits the acceleration of the camera (pan/tilt movements). 0 is a special case where a static camera is "
+"simulated."
+msgstr ""
+"Stel het aantal frames in (waarde*2 + 1) dat gebruikt wordt voor lowpass filtering van de camera-bewegingen. Standaard is 15. Bijvoorbeeld een aantal van 10 betekent dat 21 frames gebruikt worden (10 in het verleden en 10 in de toekomst) om de bewegingen in de video te versoepelen. Een hoge waarde geeft soepeler video-beelden, maar beperkt de pan/tilt bewegings-versnellingen van de camera. "
+"Waarde 0 is een speciaal geval waarbij een statische camera gesimuleerd wordt."
 
-#: ../../vdms_dialogs/filter_stab.py:363
 #, fuzzy
 msgid "Set the camera path optimization algorithm. Values are: `gauss`: gaussian kernel low-pass filter on camera motion (default), and `avg`: averaging on transformations"
 msgstr "Kies het algoritme voor camera path-optimisatie. Waarden zijn: ‘gauss’: gaussian kernel low-pass filter voor camerabeweging (standaard) en ‘avg’: gemiddelden voor transformaties"
 
-#: ../../vdms_dialogs/filter_stab.py:367
 msgid "Set maximal angle in radians (degree*PI/180) to rotate frames. Default value is -1, meaning no limit."
 msgstr "Kies maximale hoek, in radialen (graden*PI/180) om frames te roteren. Standaard is -1 : geen limiet."
 
-#: ../../vdms_dialogs/filter_stab.py:370
 #, fuzzy
 msgid "Specify how to deal with borders that may be visible due to movement compensation. Values are: `keep` keep image information from previous frame (default), `black` fill the border black"
 msgstr "Specificeer hoe om te gaan met randen die zichtbaar kunnen zijn door bewegings-compensatie. Waarden zijn: ‘keep’: behoud beeld-informatie van vorige frame (standaard) en ‘black’: vul de randen met zwart"
 
-#: ../../vdms_dialogs/filter_stab.py:375
 msgid "Invert transforms if checked. Default is unchecked."
 msgstr "Inverteer transformaties wanneer geselecteerd. Standaard is niet-geselecteerd."
 
-#: ../../vdms_dialogs/filter_stab.py:377
 msgid "Consider transforms as relative to previous frame if checked, absolute if unchecked. Default is checked."
 msgstr "Beschouw transformaties als relatief tot vorige frame wanneer geselecteerd, absoluut wanneer niet geselecteerd. Standaard is geselecteerd."
 
-#: ../../vdms_dialogs/filter_stab.py:380
 msgid "Set percentage to zoom. A positive value will result in a zoom-in effect, a negative value in a zoom-out effect. Default value is 0 (no zoom)."
 msgstr "Kies zoom-percentage. Een positieve waarde geeft een zoom-in effect, negatieve waarde is zoom-out. Standaard is 0 (geen zoom)."
 
-#: ../../vdms_dialogs/filter_stab.py:384
 #, fuzzy
 msgid "Set optimal zooming to avoid borders. Accepted values are: `0` disabled, `1` optimal static zoom value is determined (only very strong movements will lead to visible borders) (default), `2` optimal adaptive zoom value is determined (no borders will be visible), see zoomspeed. Note that the value given at zoom is added to the one calculated here."
-msgstr "Kies de optimale zoom-instelling om randen te voorkomen. Mogelijke waarden zijn: ‘0’ uitgeschakeld, ‘1’ optimale statische zoom-waarde wordt bepaald (alleen heftige bewegingen zullen zichtbare randen te zien geven), ‘2’ optimale aanpasbare zoom-waarde wordt bepaald (er zullen geen randen zichtbaar zijn), zie zoom-snelheid. Bedenk dat de ingestelde zoom-waarde opgeteld wordt bij de waarde die hier berekend wordt."
+msgstr ""
+"Kies de optimale zoom-instelling om randen te voorkomen. Mogelijke waarden zijn: ‘0’ uitgeschakeld, ‘1’ optimale statische zoom-waarde wordt bepaald (alleen heftige bewegingen zullen zichtbare randen te zien geven), ‘2’ optimale aanpasbare zoom-waarde wordt bepaald (er zullen geen randen zichtbaar zijn), zie zoom-snelheid. Bedenk dat de ingestelde zoom-waarde opgeteld wordt bij de waarde die "
+"hier berekend wordt."
 
-#: ../../vdms_dialogs/filter_stab.py:391
 msgid "Set percent to zoom maximally each frame (enabled when optzoom is set to 2). Range is from 0 to 5, default value is 0.25."
 msgstr "Kies maximaal zoom percentage van elk frame (actief als optzoom is 2). Bereik is van 0 t/m 5, standaard is 0.25."
 
-#: ../../vdms_dialogs/filter_stab.py:395
 #, fuzzy
 msgid "Specify type of interpolation. Available values are: `no` no interpolation, `linear` linear only horizontal, `bilinear` linear in both directions (default), `bicubic` cubic in both directions (slow)"
 msgstr "Specificeer interpolatie type. Beschikbare waarden zijn: ‘no’ geen interpolatie, ‘linear’ lineair alleen horizontaal, ‘bilinear’ lineair in beide richtingen (standaard), ‘bicubic’ cubic in beide richtingen (traag)"
 
-#: ../../vdms_dialogs/filter_stab.py:400
 msgid "Enable virtual tripod mode if checked, which is equivalent to relative=0:smoothing=0. Default is unchecked. Use also tripod option of vidstabdetect."
 msgstr "Activeer virtuele tripod modus als geselecteerd, wat gelijk is aan relative=0:smoothing=0. Standaard is niet-geselecteerd. Gebruik dit als tripod optie van vidstabdetect."
 
-#: ../../vdms_dialogs/filter_stab.py:405
 msgid "Sharpen or blur the input video. Note the use of the unsharp filter which is always recommended."
 msgstr "Verscherp of vervaag de input video. Het gebruik van het ont-scherp filter, wordt altijd aanbevolen."
 
-#: ../../vdms_dialogs/filter_stab.py:409
 #, fuzzy
 msgid "Video Stabilizer Tool"
 msgstr "Video stabilisatie filter"
 
-#: ../../vdms_dialogs/filter_stab.py:541 ../../vdms_io/io_tools.py:73
 msgid "Videomass - Loading..."
 msgstr "Videomass - Laden..."
 
-#: ../../vdms_dialogs/filter_stab.py:542
 msgid ""
 "Please wait,\n"
 "This process will take a few seconds."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:80
-#: ../../vdms_dialogs/filter_transpose.py:293
 msgid "Default position"
 msgstr "Standaard positie"
 
-#: ../../vdms_dialogs/filter_transpose.py:86
 msgid "Rotation setting"
 msgstr "Rotatie instelling"
 
-#: ../../vdms_dialogs/filter_transpose.py:94
 msgid "90° (left)"
 msgstr "90° (naar links)"
 
-#: ../../vdms_dialogs/filter_transpose.py:96
 msgid "90° (right)"
 msgstr "90° (naar rechts)"
 
-#: ../../vdms_dialogs/filter_transpose.py:100
 msgid "180°"
 msgstr "180°"
 
-#: ../../vdms_dialogs/filter_transpose.py:115
 #, fuzzy
 msgid "Transpose Tool"
 msgstr "Transponeer Filter"
 
-#: ../../vdms_dialogs/filter_transpose.py:229
 msgid "Rotate 90 degrees right"
 msgstr "Roteer 90 graden naar rechts"
 
-#: ../../vdms_dialogs/filter_transpose.py:251
 msgid "Rotate 180 degrees"
 msgstr "Roteer 180 graden"
 
-#: ../../vdms_dialogs/filter_transpose.py:272
 msgid "Rotate 90 degrees left"
 msgstr "Roteer 90 graden naar links"
 
-#: ../../vdms_dialogs/mediainfo.py:82
 #, fuzzy
 msgid "Format"
 msgstr "formaat"
 
-#: ../../vdms_dialogs/mediainfo.py:96
 msgid "Video Stream"
 msgstr "Video Stream"
 
-#: ../../vdms_dialogs/mediainfo.py:109
 msgid "Audio Streams"
 msgstr "Audio Streams"
 
-#: ../../vdms_dialogs/mediainfo.py:122
 msgid "Subtitle Streams"
 msgstr "Ondertitel Streams"
 
-#: ../../vdms_dialogs/mediainfo.py:126
 #, fuzzy
 msgid "Copy to clipboard"
 msgstr "Snij breedte bij"
 
-#: ../../vdms_dialogs/mediainfo.py:137
 msgid "FILE SELECTION"
 msgstr "BESTAND SELECTIE"
 
-#: ../../vdms_dialogs/mediainfo.py:139 ../../vdms_dialogs/mediainfo.py:142
-#: ../../vdms_dialogs/mediainfo.py:145 ../../vdms_dialogs/mediainfo.py:148
-#: ../../vdms_main/main_frame.py:1318
 #, fuzzy
 msgid "Properties"
 msgstr "Audio Eigenschappen"
 
-#: ../../vdms_dialogs/mediainfo.py:140 ../../vdms_dialogs/mediainfo.py:143
-#: ../../vdms_dialogs/mediainfo.py:146 ../../vdms_dialogs/mediainfo.py:149
 msgid "Values"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:152
 #, fuzzy
 msgid "Streams Properties"
 msgstr "Audio Eigenschappen"
 
-#: ../../vdms_dialogs/mediainfo.py:244
 msgid "Unable to open the clipboard on Format tab"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:263
 msgid "Unable to open the clipboard on Video Streams tab"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:283
 msgid "Unable to open the clipboard on Audio Streams tab"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:303
 msgid "Unable to open the clipboard on Subtitle Streams tab"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:90
 msgid "Where do you prefer to save your transcodes?"
 msgstr "Waar wilt u transcoderingen bewaren?"
 
-#: ../../vdms_dialogs/preferences.py:101 ../../vdms_dialogs/preferences.py:128
-#: ../../vdms_dialogs/preferences.py:149 ../../vdms_dialogs/preferences.py:161
-#: ../../vdms_dialogs/preferences.py:173 ../../vdms_panels/filedrop.py:284
 msgid "Change"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:103
-#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:602
-#: ../../vdms_panels/presets_manager.py:1050
 #, fuzzy
 msgid "Same destination paths as source files"
 msgstr "Maak een nieuwe preset"
 
-#: ../../vdms_dialogs/preferences.py:108
 #, fuzzy
 msgid "Assign optional suffix to destination file names:"
 msgstr "Ken optioneel achtervoegsel toe aan output-bestandsnamen:"
 
-#: ../../vdms_dialogs/preferences.py:114
 #, fuzzy
 msgid "File removal preferences"
 msgstr "Bestands Voorkeuren"
 
-#: ../../vdms_dialogs/preferences.py:118
 #, fuzzy
 msgid "Trash the source files after successful encoding"
 msgstr "Verplaats de orginele file naar de Videomass Prullenbak na een succesvolle encoding"
 
-#: ../../vdms_dialogs/preferences.py:131
 msgid "File Preferences"
 msgstr "Bestands Voorkeuren"
 
-#: ../../vdms_dialogs/preferences.py:138
 #, fuzzy
 msgid "Location of executables"
 msgstr "Bezig FFmpeg programmabestanden te lokaliseren\n"
 
-#: ../../vdms_dialogs/preferences.py:140
 msgid ""
 "FFmpeg can be built by enabling/disabling its options and this depends on your needs.\n"
 "For some use cases it is possible to provide a custom build of FFmpeg where you can specify\n"
 "it in this preferences tab."
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:147
 #, fuzzy
 msgid "Enable a custom location to run FFmpeg"
 msgstr "Activeer een andere lokatie om FFmpeg uit te voeren"
 
-#: ../../vdms_dialogs/preferences.py:159
 #, fuzzy
 msgid "Enable a custom location to run FFprobe"
 msgstr "Activeer een andere lokatie om FFprobe uit te voeren"
 
-#: ../../vdms_dialogs/preferences.py:171
 #, fuzzy
 msgid "Enable a custom location to run FFplay"
 msgstr "Activeer een andere lokatie om FFplay uit te voeren"
 
-#: ../../vdms_dialogs/preferences.py:183
 msgid "FFmpeg"
 msgstr "FFmpeg"
 
-#: ../../vdms_dialogs/preferences.py:189
 msgid "Look and Feel (requires application restart)"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:194
 msgid "Icon themes"
 msgstr "Icoon thema's"
 
-#: ../../vdms_dialogs/preferences.py:208
 msgid "At the top of window (default)"
 msgstr "Bovenaan venster (standaard)"
 
-#: ../../vdms_dialogs/preferences.py:209
 msgid "At the bottom of window"
 msgstr "Onderaan venster"
 
-#: ../../vdms_dialogs/preferences.py:210
 msgid "At the right of window"
 msgstr "Rechts van venster"
 
-#: ../../vdms_dialogs/preferences.py:211
 msgid "At the left of window"
 msgstr "Links van venster"
 
-#: ../../vdms_dialogs/preferences.py:213
 msgid "Place the toolbar"
 msgstr "Plaats de knoppenbalk"
 
-#: ../../vdms_dialogs/preferences.py:222
 msgid "Toolbar's icons size:"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:236
 msgid "Application Language (requires application restart)"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:248
 msgid "Look and Language"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:254
 #, fuzzy
 msgid "Upon exiting the application"
 msgstr "Maak cache leeg als programma beëindigd wordt"
 
-#: ../../vdms_dialogs/preferences.py:259
 #, fuzzy
 msgid "Always ask me to confirm"
 msgstr "Bevestig dit"
 
-#: ../../vdms_dialogs/preferences.py:261
 #, fuzzy
 msgid "Clean the log files"
 msgstr "Log bestanden lijst"
 
-#: ../../vdms_dialogs/preferences.py:264
 #, fuzzy
 msgid "Remove cached files"
 msgstr "Voeg bestanden toe"
 
-#: ../../vdms_dialogs/preferences.py:268
 #, fuzzy
 msgid "On operations completion"
 msgstr "nlmeans opties"
 
-#: ../../vdms_dialogs/preferences.py:271
 msgid "These settings will remain active until the application is closed, If necessary, remember to reactivate them."
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:276
 #, fuzzy
 msgid "Exit the application"
 msgstr "Maak cache leeg als programma beëindigd wordt"
 
-#: ../../vdms_dialogs/preferences.py:279
 msgid "Shutdown the system"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:283
 msgid "SUDO password:"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:292
 msgid "Exit and Shutdown"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:298
 msgid "Specify the character encoding format"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:301
 msgid ""
 "Although UTF-8 is the default and most widely used standard encoding format, it is not the only encoding format available.\n"
 "Some file metadata may still contain non-UTF-8 character encodings resulting in the error \"'utf-8' codec can't decode bytes...\".\n"
 "If you know the encoding format the file was written in, you can try specifying it here, e.g. ISO 8859-1, ISO 8859-16, etc."
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:311
 msgid "Character encoding:"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:320
 msgid "Default application directories"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:324
 #, fuzzy
 msgid "Configuration directory"
 msgstr "Configuratie folder"
 
-#: ../../vdms_dialogs/preferences.py:337
 #, fuzzy
 msgid "Cache directory"
 msgstr "Cache folder"
 
-#: ../../vdms_dialogs/preferences.py:349
 #, fuzzy
 msgid "Log directory"
 msgstr "Log folder"
 
-#: ../../vdms_dialogs/preferences.py:363
 #, fuzzy
 msgid "Advanced"
 msgstr "Geavanceerde Opties"
 
-#: ../../vdms_dialogs/preferences.py:369
 #, fuzzy
 msgid ""
 "The following settings affect output messages and the log messages during transcoding processes.\n"
@@ -1197,165 +878,108 @@ msgstr ""
 "en log-berichten tijdens transcode-processen.\n"
 "Wijzig alleen als u weet wat u doet.\n"
 
-#: ../../vdms_dialogs/preferences.py:376
 msgid "Set logging level flags used by FFmpeg"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:383
 msgid "Set logging level flags used by FFplay"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:391
 msgid "FFmpeg logging levels"
 msgstr "FFmpeg log niveau's"
 
-#: ../../vdms_dialogs/preferences.py:437
 msgid "By assigning an additional suffix you could avoid overwriting files"
 msgstr "Door toewijzing van een achtervoegsel kunt u overschrijven van bestanden voorkomen"
 
-#: ../../vdms_dialogs/preferences.py:440
 msgid "Type sudo password here, only for Unix-like operating systems, not for MS Windows"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:443
 #, fuzzy
 msgid "Preferences"
 msgstr "Referenties"
 
-#: ../../vdms_dialogs/preferences.py:596 ../../vdms_dialogs/preferences.py:676
-#: ../../vdms_main/main_frame.py:879 ../../vdms_main/main_frame.py:1060
 #, fuzzy
 msgid "Choose Destination"
 msgstr "Bestemming folder"
 
-#: ../../vdms_dialogs/preferences.py:627
 msgid "Enter only alphanumeric characters. You can also use the hyphen (\"-\") and the underscore (\"_\"). Spaces are not allowed."
 msgstr "Gebruik alleen alpha-numerieke tekens 0-9 A-Z. Het streepje (\"-\") en de underscore (\"_\") kunt u ook gebruiken. Spaties zijn niet toegestaan."
 
-#: ../../vdms_dialogs/preferences.py:642
-#: ../../vdms_dialogs/setting_profiles.py:257
-#: ../../vdms_dialogs/setting_profiles.py:264
-#: ../../vdms_dialogs/setting_profiles.py:286
-#: ../../vdms_dialogs/setting_profiles.py:309 ../../vdms_main/main_frame.py:399
-#: ../../vdms_main/main_frame.py:421 ../../vdms_panels/av_conversions.py:605
-#: ../../vdms_panels/av_conversions.py:612
-#: ../../vdms_panels/sequence_to_video.py:352
-#: ../../vdms_panels/video_to_sequence.py:399
 #, fuzzy
 msgid "Videomass - Warning!"
 msgstr "Videomass - Laden..."
 
-#: ../../vdms_dialogs/preferences.py:731 ../../vdms_dialogs/preferences.py:771
-#: ../../vdms_dialogs/preferences.py:811 ../../vdms_dialogs/wizard_dlg.py:365
-#: ../../vdms_dialogs/wizard_dlg.py:384 ../../vdms_dialogs/wizard_dlg.py:403
 #, fuzzy, python-brace-format
 msgid "{} location"
 msgstr "Kies het {} programmabestand"
 
-#: ../../vdms_dialogs/queue_edit.py:36
-#: ../../vdms_dialogs/setting_profiles.py:38
 msgid "One-Pass, Do not start with `ffmpeg -i filename`; do not end with `output-filename`"
 msgstr "One-Pass, begin niet met `ffmpeg -i filename`; eindig niet met `output-filename`"
 
-#: ../../vdms_dialogs/queue_edit.py:40
-#: ../../vdms_dialogs/setting_profiles.py:42
 msgid "Two-Pass (optional), Do not start with `ffmpeg -i filename`; do not end with `output-filename`"
 msgstr "Two-Pass (optioneel), begin niet met `ffmpeg -i filename`; eindig niet met `output-filename`"
 
-#: ../../vdms_dialogs/queue_edit.py:59
 #, fuzzy
 msgid "Videomass - Edit the selected item in the queue"
 msgstr "Speel de geselecteerde bestanden in de lijst af"
 
-#: ../../vdms_dialogs/queue_edit.py:71
-#: ../../vdms_dialogs/setting_profiles.py:92
 msgid "Pre-input arguments for One-Pass (optional)"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:82
-#: ../../vdms_dialogs/setting_profiles.py:151
-#: ../../vdms_panels/presets_manager.py:255
 msgid "FFmpeg arguments for one-pass encoding"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:88
-#: ../../vdms_dialogs/setting_profiles.py:158
-#: ../../vdms_panels/presets_manager.py:259
 msgid "Any optional arguments to add before input file on the one-pass encoding, e.g required names of some hardware accelerations like -hwaccel to use with CUDA."
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:102
-#: ../../vdms_dialogs/setting_profiles.py:98
 msgid "Pre-input arguments for Two-Pass (optional)"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:113
-#: ../../vdms_dialogs/setting_profiles.py:152
-#: ../../vdms_panels/presets_manager.py:257
 msgid "FFmpeg arguments for two-pass encoding"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:120
-#: ../../vdms_dialogs/setting_profiles.py:162
-#: ../../vdms_panels/presets_manager.py:263
 msgid "Any optional arguments to add before input file on the two-pass encoding, e.g required names of some hardware accelerations like -hwaccel to use with CUDA."
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:65 ../../vdms_main/main_frame.py:508
-#: ../../vdms_panels/presets_manager.py:189
-#: ../../vdms_panels/video_to_sequence.py:171
 msgid "Edit"
 msgstr "Edit"
 
-#: ../../vdms_dialogs/queuedlg.py:68
 msgid "Remove"
 msgstr "Verwijder"
 
-#: ../../vdms_dialogs/queuedlg.py:71
 #, fuzzy
 msgid "Remove all"
 msgstr "Verwijder"
 
-#: ../../vdms_dialogs/queuedlg.py:74
 msgid ""
 "Export\n"
 "queue file"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:77
 #, fuzzy
 msgid ""
 "Import\n"
 "queue file"
 msgstr "Log folder"
 
-#: ../../vdms_dialogs/queuedlg.py:85 ../../vdms_panels/filedrop.py:273
 #, fuzzy
 msgid "Destination file name"
 msgstr "Output index:"
 
-#: ../../vdms_dialogs/queuedlg.py:137
 #, fuzzy
 msgid "Remove all items in the queue"
 msgstr "Een doel-bestand moet geselecteerd zijn in de wachtrij-bestanden"
 
-#: ../../vdms_dialogs/queuedlg.py:151
 #, fuzzy
 msgid "Videomass - Queue"
 msgstr "Videomass - Wachtrij URLs"
 
-#: ../../vdms_dialogs/queuedlg.py:228
 #, fuzzy
 msgid "Export queue file"
 msgstr "Exporteer geselecteerden"
 
-#: ../../vdms_dialogs/queuedlg.py:296 ../../vdms_panels/av_conversions.py:1192
-#: ../../vdms_panels/presets_manager.py:1044
-#: ../../vdms_panels/video_to_sequence.py:600
 msgid "Same as source"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:301
 #, fuzzy
 msgid ""
 "Source\n"
@@ -1378,187 +1002,130 @@ msgstr ""
 "Tijdsperiode\n"
 "Input Audio Map"
 
-#: ../../vdms_dialogs/renamer.py:76
 msgid "# will be replaced by ascending numbers starting with:"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:87
 msgid "Font Size"
 msgstr "Lettertype grootte"
 
-#: ../../vdms_dialogs/set_timestamp.py:111
 msgid "Font Color"
 msgstr "Lettertype kleur"
 
-#: ../../vdms_dialogs/set_timestamp.py:121
 msgid "Shadow Color"
 msgstr "Schaduw kleur"
 
-#: ../../vdms_dialogs/set_timestamp.py:132
 msgid "Show text box"
 msgstr "Toon tekstkader"
 
-#: ../../vdms_dialogs/set_timestamp.py:136
 msgid "Box Color"
 msgstr "Kader kleur"
 
-#: ../../vdms_dialogs/set_timestamp.py:156
 msgid "The timestamp size does not auto-adjust to the video size, you have to set the size here"
 msgstr "De tijdcode-grootte past zich niet automatisch aan bij de video-grootte, u moet het hier instellen"
 
-#: ../../vdms_dialogs/set_timestamp.py:160 ../../vdms_main/main_frame.py:559
 msgid "Timestamp settings"
 msgstr "Tijdcode instellingen"
 
-#: ../../vdms_dialogs/setting_profiles.py:46
 msgid "Supported Formats list (optional). Do not include the `.`"
 msgstr "Lijst van ondersteunde formaten (optioneel). Laat de `.` achterwege"
 
-#: ../../vdms_dialogs/setting_profiles.py:47
 msgid "Output Format. Empty to copy format and codec. Do not include the `.`"
 msgstr "Output formaat. Bij weglaten worden formaat en codec gekopieerd. Laat de `.` achterwege"
 
-#: ../../vdms_dialogs/setting_profiles.py:70
 msgid "Profile Name"
 msgstr "Profiel Naam"
 
-#: ../../vdms_dialogs/setting_profiles.py:74
-#: ../../vdms_panels/presets_manager.py:404
 msgid "Description"
 msgstr "Beschrijving"
 
-#: ../../vdms_dialogs/setting_profiles.py:149
 msgid "A short profile name"
 msgstr "Een korte profiel naam"
 
-#: ../../vdms_dialogs/setting_profiles.py:150
 msgid "A long description of the profile"
 msgstr "Een uitgebreide beschrijving van het profiel"
 
-#: ../../vdms_dialogs/setting_profiles.py:153
 msgid "One or more comma-separated format names compatible with this profile"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:155
 msgid "Output format extension. Leave empty to copy codec and format"
 msgstr "Bestandsextensie van output formaat. Laat leeg om codec en bestandsformaat te kopiëren"
 
-#: ../../vdms_dialogs/setting_profiles.py:256
 msgid "Incomplete profile assignments"
 msgstr "Onvolledige profiel-toewijzingen"
 
-#: ../../vdms_dialogs/setting_profiles.py:263
 msgid "Formats must be comma-separated"
 msgstr "Formaten moeten gescheiden zijn door komma's"
 
-#: ../../vdms_dialogs/setting_profiles.py:279
-#: ../../vdms_utils/queue_utils.py:80
 #, python-brace-format
 msgid ""
 "ERROR: Keys mismatched for requested data.\n"
 "Invalid file: «{0}»"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:285
-#: ../../vdms_dialogs/setting_profiles.py:308
 msgid "Profile already stored with same name"
 msgstr "Profiel reeds opgeslagen onder dezelfde naam"
 
-#: ../../vdms_dialogs/setting_profiles.py:293
 #, fuzzy
 msgid "Profile stored successfully!"
 msgstr "Wizard met succes afgerond!\n"
 
-#: ../../vdms_dialogs/setting_profiles.py:311
 msgid "Profile change successful!"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:80
 msgid "Log file list"
 msgstr "Log bestanden lijst"
 
-#: ../../vdms_dialogs/showlogs.py:82 ../../vdms_dialogs/showlogs.py:116
 msgid "Log messages"
 msgstr "Log-berichten"
 
-#: ../../vdms_dialogs/showlogs.py:105
 msgid "Refresh log messages"
 msgstr "Ververs log-berichten"
 
-#: ../../vdms_dialogs/showlogs.py:107
 msgid "Clear log messages"
 msgstr "Wis log-berichten"
 
-#: ../../vdms_dialogs/showlogs.py:160
 msgid "Select a log file"
 msgstr "Selecteer een log bestand"
 
-#: ../../vdms_dialogs/showlogs.py:167
 msgid "Are you sure you want to clear the selected log file?"
 msgstr "Wilt u echt dit log-bestand legen ?"
 
-#: ../../vdms_dialogs/showlogs.py:168 ../../vdms_dialogs/wizard_dlg.py:251
-#: ../../vdms_io/checkup.py:68 ../../vdms_main/main_frame.py:205
-#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1685
-#: ../../vdms_panels/presets_manager.py:349
-#: ../../vdms_panels/presets_manager.py:550
-#: ../../vdms_panels/presets_manager.py:590
-#: ../../vdms_panels/presets_manager.py:649
-#: ../../vdms_panels/presets_manager.py:684
-#: ../../vdms_panels/presets_manager.py:749
-#: ../../vdms_panels/presets_manager.py:775
-#: ../../vdms_panels/presets_manager.py:874
-#: ../../vdms_panels/presets_manager.py:904
 msgid "Please confirm"
 msgstr "Bevestig dit"
 
-#: ../../vdms_dialogs/shownormlist.py:83
 msgid "File name"
 msgstr "Bestandsnaam"
 
-#: ../../vdms_dialogs/shownormlist.py:84
 msgid "Max volume dBFS"
 msgstr "Max volume dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:85
 msgid "Mean volume dBFS"
 msgstr "Mean volume dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:86
 msgid "Offset dBFS"
 msgstr "Offset dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:87
 msgid "Result dBFS"
 msgstr "Resultaat dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:92
 msgid "Post-normalization references:"
 msgstr "Post-normalizatie referenties:"
 
-#: ../../vdms_dialogs/shownormlist.py:102
 msgid "=  Clipped peaks"
 msgstr "=  Clipped peaks"
 
-#: ../../vdms_dialogs/shownormlist.py:111
 msgid "=  No changes"
 msgstr "=  Geen wijzigingen"
 
-#: ../../vdms_dialogs/shownormlist.py:121
 msgid "=  Below max peak"
 msgstr "=  Onder max peak"
 
-#: ../../vdms_dialogs/shownormlist.py:166
-#: ../../vdms_panels/audio_encoders/acodecs.py:841
 msgid "RMS-based volume statistics"
 msgstr "RMS-gebaseerde volume statistieken"
 
-#: ../../vdms_dialogs/shownormlist.py:191
-#: ../../vdms_panels/audio_encoders/acodecs.py:839
 msgid "PEAK-based volume statistics"
 msgstr "PEAK-gebaseerde volume statistieken"
 
-#: ../../vdms_dialogs/shownormlist.py:216
 #, fuzzy
 msgid ""
 "...It means the resulting audio will be clipped,\n"
@@ -1572,7 +1139,6 @@ msgstr ""
 "omdat het geluidsniveau hoger is dan het maximale 0 db.\n"
 "Dit geeft dataverlies en de audio kan vervormd klinken."
 
-#: ../../vdms_dialogs/shownormlist.py:242
 #, fuzzy
 msgid ""
 "...It means the resulting audio will not change,\n"
@@ -1583,7 +1149,6 @@ msgstr ""
 "...Dit betekent dat de audio niet verandert,\n"
 "omdat ze gelijk is aan het bronsignaal."
 
-#: ../../vdms_dialogs/shownormlist.py:266
 #, fuzzy
 msgid ""
 "...It means an audio signal will be produced with\n"
@@ -1594,15 +1159,12 @@ msgstr ""
 "...Dit geeft een audio signaal met\n"
 "een lager volume dan het origineel."
 
-#: ../../vdms_dialogs/videomass_check_version.py:63
 msgid "Get Latest Version"
 msgstr "Download laatste versie"
 
-#: ../../vdms_dialogs/videomass_check_version.py:67
 msgid "Checking for newer version"
 msgstr "Controleren voor een nieuwere versie"
 
-#: ../../vdms_dialogs/videomass_check_version.py:95
 msgid ""
 "\n"
 "\n"
@@ -1612,7 +1174,6 @@ msgstr ""
 "\n"
 "Nieuwe versies repareren bugs en brengen nieuwe features."
 
-#: ../../vdms_dialogs/videomass_check_version.py:96
 #, python-brace-format
 msgid ""
 "\n"
@@ -1625,7 +1186,6 @@ msgstr ""
 "Dit is Videomass v.{0}\n"
 "\n"
 
-#: ../../vdms_dialogs/while_playing.py:37
 msgid ""
 "q, ESC\n"
 "f\n"
@@ -1667,65 +1227,51 @@ msgstr ""
 "rechter muis klik\n"
 "linker muis dubbel-klik"
 
-#: ../../vdms_dialogs/while_playing.py:92
 msgid "Shortcut keys while playing with FFplay"
 msgstr "Sneltoetsen bij afspelen met FFplay"
 
-#: ../../vdms_dialogs/widget_utils.py:120 ../../vdms_main/main_frame.py:1326
 msgid "Stop"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:63
 msgid "Please take a moment to set up the application"
 msgstr "Neem even de tijd om het programma in te stellen"
 
-#: ../../vdms_dialogs/wizard_dlg.py:64
 msgid "Click the \"Next\" button to get started"
 msgstr "Druk de knop \"Volgende\" om te beginnen"
 
-#: ../../vdms_dialogs/wizard_dlg.py:79
 msgid "Welcome to the Videomass Wizard!"
 msgstr "Welkom bij de Videomass Wizard!"
 
-#: ../../vdms_dialogs/wizard_dlg.py:123
 msgid "Videomass is an application based on FFmpeg\n"
 msgstr "Videomass is gebaseerd op FFmpeg\n"
 
-#: ../../vdms_dialogs/wizard_dlg.py:125
 msgid "If FFmpeg is not on your computer, this application will be unusable"
 msgstr "Zonder FFmpeg op uw computer zal dit programma onbruikbaar zijn"
 
-#: ../../vdms_dialogs/wizard_dlg.py:128
 msgid ""
 "If you have already installed FFmpeg on your operating system,\n"
 "click the \"Auto-detection\" button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:131
 msgid ""
 "If you want to use a version of FFmpeg located on your filesystem\n"
 "but not installed on your operating system,\n"
 "click the \"Locate\" button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:162
 msgid "Auto-detection"
 msgstr "Automatische detectie"
 
-#: ../../vdms_dialogs/wizard_dlg.py:164
 msgid "Locate"
 msgstr "Lokaliseer"
 
-#: ../../vdms_dialogs/wizard_dlg.py:214
 msgid "Click the \"Next\" button"
 msgstr "Druk de knop \"Volgende\""
 
-#: ../../vdms_dialogs/wizard_dlg.py:235
 #, python-brace-format
 msgid "'{}' is not installed on your computer. Install it or indicate another location by clicking the 'Locate' button."
 msgstr "'{}' is niet op uw computer geïnstalleerd. Installeer het of geef een andere lokatie aan, door op de 'Lokaliseer' knop te drukken."
 
-#: ../../vdms_dialogs/wizard_dlg.py:249
 msgid ""
 "Videomass already seems to include FFmpeg.\n"
 "\n"
@@ -1735,11 +1281,9 @@ msgstr ""
 "\n"
 "Wilt u deze gebruiken?"
 
-#: ../../vdms_dialogs/wizard_dlg.py:275
 msgid "Locating FFmpeg executables\n"
 msgstr "Bezig FFmpeg programmabestanden te lokaliseren\n"
 
-#: ../../vdms_dialogs/wizard_dlg.py:277
 msgid ""
 "\"ffmpeg\", \"ffprobe\" and \"ffplay\" are required. Complete all\n"
 "the text boxes below by clicking on the respective buttons."
@@ -1747,41 +1291,31 @@ msgstr ""
 "\"ffmpeg\", \"ffprobe\" en \"ffplay\" zijn vereist. Vul alle onderstaande\n"
 "tekstkaders in, door op de betreffende knoppen te drukken."
 
-#: ../../vdms_dialogs/wizard_dlg.py:437
 msgid "Wizard completed successfully!\n"
 msgstr "Wizard met succes afgerond!\n"
 
-#: ../../vdms_dialogs/wizard_dlg.py:438
 #, fuzzy
 msgid "Remember that you can always change these settings later, through the Preferences dialog."
 msgstr "Bedenk dat u deze instellingen later altijd kunt wijzigen door het Installatie dialoogscherm."
 
-#: ../../vdms_dialogs/wizard_dlg.py:440
 msgid "Thank You!"
 msgstr "Dank U!"
 
-#: ../../vdms_dialogs/wizard_dlg.py:441
 msgid "To exit click the \"Finish\" button"
 msgstr "Klik op de knop \"Voltooi\" om af te sluiten"
 
-#: ../../vdms_dialogs/wizard_dlg.py:527
 msgid "< Previous"
 msgstr "< Vorige"
 
-#: ../../vdms_dialogs/wizard_dlg.py:530 ../../vdms_dialogs/wizard_dlg.py:613
 msgid "Next >"
 msgstr "Volgende >"
 
-#: ../../vdms_dialogs/wizard_dlg.py:535
 msgid "Videomass Wizard"
 msgstr "Videomass Wizard"
 
-#: ../../vdms_dialogs/wizard_dlg.py:563 ../../vdms_dialogs/wizard_dlg.py:586
-#: ../../vdms_dialogs/wizard_dlg.py:591
 msgid "Finish"
 msgstr "Voltooi"
 
-#: ../../vdms_io/checkup.py:44 ../../vdms_io/checkup.py:92
 #, python-brace-format
 msgid ""
 "Output folder does not exist:\n"
@@ -1792,34 +1326,27 @@ msgstr ""
 "\n"
 "\"{}\"\n"
 
-#: ../../vdms_io/checkup.py:65
 #, fuzzy
 msgid "Files already exist, do you want to overwrite them?"
 msgstr "Een bestand met deze naam bestaat al, wilt u het overschrijven?"
 
-#: ../../vdms_io/checkup.py:67
 msgid "Already exist"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:81
 msgid "Not found"
 msgstr "Niet gevonden"
 
-#: ../../vdms_io/checkup.py:82 ../../vdms_panels/filedrop.py:196
 msgid "Error list"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:83
 #, fuzzy
 msgid "File(s) not found"
 msgstr "Niet gevonden"
 
-#: ../../vdms_io/io_tools.py:56
 #, python-format
 msgid "File does not exist or is invalid:  %s"
 msgstr "Bestand bestaat niet of is ongeldig:  %s"
 
-#: ../../vdms_io/io_tools.py:74
 msgid ""
 "Wait....\n"
 "Audio peak analysis."
@@ -1827,425 +1354,329 @@ msgstr ""
 "Wacht....\n"
 "Audio peak analyse."
 
-#: ../../vdms_io/io_tools.py:179
 msgid "Videomass - Downloading..."
 msgstr "Videomass - Bezig met downloaden..."
 
-#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1409
-#: ../../vdms_main/main_frame.py:1441
 msgid "Ready"
 msgstr "Gereed"
 
-#: ../../vdms_main/main_frame.py:203
 msgid ""
 "Not all items in the queue were completed.\n"
 "\n"
 "Would you like to keep them in the queue?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:224
 #, python-brace-format
 msgid "Queue ({0})"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:229 ../../vdms_main/main_frame.py:1334
 msgid "Queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:396 ../../vdms_main/main_frame.py:418
 msgid "There are still active windows with running processes, make sure you finish your work before exit."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:403
 #, fuzzy
 msgid "Are you sure you want to exit the application?"
 msgstr "Afsluiten : bent u zeker?"
 
-#: ../../vdms_main/main_frame.py:405
 msgid "Exit"
 msgstr "Afsluiten"
 
-#: ../../vdms_main/main_frame.py:463
 #, fuzzy
 msgid "Import files\tCtrl+O"
 msgstr "Open...\tCtrl+O"
 
-#: ../../vdms_main/main_frame.py:466
 #, fuzzy
 msgid "Open destination folder of encodings\tCtrl+D"
 msgstr "Maak een nieuwe preset"
 
-#: ../../vdms_main/main_frame.py:469
 msgid "Load queue file"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:470
 msgid "Load a previously exported queue file"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:473
 #, fuzzy
 msgid "Open trash"
 msgstr "Videomass Prullenbak"
 
-#: ../../vdms_main/main_frame.py:474
 #, fuzzy
 msgid "Open the Videomass trash folder"
 msgstr "Opent de Videomass Prullenbak folder, als deze bestaat"
 
-#: ../../vdms_main/main_frame.py:476
 #, fuzzy
 msgid "Empty trash"
 msgstr "Prullenbak legen"
 
-#: ../../vdms_main/main_frame.py:477
 #, fuzzy
 msgid "Delete all files in the Videomass trash folder"
 msgstr "Verwijder alle bestanden uit de Videomass Prullenbak"
 
-#: ../../vdms_main/main_frame.py:480
 msgid "Exit\tCtrl+Q"
 msgstr "Afsluiten\tCtrl+Q"
 
-#: ../../vdms_main/main_frame.py:481
 #, fuzzy
 msgid "Completely exit the application"
 msgstr "Maak cache leeg als programma beëindigd wordt"
 
-#: ../../vdms_main/main_frame.py:482
 msgid "File"
 msgstr "Bestand"
 
-#: ../../vdms_main/main_frame.py:486 ../../vdms_panels/filedrop.py:340
-#: ../../vdms_panels/filedrop.py:381
 #, fuzzy
 msgid "Rename selected file\tCtrl+R"
 msgstr "Verwijder het geselecteerde profiel"
 
-#: ../../vdms_main/main_frame.py:487
 #, fuzzy
 msgid "Rename the destination of the selected file"
 msgstr "Een doel-bestand moet geselecteerd zijn in de wachtrij-bestanden"
 
-#: ../../vdms_main/main_frame.py:490 ../../vdms_panels/filedrop.py:341
-#: ../../vdms_panels/filedrop.py:384
 #, fuzzy
 msgid "Batch rename files\tCtrl+B"
 msgstr "Toon Log-berichten\tCtrl+L"
 
-#: ../../vdms_main/main_frame.py:491
 msgid "Numerically renames the destination of all items in the list"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:496 ../../vdms_panels/filedrop.py:343
-#: ../../vdms_panels/filedrop.py:388
 #, fuzzy
 msgid "Remove selected entry\tDEL"
 msgstr "Verwijder het geselecteerde profiel"
 
-#: ../../vdms_main/main_frame.py:497
 #, fuzzy
 msgid "Remove the selected file from the list"
 msgstr "Verwijder het geselecteerde bestand uit de lijst"
 
-#: ../../vdms_main/main_frame.py:500 ../../vdms_panels/filedrop.py:344
-#: ../../vdms_panels/filedrop.py:391
 msgid "Clear list\tShift+DEL"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:501
 #, fuzzy
 msgid "Clear the file list"
 msgstr "Log bestanden lijst"
 
-#: ../../vdms_main/main_frame.py:506
 msgid "Preferences\tCtrl+P"
 msgstr "Voorkeuren\tCtrl+P"
 
-#: ../../vdms_main/main_frame.py:507
 msgid "Application preferences"
 msgstr "Applicatie voorkeuren"
 
-#: ../../vdms_main/main_frame.py:512
 #, fuzzy
 msgid "Find FFmpeg topics"
 msgstr "FFmpeg help-onderwerpen"
 
-#: ../../vdms_main/main_frame.py:513
 msgid "A useful tool to search for FFmpeg help topics and options"
 msgstr "Een nuttig gereedschap om FFmpeg help-onderwerpen en opties te zoeken"
 
-#: ../../vdms_main/main_frame.py:518
 #, fuzzy
 msgid "Check for preset updates"
 msgstr "Controleer op nieuwe presets"
 
-#: ../../vdms_main/main_frame.py:519
 #, fuzzy, python-brace-format
 msgid "Check for new presets updates from {0}"
 msgstr "Controleer op nieuwe presets"
 
-#: ../../vdms_main/main_frame.py:521
 #, fuzzy
 msgid "Get latest presets"
 msgstr "Maak een nieuwe preset"
 
-#: ../../vdms_main/main_frame.py:522
 #, fuzzy, python-brace-format
 msgid "Get the latest presets from {0}"
 msgstr "Controleer op nieuwe presets"
 
-#: ../../vdms_main/main_frame.py:525
 #, fuzzy
 msgid "Work notes\tCtrl+N"
 msgstr "Notities\tCtrl+N"
 
-#: ../../vdms_main/main_frame.py:526
 msgid "Read and write useful notes and reminders."
 msgstr "Lees en maak notities en reminders."
 
-#: ../../vdms_main/main_frame.py:528
 msgid "Tools"
 msgstr "Gereedschappen"
 
-#: ../../vdms_main/main_frame.py:535
 msgid "Show FFmpeg's built-in configuration capabilities"
 msgstr "Toon ingebouwde FFmpeg configuratie mogelijkheden"
 
-#: ../../vdms_main/main_frame.py:539
 #, fuzzy
 msgid "Muxers and demuxers available on your version of FFmpeg"
 msgstr "Muxers en demuxers beschikbaar voor gebruikte FFmpeg."
 
-#: ../../vdms_main/main_frame.py:543
 #, fuzzy
 msgid "Encoders available on your version of FFmpeg"
 msgstr "Toont beschikbare encoders voor FFmpeg"
 
-#: ../../vdms_main/main_frame.py:546
 #, fuzzy
 msgid "Decoders available on your version of FFmpeg"
 msgstr "Toont beschikbare encoders voor FFmpeg"
 
-#: ../../vdms_main/main_frame.py:550
 #, fuzzy
 msgid "Enable timestamps on playback"
 msgstr "Toont tijdcode"
 
-#: ../../vdms_main/main_frame.py:551
 #, fuzzy
 msgid "Displays timestamp when playing media with FFplay"
 msgstr "Toont tijdcode bij afspelen van films met FFplay"
 
-#: ../../vdms_main/main_frame.py:554
 msgid "Auto-exit after playback"
 msgstr "Automatisch afsluiten na afspelen"
 
-#: ../../vdms_main/main_frame.py:555
 #, fuzzy
 msgid "If checked, the FFplay window will auto-close when playback is complete"
 msgstr "Als geselecteerd, zal het FFplay window auto-sluiten als het afspelen beëindigd is"
 
-#: ../../vdms_main/main_frame.py:559
 msgid "Customize the timestamp style"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:562
 #, fuzzy
 msgid "While playing..."
 msgstr "Tijdens afspelen"
 
-#: ../../vdms_main/main_frame.py:563
 #, fuzzy
 msgid "Show useful shortcut keys when playing or previewing using FFplay"
 msgstr "Toon nuttige sneltoetsen bij afspelen of preview met FFplay"
 
-#: ../../vdms_main/main_frame.py:567
 #, fuzzy
 msgid "Show timeline editor\tCtrl+T"
 msgstr "Toon tijdslijn\tCtrl+T"
 
-#: ../../vdms_main/main_frame.py:568
 msgid "Set duration or trim slices of time to remove unwanted parts from your files"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:572
 msgid "View"
 msgstr "Bekijk"
 
-#: ../../vdms_main/main_frame.py:579
 #, fuzzy
 msgid "Home panel\tCtrl+Shift+H"
 msgstr "Home panel\tShift+H"
 
-#: ../../vdms_main/main_frame.py:580
 msgid "Go to the «Home» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:583
 #, fuzzy
 msgid "Presets Manager\tCtrl+Shift+P"
 msgstr "Presets manager\tShift+P"
 
-#: ../../vdms_main/main_frame.py:584
 msgid "Go to the «Presets Manager» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:586
 #, fuzzy
 msgid "A/V Conversions\tCtrl+Shift+V"
 msgstr "A/V conversies\tShift+V"
 
-#: ../../vdms_main/main_frame.py:587
 msgid "Go to the «A/V Conversions» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:589
 #, fuzzy
 msgid "Concatenate Demuxer\tCtrl+Shift+D"
 msgstr "Samenvoeg Demuxer\tShift+D"
 
-#: ../../vdms_main/main_frame.py:590
 msgid "Go to the «Concatenate Demuxer» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:593
 msgid "Still Image Maker\tCtrl+Shift+I"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:594
 msgid "Go to the «Still Image Maker» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:596
 #, fuzzy
 msgid "From Movie to Pictures\tCtrl+Shift+S"
 msgstr "Van afbeelingen serie naar een video file"
 
-#: ../../vdms_main/main_frame.py:597
 msgid "Go to the «From Movie to Pictures» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:600
 #, fuzzy
 msgid "Output monitor\tCtrl+Shift+O"
 msgstr "Output Monitor\tShift+O"
 
-#: ../../vdms_main/main_frame.py:601
 msgid "Keeps track of the output for debugging errors"
 msgstr "Inspecteert output voor debug-fouten"
 
-#: ../../vdms_main/main_frame.py:603
 #, fuzzy
 msgid "Go"
 msgstr "Ga naar"
 
-#: ../../vdms_main/main_frame.py:607
 #, fuzzy
 msgid "User guide"
 msgstr "Handleiding"
 
-#: ../../vdms_main/main_frame.py:611
 #, fuzzy
 msgid "System version"
 msgstr "Toont de gebruikte versie"
 
-#: ../../vdms_main/main_frame.py:612
 msgid "Get version about your operating system, version of Python and wxPython."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:616
 #, fuzzy
 msgid "Show log files\tCtrl+L"
 msgstr "Toon Log-berichten\tCtrl+L"
 
-#: ../../vdms_main/main_frame.py:617
 msgid "Viewing log messages"
 msgstr "Log-berichten bekijken"
 
-#: ../../vdms_main/main_frame.py:620
 msgid "Issue tracker"
 msgstr "Issue tracker"
 
-#: ../../vdms_main/main_frame.py:624
 msgid "Contribute to the project"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:627
 msgid "Sponsor this project"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:628
 msgid "Become a developer supporter"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:629
 msgid "Donate"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:630
 msgid "Donate to the app developer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:634
 msgid "Other projects by the developer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:650
 msgid "About Videomass"
 msgstr "Over Videomass"
 
-#: ../../vdms_main/main_frame.py:651
 msgid "Check for newer version"
 msgstr "Ga nieuwere versie na"
 
-#: ../../vdms_main/main_frame.py:652
 #, fuzzy
 msgid "Check for the latest Videomass version"
 msgstr "Toon de laatste versie..."
 
-#: ../../vdms_main/main_frame.py:654
 msgid "Help"
 msgstr "Help"
 
-#: ../../vdms_main/main_frame.py:729
 #, fuzzy
 msgid "Import files"
 msgstr "Log folder"
 
-#: ../../vdms_main/main_frame.py:752
 msgid "No default folder has been set for the destination of the encodings. The current setting is \"Same destination paths as source files\"."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:784 ../../vdms_main/main_frame.py:809
 #, python-brace-format
 msgid ""
 "'{}':\n"
 "No such file or directory"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:797
 msgid "Are you sure to empty trash folder?"
 msgstr "Weet u zeker dat u de Videomass Prullenbak wilt legen?"
 
-#: ../../vdms_main/main_frame.py:805
 #, fuzzy, python-brace-format
 msgid ""
 "'{}':\n"
 "There are no files to delete."
 msgstr "Er bestaan geen logs om te tonen."
 
-#: ../../vdms_main/main_frame.py:862
 #, python-brace-format
 msgid "Installed release v{0}. A new presets release is available {1}"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:866
 #, python-brace-format
 msgid "Installed release v{0}. No new updates found."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:896
 msgid ""
 "Wait....\n"
 "The archive is being downloaded"
@@ -2253,17 +1684,14 @@ msgstr ""
 "Wacht....\n"
 "Het archief wordt gedownload"
 
-#: ../../vdms_main/main_frame.py:908
 #, python-brace-format
 msgid "Successfully downloaded to \"{0}\""
 msgstr "Succesvol gedownload naar \"{0}\""
 
-#: ../../vdms_main/main_frame.py:1120
 #, fuzzy
 msgid "Some changes require restarting the application."
 msgstr "Maak cache leeg als programma beëindigd wordt"
 
-#: ../../vdms_main/main_frame.py:1126
 #, fuzzy, python-brace-format
 msgid ""
 "{0}\n"
@@ -2271,233 +1699,178 @@ msgid ""
 "Do you want to restart the application now?"
 msgstr "Afsluiten : bent u zeker?"
 
-#: ../../vdms_main/main_frame.py:1128
 #, fuzzy
 msgid "Restart Videomass?"
 msgstr "Videomass"
 
-#: ../../vdms_main/main_frame.py:1207
 #, python-brace-format
 msgid "A new release is available - v.{0}\n"
 msgstr "Er is een nieuwe versie beschikbaar - v.{0}\n"
 
-#: ../../vdms_main/main_frame.py:1210
 msgid "You are using a development version that has not yet been released!\n"
 msgstr "U gebruikt een ontwikkelaars versie die nog niet is vrijgegeven!\n"
 
-#: ../../vdms_main/main_frame.py:1213
 msgid "Congratulation! You are already using the latest version.\n"
 msgstr "Gefeliciteerd! U gebruikt al de laatste versie.\n"
 
-#: ../../vdms_main/main_frame.py:1301
 #, fuzzy
 msgid "Previous panel"
 msgstr "Ga naar vorig panel"
 
-#: ../../vdms_main/main_frame.py:1302
 msgid "Back"
 msgstr "Terug"
 
-#: ../../vdms_main/main_frame.py:1305
 #, fuzzy
 msgid "Next panel"
 msgstr "Volgende >"
 
-#: ../../vdms_main/main_frame.py:1306
 msgid "Next"
 msgstr "Volgende"
 
-#: ../../vdms_main/main_frame.py:1309
 #, fuzzy
 msgid "Home panel"
 msgstr "Ga naar volgende panel"
 
-#: ../../vdms_main/main_frame.py:1310
 msgid "Home"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1313
 #, fuzzy
 msgid "Play the selected imput file"
 msgstr "Verwijder het geselecteerde profiel"
 
-#: ../../vdms_main/main_frame.py:1314
 msgid "Play"
 msgstr "Speel"
 
-#: ../../vdms_main/main_frame.py:1317
 #, fuzzy
 msgid "Get informative data about imported media streams"
 msgstr "Wint informatie in over multimedia streams"
 
-#: ../../vdms_main/main_frame.py:1321
 msgid "Start batch processing"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1325
 msgid "Stops current process"
 msgstr "Stopt huidige proces"
 
-#: ../../vdms_main/main_frame.py:1329
 msgid "Add an item to Queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1330
 msgid "Add to Queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1333
 msgid "Show queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1408 ../../vdms_panels/presets_manager.py:569
 msgid "Videomass"
 msgstr "Videomass"
 
-#: ../../vdms_main/main_frame.py:1442
 #, fuzzy
 msgid "Videomass - File List"
 msgstr "Videomass - Wachtrij Bestanden"
 
-#: ../../vdms_main/main_frame.py:1459
 msgid "Videomass - AV Conversions"
 msgstr "Videomass - AV Conversies"
 
-#: ../../vdms_main/main_frame.py:1488
 msgid "Videomass - Presets Manager"
 msgstr "Videomass - Presets Manager"
 
-#: ../../vdms_main/main_frame.py:1518
 msgid "Videomass - Concatenate Demuxer"
 msgstr "Videomass - Samenvoeg Demuxer"
 
-#: ../../vdms_main/main_frame.py:1547
 #, fuzzy
 msgid "Videomass - From Movie to Pictures"
 msgstr "Van afbeelingen serie naar een video file"
 
-#: ../../vdms_main/main_frame.py:1576
 #, fuzzy
 msgid "Videomass - Still Image Maker"
 msgstr "Videomass - Presets Manager"
 
-#: ../../vdms_main/main_frame.py:1660 ../../vdms_panels/av_conversions.py:577
-#: ../../vdms_panels/filedrop.py:500 ../../vdms_panels/filedrop.py:616
-#: ../../vdms_panels/sequence_to_video.py:322
-#: ../../vdms_panels/video_to_sequence.py:369
-#: ../../vdms_panels/video_to_sequence.py:501
 #, fuzzy
 msgid "Have to select an item in the file list first"
 msgstr "Selecteer eerst een profiel in de lijst"
 
-#: ../../vdms_main/main_frame.py:1682
 msgid ""
 "An item with the same destination file already exists.\n"
 "\n"
 "Do you want to replace it by adding the new item to the queue?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1703
 #, fuzzy
 msgid "Videomass - FFmpeg Message Monitoring"
 msgstr "Videomass - Output Monitor"
 
-#: ../../vdms_main/main_frame.py:1828
 #, python-brace-format
 msgid "The system will turn off in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1829
 #, fuzzy
 msgid "Videomass - Shutdown!"
 msgstr "Videomass - Laden..."
 
-#: ../../vdms_main/main_frame.py:1836
 msgid "Error while shutting down. Please see file log for details."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1848
 #, python-brace-format
 msgid "Exiting the application in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1849
 #, fuzzy
 msgid "Videomass - Exiting!"
 msgstr "Videomass - Laden..."
 
-#: ../../vdms_miniframes/timeline.py:46
 #, fuzzy
 msgid "Start point adjustment"
 msgstr "Start"
 
-#: ../../vdms_miniframes/timeline.py:48
 msgid "End point adjustment"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:105
 msgid "Hours"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:106
 #, fuzzy
 msgid "Minutes"
 msgstr "Start"
 
-#: ../../vdms_miniframes/timeline.py:107
 msgid "Seconds"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:108
 msgid "Milliseconds"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:189 ../../vdms_miniframes/timeline.py:312
 msgid "No source duration:"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:208 ../../vdms_miniframes/timeline.py:298
-#: ../../vdms_miniframes/timeline.py:333 ../../vdms_miniframes/timeline.py:338
-#: ../../vdms_miniframes/timeline.py:441
 #, python-brace-format
 msgid "{0} {1}  |  Segment Duration: {2}"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:260 ../../vdms_miniframes/timeline.py:277
 msgid "End adjustment"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:261 ../../vdms_miniframes/timeline.py:279
 #, fuzzy
 msgid "Start adjustment"
 msgstr "Start"
 
-#: ../../vdms_miniframes/timeline.py:320
 #, fuzzy
 msgid "Source duration:"
 msgstr "Duur:"
 
-#: ../../vdms_miniframes/timeline.py:387
 msgid "WARNING: Invalid selection, out of range."
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:461
 msgid ""
 "Start by dragging the bottom left handle,\n"
 "or right-click for options."
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:497
 #, fuzzy
 msgid "Start"
 msgstr "Start"
 
-#: ../../vdms_miniframes/timeline.py:498
 #, fuzzy
 msgid "End"
 msgstr "Geactiveerd"
 
-#: ../../vdms_miniframes/timeline.py:548
 msgid ""
 "The timeline editor is a tool that allows you to trim slices of time on selected imported media (see File List panel).\n"
 "\n"
@@ -2510,45 +1883,36 @@ msgid ""
 "The \"Start\"/\"End\" duration values always refer to the initial position of the timeline: 00:00:00.000. For other informations as the segment duration and warnings, please refer to the status bar messages."
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:565
 #, fuzzy
 msgid "Timeline Editor Usage"
 msgstr "Toon tijdslijn\tCtrl+T"
 
-#: ../../vdms_panels/av_conversions.py:153
 msgid "Media:"
 msgstr "Media:"
 
-#: ../../vdms_panels/av_conversions.py:169
 msgid "Container:"
 msgstr "Container:"
 
-#: ../../vdms_panels/av_conversions.py:180
 #, fuzzy
 msgid "Save profile"
 msgstr "Schrijf het nieuwe profiel naar..."
 
-#: ../../vdms_panels/av_conversions.py:183
 #, fuzzy
 msgid "Target"
 msgstr "Doel niveau:"
 
-#: ../../vdms_panels/av_conversions.py:316
 #, fuzzy
 msgid "Miscellaneous"
 msgstr "Diversen"
 
-#: ../../vdms_panels/av_conversions.py:323
 #, fuzzy
 msgid "Save as a new profile of the Presets Manager."
 msgstr "Verwijder de geselecteerde preset uit de Presets Manager"
 
-#: ../../vdms_panels/av_conversions.py:325
 #, fuzzy
 msgid "Available video encoders. \"Copy\" means that the video stream will not be re-encoded and will allow you (depending on the encoder) to change the container, audio codec and a few other parameters."
 msgstr "Beschikbare video codecs. \"Copy\" is geen codec maar geeft aan dat de video stream niet her-encoded dient te worden en staat toe het formaat of andere parameters te wijzigen"
 
-#: ../../vdms_panels/av_conversions.py:330
 msgid ""
 "Container format. It is usually represented by the file extension (output format).\n"
 "\n"
@@ -2557,79 +1921,59 @@ msgid ""
 "If the media target is set to \"Audio\", you can extract only the audio streams from videos, or simply convert audio source files."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:338
 msgid ""
 "Set output files target: \"Video\" to save output files as video files; \"Audio\" to save files using an audio encoder and format.\n"
 "\n"
 "Note that by using \"Audio\" as the target, you will still be able to work on the video source files but you will only be able to extract the audio streams, convert them and apply audio filters such as normalization."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:346
 msgid "Preview video filters"
 msgstr "Voorvertoon video filters"
 
-#: ../../vdms_panels/av_conversions.py:347
 #, fuzzy
 msgid "Disable active filters"
 msgstr "Uitgezet"
 
-#: ../../vdms_panels/av_conversions.py:348
-#: ../../vdms_panels/sequence_to_video.py:156
-#: ../../vdms_panels/video_to_sequence.py:113
 #, fuzzy
 msgid "Resize"
 msgstr "Herschalen bezig"
 
-#: ../../vdms_panels/av_conversions.py:349
 #, fuzzy
 msgid "Crop"
 msgstr "Bijsnijden bezig"
 
-#: ../../vdms_panels/av_conversions.py:350
 #, fuzzy
 msgid "Transpose"
 msgstr "Transponeer Filter"
 
-#: ../../vdms_panels/av_conversions.py:352
 #, fuzzy
 msgid "Denoise"
 msgstr "Denoiser"
 
-#: ../../vdms_panels/av_conversions.py:353
 #, fuzzy
 msgid "Stabilize"
 msgstr "Stabilisatie filter"
 
-#: ../../vdms_panels/av_conversions.py:354
 msgid "Equalize"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:517
 msgid "Unable to preview Video Stabilizer filter"
 msgstr "Geen preview van Video Stabilisatie filter mogelijk"
 
-#: ../../vdms_panels/av_conversions.py:602
 msgid ""
 "Unsupported file:\n"
 "Missing decoder or library? Check FFmpeg configuration."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:611
-#: ../../vdms_panels/sequence_to_video.py:351
-#: ../../vdms_panels/video_to_sequence.py:398
 msgid "The file is not a frame or a video file"
 msgstr "Het bestand is geen frame en geen video bestand"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:434
-#: ../../vdms_panels/av_conversions.py:861
 msgid "Undetected volume values! Click the \"Volume detect\" button to analyze audio volume data."
 msgstr "Volume waarden niet gedetecteerd! Druk de \"Volume detect\" knop om de audio volume data te laten analyseren."
 
-#: ../../vdms_panels/av_conversions.py:1186
 msgid "Off"
 msgstr "Uit"
 
-#: ../../vdms_panels/av_conversions.py:1203
 #, fuzzy
 msgid ""
 "Batch processing items\n"
@@ -2656,115 +2000,87 @@ msgstr ""
 "Tijdsperiode\n"
 "Input Audio Map"
 
-#: ../../vdms_panels/av_conversions.py:1246
-#: ../../vdms_panels/presets_manager.py:814
 #, python-brace-format
 msgid "Write profile on «{0}»"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1266
-#: ../../vdms_panels/presets_manager.py:513
 msgid "Enter name for new preset"
 msgstr "Voer naam in voor nieuwe preset"
 
-#: ../../vdms_panels/av_conversions.py:1276
-#: ../../vdms_panels/presets_manager.py:524
 msgid "Invalid file name, make sure to provide a valid name including the «.json» extension"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1284
 #, fuzzy, python-brace-format
 msgid "Cannot save current data in file «{}»."
 msgstr "Kan huidige data niet in bestand '{}' bewaren."
 
-#: ../../vdms_panels/av_conversions.py:1289
 #, fuzzy
 msgid "Open Videomass preset"
 msgstr "Sluit Videomass af"
 
-#: ../../vdms_panels/av_conversions.py:1307
 #, fuzzy
 msgid "Videomass - Save new profile"
 msgstr "Maak een nieuw profiel"
 
-#: ../../vdms_panels/av_conversions.py:1308
 #, fuzzy
 msgid "Where do you want to save this profile?"
 msgstr " Wilt u deze mogelijkheid activeren?"
 
-#: ../../vdms_panels/av_conversions.py:1309
 #, fuzzy
 msgid "Save the profile to a new preset"
 msgstr "Maak een nieuw profiel op \"{}\" preset"
 
-#: ../../vdms_panels/av_conversions.py:1310
 #, fuzzy
 msgid "Save the profile to an existing preset"
 msgstr "Maak een nieuw profiel op \"{}\" preset"
 
-#: ../../vdms_panels/choose_topic.py:69
 msgid "Welcome to Videomass"
 msgstr "Welkom bij Videomass"
 
-#: ../../vdms_panels/choose_topic.py:71
 #, python-brace-format
 msgid "Version {}"
 msgstr "Versie {}"
 
-#: ../../vdms_panels/choose_topic.py:82
 msgid "Presets Manager"
 msgstr "Presets Manager"
 
-#: ../../vdms_panels/choose_topic.py:85
 msgid "AV-Conversions"
 msgstr "AV-Conversies"
 
-#: ../../vdms_panels/choose_topic.py:88
 msgid "Concatenate media files"
 msgstr "Media files samenvoegen"
 
-#: ../../vdms_panels/choose_topic.py:91
 msgid "Still Image Maker"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:94
 #, fuzzy
 msgid "From Movie to Pictures"
 msgstr "Van afbeelingen serie naar een video file"
 
-#: ../../vdms_panels/choose_topic.py:123
 msgid "Create, edit and use quickly your favorite FFmpeg presets and profiles with full formats support and codecs."
 msgstr "Maak, edit en gebruik snel uw favoriete FFmpeg presets en profielen met volledige ondersteuning van formaten en codecs."
 
-#: ../../vdms_panels/choose_topic.py:127
 msgid "A set of useful tools for audio and video conversions. Save your profiles and reuse them with Presets Manager."
 msgstr "Een stel handige gereedschappen voor audio en video conversies. Bewaar uw profielen en gebruik ze met Presets Manager."
 
-#: ../../vdms_panels/choose_topic.py:131
 msgid "Concatenate multiple media files based on import order without re-encoding"
 msgstr "Schakel meerdere media files aaneen, gebaseerd op import volgorde zonder her-encoding"
 
-#: ../../vdms_panels/choose_topic.py:134
 msgid "Create video from a sequence of images, based on import order, with the ability to add an audio file."
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:137
 msgid "Extract images (frames) from your movies in JPG, PNG, BMP, GIF formats."
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:47
 msgid "At least two files are required to perform concatenation."
 msgstr "Samevoegen vereist minstens twee bestanden."
 
-#: ../../vdms_panels/concatenate.py:63
 msgid "Invalid data found"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:68
 msgid "The files do not have the same \"codec_types\", same \"sample_rate\" or same \"width\" or \"height\". Unable to proceed."
 msgstr "De bestanden hebben niet dezelfde \"codec_types\", \"sample_rate\" of \"breedte\" of \"hoogte\". Voortgang onmogelijk."
 
-#: ../../vdms_panels/concatenate.py:84
 #, fuzzy
 msgid ""
 "\n"
@@ -2794,17 +2110,12 @@ msgstr ""
 "\n"
 "- Audio bestanden moeten exact hetzelfde formaat hebben, evenals hun codecs en sample rate."
 
-#: ../../vdms_panels/concatenate.py:125
 msgid "Videomass Documentation:"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:136
-#: ../../vdms_panels/sequence_to_video.py:212
-#: ../../vdms_panels/video_to_sequence.py:181
 msgid "Official FFmpeg documentation:"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:253
 #, fuzzy
 msgid ""
 "Items to concatenate\n"
@@ -2819,277 +2130,215 @@ msgstr ""
 "Output Formaat\n"
 "Tijd Periode"
 
-#: ../../vdms_panels/filedrop.py:45
 msgid "File has illegal characters like:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:46
 msgid "Invalid character found in path name: (\")"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:47
 msgid "Directories are not allowed, just add files, please."
 msgstr "Folders zijn niet toegestaan, voeg alleen bestanden toe."
 
-#: ../../vdms_panels/filedrop.py:48
 msgid "File without format extension: please give an appropriate extension to the file name, example '.mkv', '.avi', '.mp3', etc."
 msgstr "Bestand zonder formaat extensie: u dient een treffende extensie te geven aan de bestandsnaam, bijv. '.mkv', '.avi', '.mp3', etc."
 
-#: ../../vdms_panels/filedrop.py:84
 #, python-brace-format
 msgid "Name has illegal characters like: {0}"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:85
 msgid "Name already in use:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:185
 msgid "Duplicate file, it has already been added to the list."
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:197
 #, fuzzy
 msgid "Rejected files"
 msgstr "Voeg bestanden toe"
 
-#: ../../vdms_panels/filedrop.py:269
 #, fuzzy
 msgid "Source file"
 msgstr "Bestands Voorkeuren"
 
-#: ../../vdms_panels/filedrop.py:270
 msgid "Duration"
 msgstr "Duur"
 
-#: ../../vdms_panels/filedrop.py:271
 msgid "Media type"
 msgstr "Media type"
 
-#: ../../vdms_panels/filedrop.py:272
 msgid "Size"
 msgstr "Grootte"
 
-#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:405
 msgid "Drag one or more files below"
 msgstr "Sleep een of meer bestanden hieronder"
 
-#: ../../vdms_panels/filedrop.py:282
 #, fuzzy
 msgid "Save to:"
 msgstr "Preset"
 
-#: ../../vdms_panels/filedrop.py:306
 #, fuzzy
 msgid "Set a new destination folder for encodings"
 msgstr "Maak een nieuwe preset"
 
-#: ../../vdms_panels/filedrop.py:308
 #, fuzzy
 msgid "Encodings destination folder"
 msgstr "Configuratie folder"
 
-#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:394
 #, fuzzy
 msgid "Play file"
 msgstr "Profiel"
 
-#: ../../vdms_panels/filedrop.py:408
 #, fuzzy
 msgid "Drag two or more Audio/Video files below"
 msgstr "Sleep een of meer bestanden hieronder"
 
-#: ../../vdms_panels/filedrop.py:412
 #, fuzzy
 msgid "Drag one or more Image files below"
 msgstr "Sleep een of meer bestanden hieronder"
 
-#: ../../vdms_panels/filedrop.py:415
 #, fuzzy
 msgid "Drag one or more Video files below"
 msgstr "Sleep een of meer bestanden hieronder"
 
-#: ../../vdms_panels/filedrop.py:623
 #, fuzzy
 msgid "Rename the file destination"
 msgstr "Herstel de standaard bestemming-folders"
 
-#: ../../vdms_panels/filedrop.py:624
 #, fuzzy
 msgid "Rename the selected file to:"
 msgstr "Verwijder het geselecteerde profiel"
 
-#: ../../vdms_panels/filedrop.py:638 ../../vdms_panels/filedrop.py:648
-#: ../../vdms_panels/filedrop.py:679
 msgid "Add Files"
 msgstr "Voeg bestanden toe"
 
-#: ../../vdms_panels/filedrop.py:655
 msgid "Rename in batch"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:656
 #, python-brace-format
 msgid "Rename the {0} items to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:658
 #, fuzzy
 msgid "New Name #"
 msgstr "Bestandsnaam"
 
-#: ../../vdms_panels/long_processing_task.py:114
 msgid "Sorry, all task failed !"
 msgstr "Sorry, opdracht niet geslaagd !"
 
-#: ../../vdms_panels/long_processing_task.py:115
 msgid "The process was stopped due to a fatal error."
 msgstr "Het proces is gestopt door een fatale fout."
 
-#: ../../vdms_panels/long_processing_task.py:116
 msgid "Interrupted Process !"
 msgstr "Proces Onderbroken !"
 
-#: ../../vdms_panels/long_processing_task.py:117
 msgid "Successfully completed !"
 msgstr "Succesvol afgerond !"
 
-#: ../../vdms_panels/long_processing_task.py:118
 msgid "Not everything was successful."
 msgstr "Niet alles was succesvol."
 
-#: ../../vdms_panels/long_processing_task.py:148
 msgid "Encoding Status"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:152
 #, fuzzy
 msgid "Current Log"
 msgstr "Huidig pad:"
 
-#: ../../vdms_panels/long_processing_task.py:354
 msgid "Fatal Error !"
 msgstr "Fatale Fout !"
 
-#: ../../vdms_panels/long_processing_task.py:363
 msgid "Get your files at the destination you specified"
 msgstr "Uw bestanden staan op de door u aangegeven plek"
 
-#: ../../vdms_panels/long_processing_task.py:377
 msgid "For more details please read the Current Log."
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:380
 msgid "...Finished"
 msgstr "...Afgerond"
 
-#: ../../vdms_panels/long_processing_task.py:399
 #, fuzzy
 msgid "Please wait... interruption in progress"
 msgstr "wacht... bezig met afbreken"
 
-#: ../../vdms_panels/long_processing_task.py:402
 msgid "...Interrupted"
 msgstr "...Onderbroken"
 
-#: ../../vdms_panels/presets_manager.py:166
 msgid "Presets"
 msgstr "Presets"
 
-#: ../../vdms_panels/presets_manager.py:180
 msgid "Write"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:184
 msgid "Delete"
 msgstr "Verwijder"
 
-#: ../../vdms_panels/presets_manager.py:194
 msgid "Duplicate"
 msgstr "Kopieer"
 
-#: ../../vdms_panels/presets_manager.py:199
 msgid "Profiles"
 msgstr "Profielen"
 
-#: ../../vdms_panels/presets_manager.py:206
 #, fuzzy
 msgid "One-Pass Encoding"
 msgstr "Een-Pass"
 
-#: ../../vdms_panels/presets_manager.py:218
 #, fuzzy
 msgid "Two-Pass Encoding"
 msgstr "Twee-Pass"
 
-#: ../../vdms_panels/presets_manager.py:232
 msgid "Choose a preset and view its profiles"
 msgstr "Kies een preset en bekijk de profielen ervan"
 
-#: ../../vdms_panels/presets_manager.py:233
 #, fuzzy
 msgid "Write a new profile and save it in the selected preset"
 msgstr "Maak een nieuw profiel en bewaar het in de geselecteerde preset"
 
-#: ../../vdms_panels/presets_manager.py:235
 msgid "Delete the selected profile"
 msgstr "Verwijder het geselecteerde profiel"
 
-#: ../../vdms_panels/presets_manager.py:236
 msgid "Edit the selected profile"
 msgstr "Edit het geselecteerde profiel"
 
-#: ../../vdms_panels/presets_manager.py:237
 #, fuzzy
 msgid "Duplicate the selected profile"
 msgstr "Verwijder het geselecteerde profiel"
 
-#: ../../vdms_panels/presets_manager.py:238
 #, fuzzy
 msgid "Create new preset"
 msgstr "Maak een nieuwe preset"
 
-#: ../../vdms_panels/presets_manager.py:240
 #, fuzzy
 msgid "Remove selected preset"
 msgstr "Verwijder het geselecteerde profiel"
 
-#: ../../vdms_panels/presets_manager.py:242
 #, fuzzy
 msgid "Backup selected preset"
 msgstr "Exporteer geselecteerde preset als copy"
 
-#: ../../vdms_panels/presets_manager.py:244
 #, fuzzy
 msgid "Backup the presets folder"
 msgstr "Importeer een nieuwe preset folder"
 
-#: ../../vdms_panels/presets_manager.py:246
 #, fuzzy
 msgid "Restore a preset"
 msgstr "Exporteer geselecteerden"
 
-#: ../../vdms_panels/presets_manager.py:248
 #, fuzzy
 msgid "Restore a presets folder"
 msgstr "Importeer een nieuwe preset folder"
 
-#: ../../vdms_panels/presets_manager.py:250
 #, fuzzy
 msgid "Resets the selected preset to default values"
 msgstr "Vervang de geselecteerde preset met de Videomass standaard"
 
-#: ../../vdms_panels/presets_manager.py:252
 #, fuzzy
 msgid "Reset all presets to default values"
 msgstr "Haal alle Videomass standaard presets op"
 
-#: ../../vdms_panels/presets_manager.py:254
 #, fuzzy
 msgid "Refresh the presets list"
 msgstr "Update de presets lijst"
 
-#: ../../vdms_panels/presets_manager.py:338
 #, python-brace-format
 msgid ""
 "Outdated presets version found: v{1}\n"
@@ -3103,28 +2352,22 @@ msgid ""
 "Do you want to perform this update now?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:403
 msgid "Name"
 msgstr "Naam"
 
-#: ../../vdms_panels/presets_manager.py:405
 msgid "Output Format"
 msgstr "Output Formaat"
 
-#: ../../vdms_panels/presets_manager.py:406
 msgid "Supported Format List"
 msgstr "Lijst Ondersteunde Formaten"
 
-#: ../../vdms_panels/presets_manager.py:531
 #, python-brace-format
 msgid "Cannot save current data in file '{}'."
 msgstr "Kan huidige data niet in bestand '{}' bewaren."
 
-#: ../../vdms_panels/presets_manager.py:535
 msgid "You just successfully created a new preset!"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:547
 #, fuzzy, python-brace-format
 msgid ""
 "Are you sure you want to remove \"{}\" preset?\n"
@@ -3135,7 +2378,6 @@ msgstr ""
 "\n"
 "Deze wordt verplaatst naar de \"Verwijderd\" subfolder in de presets folder."
 
-#: ../../vdms_panels/presets_manager.py:558
 #, python-brace-format
 msgid ""
 "{}\n"
@@ -3146,32 +2388,24 @@ msgstr ""
 "\n"
 "Sorry, verwijdering mislukt, kan niet verder gaan.."
 
-#: ../../vdms_panels/presets_manager.py:568
 #, python-brace-format
 msgid "The preset \"{0}\" was successfully removed"
 msgstr "De preset \"{0}\" was succesvol verwijderd"
 
-#: ../../vdms_panels/presets_manager.py:583
-#: ../../vdms_panels/presets_manager.py:612
 #, fuzzy
 msgid "Open a destination folder"
 msgstr "Bestemming folder"
 
-#: ../../vdms_panels/presets_manager.py:588
 msgid "A file with this name already exists, do you want to overwrite it?"
 msgstr "Een bestand met deze naam bestaat al, wilt u het overschrijven?"
 
-#: ../../vdms_panels/presets_manager.py:602
-#: ../../vdms_panels/presets_manager.py:622
 #, fuzzy
 msgid "Backup completed successfully"
 msgstr "Wizard met succes afgerond!\n"
 
-#: ../../vdms_panels/presets_manager.py:631
 msgid "Open the preset you want to restore"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:645
 msgid ""
 "This preset already exists and is about to be updated. Don't worry, it will keep all your saved profiles.\n"
 "\n"
@@ -3181,12 +2415,10 @@ msgstr ""
 "\n"
 "Wilt u verder gaan?"
 
-#: ../../vdms_panels/presets_manager.py:663
 #, fuzzy
 msgid "Restore successful"
 msgstr "Wizard met succes afgerond!\n"
 
-#: ../../vdms_panels/presets_manager.py:681
 msgid ""
 "This will update the presets database. Don't worry, it will keep all your saved profiles.\n"
 "\n"
@@ -3196,21 +2428,17 @@ msgstr ""
 "\n"
 "Wilt u verder gaan?"
 
-#: ../../vdms_panels/presets_manager.py:689
 #, fuzzy
 msgid "Open the presets folder to restore"
 msgstr "Importeer een nieuwe preset folder"
 
-#: ../../vdms_panels/presets_manager.py:725
 msgid "The presets database has been successfully updated"
 msgstr "De presets database is succesvol ge-update"
 
-#: ../../vdms_panels/presets_manager.py:740
 #, fuzzy
 msgid "The selected preset is not part of Videomass's default presets."
 msgstr "Vervang de geselecteerde preset met de Videomass standaard"
 
-#: ../../vdms_panels/presets_manager.py:745
 msgid ""
 "Be careful! The selected preset will be overwritten with the default one. Your profiles may be deleted!\n"
 "\n"
@@ -3220,12 +2448,9 @@ msgstr ""
 "\n"
 "Wilt u verder gaan?"
 
-#: ../../vdms_panels/presets_manager.py:760
-#: ../../vdms_panels/presets_manager.py:794
 msgid "Successful recovery"
 msgstr "Succesvol herstel"
 
-#: ../../vdms_panels/presets_manager.py:769
 #, fuzzy
 msgid ""
 "Be careful! This action will restore all presets to default ones. Your profiles may be deleted!\n"
@@ -3238,20 +2463,16 @@ msgstr ""
 "\n"
 "Wilt u verder gaan?"
 
-#: ../../vdms_panels/presets_manager.py:833
 #, fuzzy, python-brace-format
 msgid "Edit profile on «{0}»"
 msgstr "Edit profiel van de \"{}\" preset"
 
-#: ../../vdms_panels/presets_manager.py:872
 msgid "Are you sure you want to delete the selected profile? It will no longer be possible to recover it."
 msgstr "Geselecteerde profiel verwijderen? Het zal niet meer hersteld kunnen worden."
 
-#: ../../vdms_panels/presets_manager.py:891
 msgid "First select a profile in the list"
 msgstr "Selecteer eerst een profiel in de lijst"
 
-#: ../../vdms_panels/presets_manager.py:899
 msgid ""
 "The selected profile command has been changed manually.\n"
 "Do you want to apply it during the conversion process?"
@@ -3259,11 +2480,9 @@ msgstr ""
 "Het geselecteerde profiel commando is handmatig gewijzigd.\n"
 "Wilt u dit toepassen voor het conversie proces?"
 
-#: ../../vdms_panels/presets_manager.py:909
 msgid "Don't show this dialog again"
 msgstr "Toon dit dialoogscherm niet meer"
 
-#: ../../vdms_panels/presets_manager.py:1054
 #, fuzzy
 msgid ""
 "Batch processing items\n"
@@ -3287,11 +2506,9 @@ msgstr ""
 "Tijdsperiode\n"
 "Input Audio Map"
 
-#: ../../vdms_panels/sequence_to_video.py:54
 msgid "Images need to be resized, please use Resize function."
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:73
 msgid ""
 "\n"
 "1. Import one or more image files such as JPG, PNG and BMP formats, then select one.\n"
@@ -3309,39 +2526,30 @@ msgid ""
 "will be saved in a folder named 'Still_Images' with a progressive digit, in the path you specify."
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:129
 msgid "Enable a single still image"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:162
 msgid ""
 "Force original aspect ratio using\n"
 "padding rather than stretching"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:170
 msgid "Include audio file"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:173
 msgid "Play the video until audio track finishes"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:180
-#: ../../vdms_panels/sequence_to_video.py:439
 msgid "Open audio file"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:199
 msgid "Additional arguments"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:454
 #, fuzzy
 msgid "Open Audio File"
 msgstr "Open een of meer bestanden"
 
-#: ../../vdms_panels/sequence_to_video.py:466
 #, fuzzy, python-brace-format
 msgid ""
 "Invalid file: '{}'\n"
@@ -3349,7 +2557,6 @@ msgid ""
 "{}"
 msgstr "Ongeldige URL: \"{}\""
 
-#: ../../vdms_panels/sequence_to_video.py:471
 #, python-brace-format
 msgid ""
 "Invalid file: '{}'\n"
@@ -3357,21 +2564,14 @@ msgid ""
 "It doesn't appear to be an audio file."
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:560
-#: ../../vdms_panels/sequence_to_video.py:587
-#: ../../vdms_panels/video_to_sequence.py:511
 #, fuzzy, python-brace-format
 msgid "Invalid file: '{}'"
 msgstr "Ongeldige URL: \"{}\""
 
-#: ../../vdms_panels/sequence_to_video.py:570
-#: ../../vdms_panels/sequence_to_video.py:595
 #, fuzzy, python-brace-format
 msgid "Unsupported format '{}'"
 msgstr "Lijst Ondersteunde Formaten"
 
-#: ../../vdms_panels/sequence_to_video.py:576
-#: ../../vdms_panels/sequence_to_video.py:600
 #, python-brace-format
 msgid ""
 "File does not exist:\n"
@@ -3382,15 +2582,9 @@ msgstr ""
 "\n"
 "\"{}\"\n"
 
-#: ../../vdms_panels/sequence_to_video.py:577
 msgid "ERROR"
 msgstr "FOUT"
 
-#: ../../vdms_panels/sequence_to_video.py:707
-msgid "Shortest"
-msgstr ""
-
-#: ../../vdms_panels/sequence_to_video.py:715
 msgid ""
 "Items to concatenate\n"
 "Output filename\n"
@@ -3406,7 +2600,6 @@ msgid ""
 "Overall video duration"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:50
 msgid ""
 "\n"
 "1. Import one or more video files, then select one.\n"
@@ -3423,51 +2616,39 @@ msgid ""
 "with a progressive digit, in the path you specify."
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:86
 msgid "Create thumbnails"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:87
 msgid "Create tiled mosaics"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:88
 msgid "Create animated GIF"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:90
 msgid "Options"
 msgstr "Opties"
 
-#: ../../vdms_panels/video_to_sequence.py:119
 msgid "Output format:"
 msgstr "Output Formaat:"
 
-#: ../../vdms_panels/video_to_sequence.py:131
 msgid "Rows:"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:141
 msgid "Columns:"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:205
 msgid "Other unofficial resources:"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:229
 msgid "Set FPS control from 0.1 to 30.0 fps. The higher this value, the more images will be extracted."
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:232
 msgid "Spaces around the mosaic tiles. From 0 to 32 pixels"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:234
 msgid "Spaces around the mosaic borders. From 0 to 32 pixels"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:626
 msgid ""
 "Selected File\n"
 "Output Format\n"
@@ -3483,58 +2664,45 @@ msgid ""
 "Duration"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:118
 msgid "Audio encoder settings, mapping and filters"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:128
 msgid "Audio Encoder"
 msgstr "Audio Encoder"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:137
 msgid "Settings"
 msgstr "Instellingen"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:148
 msgid "Index Selection:"
 msgstr "Index Selectie:"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:157
 msgid "Map:"
 msgstr "Map:"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:180
 msgid "Normalization"
 msgstr "Normalisatie"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:191
 msgid "Volume detect"
 msgstr "Volume detectering"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:195
 msgid "Volume Statistics"
 msgstr "Volume Statistieken"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:199
 msgid "Target level:"
 msgstr "Doel niveau:"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:264
 msgid "Gets maximum volume and average volume data in dBFS, then calculates the offset amount for audio normalization."
 msgstr "Verkrijgt maximum volume en gemiddelde volume data in dBFS, en berekent vervolgens de hoeveelheid offset voor audio normalisatie."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:267
 msgid "Limiter for the maximum peak level or the mean level (when switch to RMS) in dBFS. From -99.0 to +0.0; default for PEAK level is -1.0; default for RMS is -20.0"
 msgstr "Beperker voor het maximum peak level of het mean level (wanneer overgang naar RMS) in dBFS. Van -99.0 tot +0.0; standaard voor PEAK level is -1.0; standaard voor RMS is -20.0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:271
 msgid ""
 "Normally on a video with correctly indexed streams and having one or more audio streams, the first audio stream should be indexed at \"1\", the second at \"2\" and so on (the video stream on the other hand is always indexed at \"0\"). In this case it is recommended to select the desired stream by setting a specific index, e.g \"1\" for for the first available audio stream.\n"
 "\n"
 "Set this control to \"Auto\" if the source file is simply an audio track."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:280
 #, fuzzy
 msgid ""
 "\"Auto\" keeps all audio streams and processes only the one selected by the \"Index Selection\" control.\n"
@@ -3544,30 +2712,24 @@ msgid ""
 "\"Index Only\" processes only the audio stream selected by the \"Index Selection\" control and removes all others from the video"
 msgstr "\"Auto\" behoudt alle audio streams maar converteert alleen de geselecteerde; \"Allemaal\" behoudt alle audio streams en converteert deze allemaal; \"Index only\" behoudt en converteert alleen de geselecteerde audio stream."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:288
 #, fuzzy
 msgid "Integrated Loudness Target in LUFS. From -70.0 to -5.0, default is -16.0"
 msgstr "Geïntegreerd Loudness Doel in LUFS. Van -70.0 tot -5.0, standaard is -24.0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:291
 #, fuzzy
 msgid "Maximum True Peak in dBTP. From -1.5 to +0.0, default is -2.0"
 msgstr "Maximum Ware Peak in dBTP. Van -9.0 tot +0.0, standaard is -2.0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:294
 #, fuzzy
 msgid "Loudness Range Target in LUFS. From +1.0 to +20.0, default is +11.0"
 msgstr "Loudness Bereik Doel in LUFS. Van +1.0 tot +20.0, standaard is +7.0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:297
 msgid "Play the audio stream selected in the \"Index Selection\" control. Using this function you can test the result of audio normalization."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:503
 msgid "Selected index does not exist or does not contain any audio streams"
 msgstr "Gekozen index bestaat niet of bevat geen audio"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:508
 #, python-brace-format
 msgid ""
 "ERROR: Missing audio stream:\n"
@@ -3576,47 +2738,38 @@ msgstr ""
 "FOUT: Audio ontbreekt:\n"
 "\"{}\""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:726
 #, fuzzy
 msgid "PEAK level normalization, which will produce a maximum peak level equal to the set target level."
 msgstr "Activeer peak level normalisatie, wat een maximum peak level zal geven gelijk aan het ingestelde doel-level."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:729
 #, fuzzy
 msgid "RMS-based normalization, which according to mean volume calculates the amount of gain to reach same average power signal."
 msgstr "Activeer op RMS gebaseerde normalisatie, welke volgens het mean volume de hoeveelheid gain berekent om dezelfde gemiddelde signaal-sterkte te bereiken."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:733
 #, fuzzy
 msgid ""
 "Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements the EBU R128 algorithm.\n"
 "Ideal for live normalization. It produces worse results than the High-quality two-pass Loudnorm normalization, but is faster."
 msgstr "Activeer twee-pass normalisatie. Het normaliseert de ervaarde loudness door gebruikmaking van het \"​loudnorm\" filter, wat het EBU R128 algoritme toepast."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:740
 #, fuzzy
 msgid ""
 "High-quality two-pass Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements\n"
 "the EBU R128 algorithm. Ideal for postprocessing."
 msgstr "Activeer twee-pass normalisatie. Het normaliseert de ervaarde loudness door gebruikmaking van het \"​loudnorm\" filter, wat het EBU R128 algoritme toepast."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:789
 msgid "You need to import at least one file"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:63
 msgid "Subtitle Mapping:"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:77
 msgid "Copy Chapters"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:79
 msgid "Copy Metadata"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:85
 msgid ""
 "Select \"All\" to include any source file subtitles in the output video.\n"
 "\n"
@@ -3625,158 +2778,74 @@ msgid ""
 "This option is automatically ignored for output audio files."
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:90
 msgid "Copy the chapter markers as is from source file. This option is automatically ignored for output audio files."
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:93
 msgid "Copy all incoming metadata from source file, such as audio/video tags, titles, unique marks, and so on."
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:108
 #, fuzzy
 msgid "Additional options"
 msgstr "print meer opties"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:89
-#: ../../vdms_panels/video_encoders/av1_svt.py:120
-#: ../../vdms_panels/video_encoders/avc_x264.py:90
-#: ../../vdms_panels/video_encoders/hevc_x265.py:98
-#: ../../vdms_panels/video_encoders/mpeg4.py:71
-#: ../../vdms_panels/video_encoders/vp9_webm.py:131
 #, fuzzy
 msgid "Reload"
 msgstr "Herlaad"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:101
-#: ../../vdms_panels/video_encoders/av1_svt.py:129
-#: ../../vdms_panels/video_encoders/avc_x264.py:101
-#: ../../vdms_panels/video_encoders/hevc_x265.py:109
-#: ../../vdms_panels/video_encoders/mpeg4.py:82
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:97
-#: ../../vdms_panels/video_encoders/vp9_webm.py:141
 #, fuzzy
 msgid "Optimize for Web"
 msgstr "Gebruik voor Web"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:247
-#: ../../vdms_panels/video_encoders/av1_svt.py:313
-#: ../../vdms_panels/video_encoders/avc_x264.py:242
-#: ../../vdms_panels/video_encoders/hevc_x265.py:250
-#: ../../vdms_panels/video_encoders/mpeg4.py:198
-#: ../../vdms_panels/video_encoders/vp9_webm.py:288
 msgid "Reloads the selected video encoder settings. Changes will be discarded."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:250
-#: ../../vdms_panels/video_encoders/avc_x264.py:273
-#: ../../vdms_panels/video_encoders/hevc_x265.py:277
-#: ../../vdms_panels/video_encoders/vp9_webm.py:291
 #, fuzzy
 msgid "Constant rate factor. Lower values correspond to higher quality and greater file size. Set to -1 to disable this control."
 msgstr "Constante rate factor. Lagere waarden = hogere kwaliteit en een hogere bestands-grootte. Zet op -1 om dit niet te gebruiken."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:254
-#: ../../vdms_panels/video_encoders/av1_svt.py:357
-#: ../../vdms_panels/video_encoders/vp9_webm.py:295
 msgid "Number of tile rows to use, default changes per resolution"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:256
-#: ../../vdms_panels/video_encoders/av1_svt.py:359
-#: ../../vdms_panels/video_encoders/vp9_webm.py:297
 msgid "Number of tile columns to use, default changes per resolution"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:259
-#: ../../vdms_panels/video_encoders/av1_svt.py:368
-#: ../../vdms_panels/video_encoders/avc_x264.py:253
-#: ../../vdms_panels/video_encoders/hevc_x265.py:261
-#: ../../vdms_panels/video_encoders/mpeg4.py:201
-#: ../../vdms_panels/video_encoders/vp9_webm.py:300
 #, fuzzy
 msgid "Set the Group Of Picture (GOP). Set to -1 to disable this control."
 msgstr "Specificeert een minimum tolerantie om te gebruiken"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:262
-#: ../../vdms_panels/video_encoders/av1_svt.py:371
-#: ../../vdms_panels/video_encoders/avc_x264.py:256
-#: ../../vdms_panels/video_encoders/hevc_x265.py:264
-#: ../../vdms_panels/video_encoders/mpeg4.py:204
-#: ../../vdms_panels/video_encoders/vp9_webm.py:303
 msgid "It can reduce the file size, but takes longer."
 msgstr "Het kan de bestands-grootte reduceren, maar duurt langer."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:264
-#: ../../vdms_panels/video_encoders/av1_svt.py:373
-#: ../../vdms_panels/video_encoders/avc_x264.py:258
-#: ../../vdms_panels/video_encoders/hevc_x265.py:266
-#: ../../vdms_panels/video_encoders/mpeg4.py:206
-#: ../../vdms_panels/video_encoders/vp9_webm.py:305
 #, fuzzy
 msgid "Set minimum bitrate tolerance. Most useful in setting up a CBR encode. It is of little use otherwise. Set to -1 to disable this control."
 msgstr "Specificeert een maximale tolerantie. Dit wordt alleen gebruikt samen met buffer-grootte"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:268
-#: ../../vdms_panels/video_encoders/av1_svt.py:377
-#: ../../vdms_panels/video_encoders/avc_x264.py:262
-#: ../../vdms_panels/video_encoders/hevc_x265.py:270
-#: ../../vdms_panels/video_encoders/mpeg4.py:210
-#: ../../vdms_panels/video_encoders/vp9_webm.py:309
 #, fuzzy
 msgid "Specifies a maximum tolerance. Requires bufsize to be set. Set to -1 to disable this control."
 msgstr "Specificeert een minimum tolerantie om te gebruiken"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:271
-#: ../../vdms_panels/video_encoders/av1_svt.py:380
-#: ../../vdms_panels/video_encoders/avc_x264.py:265
-#: ../../vdms_panels/video_encoders/hevc_x265.py:273
-#: ../../vdms_panels/video_encoders/mpeg4.py:213
-#: ../../vdms_panels/video_encoders/vp9_webm.py:312
 #, fuzzy
 msgid "Set ratecontrol buffer size, which determines the variability of the output bitrate. Set to -1 to disable this control."
 msgstr "Specificeert de buffer-grootte van de decoder, welke de veranderlijkheid van de output bitrate bepaalt "
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:275
-#: ../../vdms_panels/video_encoders/av1_svt.py:384
-#: ../../vdms_panels/video_encoders/avc_x264.py:277
-#: ../../vdms_panels/video_encoders/hevc_x265.py:281
-#: ../../vdms_panels/video_encoders/mpeg4.py:231
-#: ../../vdms_panels/video_encoders/vp9_webm.py:316
 #, fuzzy
 msgid "Specifies the target (average) bit rate for the encoder to use. Higher value = higher quality. Set -1 to disable this control."
 msgstr "specificeert de (gemiddelde) doel bit rate voor de te-gebruiken encoder. Hogere waarde = hogere kwaliteit. Zet op -1 om dit niet te gebruiken."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:279
-#: ../../vdms_panels/video_encoders/av1_svt.py:388
-#: ../../vdms_panels/video_encoders/avc_x264.py:281
-#: ../../vdms_panels/video_encoders/hevc_x265.py:285
-#: ../../vdms_panels/video_encoders/mpeg4.py:235
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:131
-#: ../../vdms_panels/video_encoders/vp9_webm.py:320
 msgid "Video width and video height ratio."
 msgstr "Video breedte en video hoogte ratio."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:281
-#: ../../vdms_panels/video_encoders/av1_svt.py:390
-#: ../../vdms_panels/video_encoders/avc_x264.py:283
-#: ../../vdms_panels/video_encoders/hevc_x265.py:287
-#: ../../vdms_panels/video_encoders/mpeg4.py:237
-#: ../../vdms_panels/video_encoders/vp9_webm.py:322
 #, fuzzy
 msgid "Frame rate (frames per second). Frames repeat a given number of times per second. In some countries this is 30 for NTSC, other countries (like Italy) use 25 for PAL"
 msgstr "Frames herhalen zich een opgegeven aantal maal per seconde. In sommige landen is dit 30 voor NTSC, andere landen (zoals Italië) gebruiken 25 voor PAL"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:285
 msgid "Quality/Speed ratio modifier. CPU Used sets how efficient the compression will be. Lower values mean slower encoding with better quality, and vice-versa. Valid values are from 0 to 8 inclusive."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:290
 #, fuzzy
 msgid "Quality and compression efficiency vs speed trade-off. \"good\" is the default and recommended for most applications; \"realtime\" is recommended for live/fast encoding (live streaming, video conferencing, etc); \"allintra\" for All Intra encoding."
 msgstr "\"goed\" is de standaard en aanbevolen voor de meeste applicaties; \"best\" is aanbevolen wanneer u geduld heeft en de beste compressie-efficiëntie wenst; \"realtime\" is aanbevolen voor live/snelle encoding"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:297
 msgid ""
 "Row Multi-Threading enables row-based multi-threading which maximizes CPU usage.\n"
 "\n"
@@ -3785,7 +2854,6 @@ msgid ""
 "Enabling Row Multi-Threading is only faster when the CPU has more threads than the number of encoded tiles."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:316
 msgid ""
 "presets 1-3 represent extremely high efficiency, for use when encode time is not important and quality/size of the resulting video file is critical.\n"
 "\n"
@@ -3796,7 +2864,6 @@ msgid ""
 "Preset 13 is even faster but not intended for direct human consumption--it can be used, for example, as a per-scene quality metric in VOD applications. One should use the lowest preset that is tolerable."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:327
 msgid ""
 "Constant rate factor. This parameter governs the quality/size trade-off.\n"
 "\n"
@@ -3807,7 +2874,6 @@ msgid ""
 "Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:334
 msgid ""
 "The \"Film Grain\" parameter allows SVT-AV1 to detect and delete film grain from the source video, and replace it with synthetic grain of the same character, resulting in significant bitrate savings.\n"
 "\n"
@@ -3820,81 +2886,58 @@ msgid ""
 "If the source video does not have natural grain, this parameter can be set to -1 to disable it or at least 0."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:346
 msgid ""
 "If enabled, the \"Film Grain Denoiser\" option can mitigate the detail removal caused by high \"Film Grain\" values required to preserve the look of very grainy films\n"
 "\n"
 "By default, the denoised frames are passed to be encoded as the final pictures, enabling this feature will lead to the original frames to be used instead. "
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:353
 msgid "Enables encoder optimization to produce faster (less CPU intensive) bit streams to decode, similar to the fastdecode tuning in x264 and x265."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:362
-#: ../../vdms_panels/video_encoders/avc_x264.py:247
-#: ../../vdms_panels/video_encoders/hevc_x265.py:255
 msgid "Set profile restrictions"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:364
-#: ../../vdms_panels/video_encoders/avc_x264.py:249
-#: ../../vdms_panels/video_encoders/hevc_x265.py:257
 #, fuzzy
 msgid "Specify level for a selected profile"
 msgstr "Verwijder het geselecteerde profiel"
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:366
-#: ../../vdms_panels/video_encoders/avc_x264.py:251
-#: ../../vdms_panels/video_encoders/hevc_x265.py:259
 msgid "Tune the encoding params"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/avc_x264.py:245
-#: ../../vdms_panels/video_encoders/hevc_x265.py:253
 msgid "Set the encoding preset (default \"medium\")"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/avc_x264.py:269
 msgid "specifies the target (average) bit rate for the encoder to use. Higher value = higher quality. Set -1 to disable this control."
 msgstr "specificeert de (gemiddelde) doel bit rate voor de te-gebruiken encoder. Hogere waarde = hogere kwaliteit. Zet op -1 om dit niet te gebruiken."
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:217
 msgid "Variable Bit Rate. From 0-30, with 1 being highest quality/largest filesize and 30 being the lowest quality/smallest filesize. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:222
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:133
 msgid "Frames repeat a given number of times per second. In some countries this is 30 for NTSC, other countries (like Italy) use 25 for PAL"
 msgstr "Frames herhalen zich een opgegeven aantal maal per seconde. In sommige landen is dit 30 voor NTSC, andere landen (zoals Italië) gebruiken 25 voor PAL"
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:226
 msgid "The default FourCC stored in an MPEG-4-coded file will be FMP4. If you want a different FourCC, set this option to xvid to force the FourCC xvid to be stored as the video FourCC rather than the default."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:162
 msgid "Copy Video Codec"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:163
 msgid ""
 "This will just copy the video track as is, without any video re-encoding.\n"
 "You will only be able to change output format, select other audio encoders and\n"
 "a few other options."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_no_enc.py:74
 msgid "Video export disabled"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_no_enc.py:75
 msgid ""
 "The Media target you just selected will only allow you to export files as audio tracks.\n"
 "You can then process audio source files only or extract indexed audio streams on\n"
 "video files."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:326
 msgid ""
 "Speed sets how efficient the compression will be.\n"
 "\n"
@@ -3907,7 +2950,6 @@ msgid ""
 "When the Quality is set to realtime, the available values for Speed are 0 to 8."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:335
 #, fuzzy
 msgid ""
 "Time to spend encoding.\n"
@@ -3919,25 +2961,22 @@ msgid ""
 "\"realtime\" is recommended for live / fast encoding."
 msgstr "\"goed\" is de standaard en aanbevolen voor de meeste applicaties; \"best\" is aanbevolen wanneer u geduld heeft en de beste compressie-efficiëntie wenst; \"realtime\" is aanbevolen voor live/snelle encoding"
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:341
-msgid "If enabled, adds support for row based multithreading which greatly enhances the number of threads the encoder can utilise. This improves encoding speed significantly on systems that are otherwise underutilised when encoding VP9. Since the amount of additional threads depends on the number of \"tiles\", which itself depends on the video resolution, encoding higher resolution videos will see a larger performance improvement."
+msgid ""
+"If enabled, adds support for row based multithreading which greatly enhances the number of threads the encoder can utilise. This improves encoding speed significantly on systems that are otherwise underutilised when encoding VP9. Since the amount of additional threads depends on the number of \"tiles\", which itself depends on the video resolution, encoding higher resolution videos will see a "
+"larger performance improvement."
 msgstr ""
 
-#: ../../vdms_utils/presets_manager_utils.py:46
 #, python-brace-format
 msgid "Supports ({0}) formats only, not ({1})"
 msgstr ""
 
-#: ../../vdms_utils/presets_manager_utils.py:49
 #, fuzzy
 msgid "File formats not supported by the selected profile"
 msgstr "Eerste pass van het geselecteerde profiel"
 
-#: ../../vdms_utils/presets_manager_utils.py:52
 msgid "Warning"
 msgstr "Waarschuwing"
 
-#: ../../vdms_utils/presets_manager_utils.py:90
 msgid ""
 "No presets found.\n"
 "\n"
@@ -3947,12 +2986,10 @@ msgstr ""
 "\n"
 "Mogelijke oplossing: open het Presets Manager paneel, ga naar de presets kolom en probeer de \"Herstel allen...\" knop te drukken"
 
-#: ../../vdms_utils/queue_utils.py:54
 #, fuzzy
 msgid "Import queue file"
 msgstr "Log folder"
 
-#: ../../vdms_utils/queue_utils.py:89
 #, python-brace-format
 msgid ""
 "ERROR: invalid data found loading queue file.\n"
@@ -3961,26 +2998,21 @@ msgid ""
 "Cannot contain multiple occurrences in `destination` keys value."
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:118
 #, fuzzy
 msgid "Videomass - Add Items to Queue"
 msgstr "Videomass - Wachtrij URLs"
 
-#: ../../vdms_utils/queue_utils.py:119
 msgid ""
 "Multiple items with identical names and destination paths cannot coexist.\n"
 "Please choose one of the following actions:"
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:123
 msgid "Replace occurrences with items from the imported queue."
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:124
 msgid "Add only the currently missing items to the queue."
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:125
 msgid "Remove the current queue and replace it with the imported one."
 msgstr ""
 
@@ -3992,4 +3024,7 @@ msgstr ""
 
 #~ msgid "Subtitle Mapping"
 #~ msgstr "Ondertitel Map"
+
+#~ msgid "Shortest"
+#~ msgstr ""
 

--- a/videomass/data/locale/pt_BR/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/pt_BR/LC_MESSAGES/videomass.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Videomass 5.0.18\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-30 11:02+0200\n"
+"POT-Creation-Date: 2025-07-30 15:28+0200\n"
 "PO-Revision-Date: 2024-07-03 18:48+0200\n"
 "Last-Translator: Samuel / http://littlesvr.ca/ostd/\n"
 "Language: pt_BR\n"
@@ -3013,16 +3013,4 @@ msgstr ""
 
 msgid "Remove the current queue and replace it with the imported one."
 msgstr ""
-
-#~ msgid "Some text boxes are still incomplete"
-#~ msgstr "Algumas caixas de texto ainda estão incompletas"
-
-#~ msgid "FFplay"
-#~ msgstr "FFplay"
-
-#~ msgid "Subtitle Mapping"
-#~ msgstr "Mapa de Legendas"
-
-#~ msgid "Shortest"
-#~ msgstr ""
 

--- a/videomass/data/locale/pt_BR/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/pt_BR/LC_MESSAGES/videomass.po
@@ -1,12 +1,13 @@
-# Portuguese (Brazil) (pt_BR) translation of videomass.pot
-# Generated 2021-03-31 23:51 using the Open Source Translation Database
-# http://littlesvr.ca/ostd/
+# Portuguese (Brazil) translations for Videomass.
+# Copyright (C) 2025 ORGANIZATION
+# This file is distributed under the same license as the Videomass project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Videomass 5.0.18\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-26 15:04+0200\n"
+"POT-Creation-Date: 2025-07-30 11:02+0200\n"
 "PO-Revision-Date: 2024-07-03 18:48+0200\n"
 "Last-Translator: Samuel / http://littlesvr.ca/ostd/\n"
 "Language: pt_BR\n"
@@ -17,7 +18,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
-#: ../../gui_app.py:196
 #, python-brace-format
 msgid ""
 "Unexpected error while deleting file contents:\n"
@@ -25,168 +25,117 @@ msgid ""
 "{0}"
 msgstr ""
 
-#: ../../vdms_dialogs/about_dialog.py:52
 msgid "Cross-platform graphical user interface for FFmpeg\n"
 msgstr ""
 
-#: ../../vdms_dialogs/audioproperties.py:224
 msgid "Videomass supports mono and stereo audio channels. If you are not sure set to \"Auto\" and source values will be copied."
 msgstr "Videomass oferece suporte a canais de áudio mono e estéreo. Se você não tiver certeza, defina como \"Auto\" e os valores da fonte serão copiados."
 
-#: ../../vdms_dialogs/audioproperties.py:228
 msgid "The audio Rate (or sample-rate) is the sound sampling frequency and is measured in Hertz. The higher the frequency, the more true it will be to the sound source and the more the file will increase in size. For audio CD playback, set a sampling frequency of 44100 kHz. If you are not sure, set to \"Auto\" and source values will be copied."
 msgstr "A taxa de áudio (ou taxa de amostragem) é a amostragem de frequência de som e é medido em Hertz. Quanto maior a frequência, mais parecido será com a fonte do som e mais o arquivo aumentará de tamanho. Para reprodução de CD de áudio, defina uma frequência de amostragem de 44100 kHz. Se você não tiver certeza, defina como \"Auto\" e os valores da fonte serão copiados."
 
-#: ../../vdms_dialogs/audioproperties.py:237
 msgid "The audio bitrate affects the file compression and thus the quality of listening. The higher the value, the higher the quality."
 msgstr "A taxa de bits de áudio afeta a compressão do arquivo e, portanto, a qualidade da escuta. Quanto maior o valor, maior será a qualidade."
 
-#: ../../vdms_dialogs/audioproperties.py:241
 msgid "Bit depth is the number of bits of information in each sample, and it directly corresponds to the resolution of each sample. Bit depth is only meaningful in reference to a PCM digital signal. Non-PCM formats, such as lossy compression formats, do not have associated bit depths."
 msgstr "Profundidade de bits é o número de bits de informação em cada amostra, e corresponde diretamente à resolução de cada amostra. A profundidade de bits só é significativa na referência a um sinal digital PCM. Formatos não PCM, como com perdas formatos de compressão, não têm profundidades de bits associadas."
 
-#: ../../vdms_dialogs/epilogue.py:74 ../../vdms_dialogs/queuedlg.py:120
 msgid "When finished, once the operations have been completed successfully:"
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:80 ../../vdms_dialogs/queuedlg.py:126
 #, fuzzy
 msgid "Trash the source files"
 msgstr "Exclua o perfil selecionado"
 
-#: ../../vdms_dialogs/epilogue.py:84 ../../vdms_dialogs/queuedlg.py:130
 #, fuzzy
 msgid "Clear the File List"
 msgstr "Nenhum arquivo selecionado"
 
-#: ../../vdms_dialogs/epilogue.py:91 ../../vdms_dialogs/queuedlg.py:142
-#: ../../vdms_main/main_frame.py:1322
 msgid "Run"
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:97
 #, fuzzy
 msgid "Videomass - Batch Mode"
 msgstr "Videomass - Gerenciador de predefinições"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:47
 msgid "FFmpeg encoders"
 msgstr "Codificadores FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:48
 #, fuzzy
 msgid "supported encoders"
 msgstr "Codificadores FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:50
 msgid "FFmpeg decoders"
 msgstr "Decodificadores FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:51
 #, fuzzy
 msgid "supported decoders"
 msgstr "Decodificadores FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:77
-#: ../../vdms_panels/av_conversions.py:293
 msgid "Video"
 msgstr "Vídeo"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:87
-#: ../../vdms_panels/av_conversions.py:305
 msgid "Audio"
 msgstr "Áudio"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:97
 msgid "Subtitle"
 msgstr "Legenda"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:114
-#: ../../vdms_dialogs/ffmpeg_codecs.py:123
-#: ../../vdms_dialogs/ffmpeg_codecs.py:132
-#: ../../vdms_dialogs/ffmpeg_formats.py:112
-#: ../../vdms_dialogs/ffmpeg_formats.py:115
-#: ../../vdms_dialogs/ffmpeg_formats.py:118
 msgid "description"
 msgstr "descrição"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:72
 msgid "Informations"
 msgstr "Informações"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:83
 msgid "Flags settings"
 msgstr "Configurações de sinalizadores"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:93
 msgid "Flags enabled"
 msgstr "Sinalizadores ativados"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:103
 msgid "Flags disabled"
 msgstr "Sinalizadores desativados"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:116
 msgid "FFmpeg configuration"
 msgstr "Configuração do FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:124
 msgid "flags"
 msgstr "sinalizadores"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:125 ../../vdms_dialogs/ffmpeg_conf.py:129
-#: ../../vdms_dialogs/ffmpeg_conf.py:133
 msgid "options"
 msgstr "opções"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:128 ../../vdms_dialogs/ffmpeg_conf.py:132
 msgid "status"
 msgstr "status"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:167
 msgid "FFprobe   ...not found !"
 msgstr "FFprobe ... não encontrado!"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:175
 msgid "FFplay   ...not found !"
 msgstr "FFplay ... não encontrado!"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:205
-#: ../../vdms_panels/sequence_to_video.py:706
-#: ../../vdms_panels/video_to_sequence.py:606
 msgid "Enabled"
 msgstr "Ativado"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:216
-#: ../../vdms_panels/sequence_to_video.py:706
-#: ../../vdms_panels/video_to_sequence.py:610
 msgid "Disabled"
 msgstr "Desabilitado"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:71
 msgid "Demuxing only"
 msgstr "Apenas demultiplexação"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:82
 msgid "Muxing only"
 msgstr "Apenas multiplexação"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:93
 msgid "Demuxing/Muxing support"
 msgstr "Suporte para demultiplexação / multiplexação"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:104
 msgid "FFmpeg file formats"
 msgstr "Formatos de arquivo FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:111
-#: ../../vdms_dialogs/ffmpeg_formats.py:114
-#: ../../vdms_dialogs/ffmpeg_formats.py:117
 #, fuzzy
 msgid "supported formats"
 msgstr "Lista de formatos suportados"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:46
 msgid ""
 "Contextual help based on the argument entered in the additional text field.\n"
 "Each argument consists of the type and a type-specific name.\n"
@@ -201,132 +150,99 @@ msgid ""
 "Some examples:"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:68 ../../vdms_dialogs/ffmpeg_help.py:301
-#: ../../vdms_dialogs/ffmpeg_help.py:315
 #, fuzzy
 msgid "Help topic"
 msgstr "lista de tópicos de ajuda"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:69
 #, fuzzy
 msgid "List basic options"
 msgstr "mostrar opções básicas"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:70
 #, fuzzy
 msgid "List more options"
 msgstr "mostrar mais opções"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:71
 #, fuzzy
 msgid "List all options (very long)"
 msgstr "mostrar todas as opções (muito longo)"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:72
 #, fuzzy
 msgid "Show available devices"
 msgstr "mostrar dispositivos disponíveis"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:73
 #, fuzzy
 msgid "Show available bit stream filters"
 msgstr "mostrar filtros de fluxo de bits disponíveis"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:74
 #, fuzzy
 msgid "Show available protocols"
 msgstr "mostrar protocolos disponíveis"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:75
 #, fuzzy
 msgid "Show available filters"
 msgstr "mostrar filtros disponíveis"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:76
 #, fuzzy
 msgid "Show available pixel formats"
 msgstr "mostrar formatos de pixel disponíveis"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:77
 #, fuzzy
 msgid "Show available audio sample formats"
 msgstr "mostrar formatos de amostra de áudio disponíveis"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:78
 #, fuzzy
 msgid "Show available color names"
 msgstr "mostrar nomes de cores disponíveis"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:79
 #, fuzzy
 msgid "List sources of the input device"
 msgstr "listar as fontes do dispositivo de entrada"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:80
 #, fuzzy
 msgid "List sinks of the output device"
 msgstr "listar coletores do dispositivo de saída"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:81
 #, fuzzy
 msgid "Show available HW acceleration methods"
 msgstr "mostrar métodos de aceleração HW disponíveis"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:82
 msgid "Show license"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:117 ../../vdms_dialogs/filter_scale.py:76
-#: ../../vdms_dialogs/shownormlist.py:98 ../../vdms_dialogs/shownormlist.py:107
-#: ../../vdms_dialogs/shownormlist.py:116 ../../vdms_miniframes/timeline.py:263
-#: ../../vdms_miniframes/timeline.py:283 ../../vdms_panels/concatenate.py:117
-#: ../../vdms_panels/sequence_to_video.py:117
-#: ../../vdms_panels/video_to_sequence.py:81
 #, fuzzy
 msgid "Read me"
 msgstr "Pronto"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:123 ../../vdms_main/main_frame.py:534
 msgid "Show configuration"
 msgstr "Exibir configuração"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:127 ../../vdms_main/main_frame.py:542
 msgid "Encoders"
 msgstr "Codificadores"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:131 ../../vdms_main/main_frame.py:545
 msgid "Decoders"
 msgstr "Decodificadores"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:135 ../../vdms_main/main_frame.py:538
 msgid "Muxers and Demuxers"
 msgstr "Muxers e Demuxers"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:165
 msgid "help topic list"
 msgstr "lista de tópicos de ajuda"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:184
 msgid "Type the argument here and confirm with the enter key on your keyboard"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:192
 msgid "The search function allows you to find entries in the current topic"
 msgstr "A função de pesquisa permite que você encontre entradas no tópico atual"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:195
 msgid "Ignore case"
 msgstr "Ignorar maiúsculas / minúsculas"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:196
 msgid "Ignore case distinctions: characters with different case will match."
 msgstr "Ignorar distinções de maiúsculas e minúsculas: os caracteres com maiúsculas e minúsculas serão iguais."
 
-#: ../../vdms_dialogs/ffmpeg_help.py:206
 msgid "FFmpeg help topics"
 msgstr "Tópicos de ajuda do FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:254
 msgid ""
 "This is a multifunctional search tool useful for local help searches\n"
 "on multiple FFmpeg topics and options. The search control, to\n"
@@ -339,8 +255,6 @@ msgid ""
 "with those features."
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:320 ../../vdms_dialogs/ffmpeg_help.py:345
-#: ../../vdms_dialogs/ffmpeg_help.py:371
 msgid ""
 "\n"
 "  ..Nothing available"
@@ -348,7 +262,6 @@ msgstr ""
 "\n"
 "..Nada disponível"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:391
 #, fuzzy
 msgid ""
 "\n"
@@ -357,224 +270,128 @@ msgstr ""
 "\n"
 "...Não encontrado"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:91
 msgid "Before"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:97
 msgid "After"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:103
-#: ../../vdms_dialogs/filter_crop.py:239
 msgid "Search for a specific frame"
 msgstr "Procure por um quadro específico"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:117
-#: ../../vdms_dialogs/filter_crop.py:253
 msgid "Load"
 msgstr "Carregar"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:120
 msgid "Color EQ"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:126
 #, fuzzy
 msgid "Contrast:"
 msgstr "Contêiner:"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:134
-#: ../../vdms_dialogs/filter_colorcorrection.py:148
 msgid "-100 to +100, default value 0"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:139
 msgid "Brightness:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:158
 #, fuzzy
 msgid "Saturation:"
 msgstr "Duração"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:166
 msgid "0 to 300, default value 100"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:170
 msgid "Gamma:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:179
 msgid "0 to 100, default value 10"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:187
-#: ../../vdms_dialogs/filter_crop.py:306
-#: ../../vdms_dialogs/filter_deinterlace.py:209
-#: ../../vdms_dialogs/filter_denoisers.py:110
-#: ../../vdms_dialogs/filter_scale.py:210 ../../vdms_dialogs/filter_stab.py:316
-#: ../../vdms_dialogs/filter_transpose.py:105
-#: ../../vdms_miniframes/timeline.py:262 ../../vdms_miniframes/timeline.py:281
 msgid "Reset"
 msgstr "Resetar"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:207
 msgid "Color Correction EQ Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:343
-#: ../../vdms_dialogs/filter_colorcorrection.py:383
-#: ../../vdms_dialogs/filter_colorcorrection.py:390
-#: ../../vdms_dialogs/filter_crop.py:417 ../../vdms_dialogs/filter_scale.py:287
-#: ../../vdms_dialogs/filter_scale.py:394 ../../vdms_dialogs/filter_stab.py:473
-#: ../../vdms_dialogs/filter_stab.py:483 ../../vdms_dialogs/filter_stab.py:494
-#: ../../vdms_dialogs/filter_transpose.py:182
-#: ../../vdms_dialogs/mediainfo.py:245 ../../vdms_dialogs/mediainfo.py:265
-#: ../../vdms_dialogs/mediainfo.py:285 ../../vdms_dialogs/mediainfo.py:305
-#: ../../vdms_dialogs/setting_profiles.py:281
-#: ../../vdms_dialogs/setting_profiles.py:289 ../../vdms_io/checkup.py:45
-#: ../../vdms_io/checkup.py:93 ../../vdms_io/io_tools.py:144
-#: ../../vdms_main/main_frame.py:904 ../../vdms_main/main_frame.py:939
-#: ../../vdms_main/main_frame.py:961 ../../vdms_main/main_frame.py:979
-#: ../../vdms_main/main_frame.py:999
-#: ../../vdms_panels/audio_encoders/acodecs.py:510
-#: ../../vdms_panels/audio_encoders/acodecs.py:800
-#: ../../vdms_panels/concatenate.py:186
-#: ../../vdms_panels/long_processing_task.py:60
-#: ../../vdms_panels/presets_manager.py:426
-#: ../../vdms_panels/presets_manager.py:490
-#: ../../vdms_panels/presets_manager.py:560
-#: ../../vdms_panels/presets_manager.py:599
-#: ../../vdms_panels/presets_manager.py:619
-#: ../../vdms_panels/presets_manager.py:657
-#: ../../vdms_panels/presets_manager.py:701
-#: ../../vdms_panels/presets_manager.py:714
-#: ../../vdms_panels/presets_manager.py:721
-#: ../../vdms_panels/presets_manager.py:756
-#: ../../vdms_panels/presets_manager.py:785
-#: ../../vdms_panels/presets_manager.py:791
-#: ../../vdms_panels/sequence_to_video.py:467
-#: ../../vdms_panels/sequence_to_video.py:473
-#: ../../vdms_panels/sequence_to_video.py:561
-#: ../../vdms_panels/sequence_to_video.py:571
-#: ../../vdms_panels/sequence_to_video.py:588
-#: ../../vdms_panels/sequence_to_video.py:596
-#: ../../vdms_panels/sequence_to_video.py:602
-#: ../../vdms_panels/sequence_to_video.py:643
-#: ../../vdms_panels/sequence_to_video.py:689
-#: ../../vdms_panels/video_to_sequence.py:512
-#: ../../vdms_panels/video_to_sequence.py:583
-#: ../../vdms_threads/ffplay_file.py:43
-#: ../../vdms_utils/presets_manager_utils.py:86
-#: ../../vdms_utils/presets_manager_utils.py:95
-#: ../../vdms_utils/queue_utils.py:68 ../../vdms_utils/queue_utils.py:82
-#: ../../vdms_utils/queue_utils.py:95
 #, fuzzy
 msgid "Videomass - Error!"
 msgstr "Videomass - Carregando ..."
 
-#: ../../vdms_dialogs/filter_crop.py:228 ../../vdms_dialogs/filter_scale.py:109
 #, python-brace-format
 msgid "Source size: {0} x {1} pixels"
 msgstr "Tamanho da fonte: {0} x {1} pixels"
 
-#: ../../vdms_dialogs/filter_crop.py:236
 #, fuzzy
 msgid "Crop color"
 msgstr "Filtro de corte"
 
-#: ../../vdms_dialogs/filter_crop.py:256
 msgid "Cropping area selection "
 msgstr "Seleção da área de corte "
 
-#: ../../vdms_dialogs/filter_crop.py:261 ../../vdms_dialogs/filter_scale.py:121
 msgid "Height"
 msgstr "Altura"
 
-#: ../../vdms_dialogs/filter_crop.py:281
 msgid "Center"
 msgstr "Centralizar"
 
-#: ../../vdms_dialogs/filter_crop.py:292 ../../vdms_dialogs/filter_scale.py:121
 msgid "Width"
 msgstr "Largura"
 
-#: ../../vdms_dialogs/filter_crop.py:334
 #, fuzzy
 msgid "Crop Tool"
 msgstr "Filtro de corte"
 
-#: ../../vdms_dialogs/filter_crop.py:335
 msgid "Choose the color to draw the cropping area"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:337
 msgid "Crop to width"
 msgstr "Cortar na largura"
 
-#: ../../vdms_dialogs/filter_crop.py:338
 #, fuzzy
 msgid "Move vertically (set to -1 to center the vertical axis)"
 msgstr "Mover verticalmente - defina como -1 para centralizar o eixo vertical"
 
-#: ../../vdms_dialogs/filter_crop.py:340
 #, fuzzy
 msgid "Move horizontally (set to -1 to center the horizontal axis)"
 msgstr "Mova horizontalmente - defina como -1 para centralizar o eixo horizontal"
 
-#: ../../vdms_dialogs/filter_crop.py:342
 msgid "Crop to height"
 msgstr "Cortar na altura"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:56
 msgid "Advanced Options"
 msgstr "Opções Avançadas"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:57
-#: ../../vdms_panels/av_conversions.py:351
 msgid "Deinterlace"
 msgstr "Desentrelaçar"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:59
 msgid "Interlace"
 msgstr "Entrelaçar"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:63
 msgid "Deinterlaces with w3fdif filter"
 msgstr "Desentrelaçar com filtro w3fdif"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:77
 msgid "Deinterlaces with yadif filter"
 msgstr "Desentrelaça com filtro yadif"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:101
 msgid "Interlaces with interlace filter"
 msgstr "Entrelaço com filtro de entrelaçamento"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:118
 msgid "Deinterlacing and Interlacing"
 msgstr "Desentrelaçamento e entrelaçamento"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:144
 msgid "Deinterlace the input video with `w3fdif` filter"
 msgstr "Desentrelaçar o vídeo de entrada com o filtro `w3fdif`"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:146
 msgid "Set the interlacing filter coefficients."
 msgstr "Defina os coeficientes do filtro de entrelaçamento."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:148
-#: ../../vdms_dialogs/filter_deinterlace.py:158
 msgid "Specify which frames to deinterlace."
 msgstr "Especifique quais quadros serão desentrelaçados."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:150
 msgid "Deinterlace the input video with `yadif` filter. Using FFmpeg, this is the best and fastest choice"
 msgstr "Desentrelaçar o vídeo de entrada com o filtro `yadif`. Usando FFmpeg, esta é a melhor e mais rápida escolha"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:153
 msgid ""
 "mode\n"
 "The interlacing mode to adopt."
@@ -582,7 +399,6 @@ msgstr ""
 "modo\n"
 "O modo de entrelaçamento a ser adotado."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:155
 msgid ""
 "parity\n"
 "The picture field parity assumed for the input interlaced video."
@@ -590,11 +406,9 @@ msgstr ""
 "paridade\n"
 "A paridade do campo de imagem assumida para o vídeo entrelaçado de entrada."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:160
 msgid "Simple interlacing filter from progressive contents."
 msgstr "Filtro de entrelaçamento simples de conteúdos progressivos."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:162
 msgid ""
 "scan:\n"
 "determines whether the interlaced frame is taken from the even (tff - default) or odd (bff) lines of the progressive frame."
@@ -602,7 +416,6 @@ msgstr ""
 "varredura:\n"
 "determina se o quadro entrelaçado é obtido das linhas pares (tff - padrão) ou ímpares (bff) do quadro progressivo."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:166
 msgid ""
 "lowpass:\n"
 "Enable (default) or disable the vertical lowpass filter to avoid twitter interlacing and reduce moire patterns.\n"
@@ -612,33 +425,26 @@ msgstr ""
 "Ative (padrão) ou desative o filtro passa-baixo vertical para evitar o entrelaçamento do twitter e reduzir os padrões de moiré.\n"
 "O padrão é nenhuma configuração."
 
-#: ../../vdms_dialogs/filter_denoisers.py:56
 #, fuzzy
 msgid "Denoiser Filters"
 msgstr "Filtros de redução de ruído"
 
-#: ../../vdms_dialogs/filter_denoisers.py:60
 msgid "Enable nlmeans denoiser"
 msgstr "Habilitar redução de ruído nlmeans"
 
-#: ../../vdms_dialogs/filter_denoisers.py:73
 msgid "nlmeans options"
 msgstr "opções nlmeans"
 
-#: ../../vdms_dialogs/filter_denoisers.py:82
 msgid "Enable hqdn3d denoiser"
 msgstr "Habilitar redução de ruído hqdn3d"
 
-#: ../../vdms_dialogs/filter_denoisers.py:91
 msgid "hqdn3d options"
 msgstr "opções hqdn3d"
 
-#: ../../vdms_dialogs/filter_denoisers.py:116
 #, fuzzy
 msgid "Denoiser Tool"
 msgstr "Redução de ruído"
 
-#: ../../vdms_dialogs/filter_denoisers.py:117
 msgid ""
 "nlmeans:\n"
 "Denoise frames using Non-Local Means algorithm is capable of restoring video sequences, even with strong noise. It is ideal for enhancing the quality of old VHS tapes."
@@ -646,7 +452,6 @@ msgstr ""
 "nlmeans:\n"
 "redução de ruído usando o algoritmo Non-Local Means é capaz de restaurar sequências de vídeo mesmo com ruído forte. É ideal para melhorar a qualidade de fitas VHS antigas. ."
 
-#: ../../vdms_dialogs/filter_denoisers.py:122
 msgid ""
 "hqdn3d:\n"
 "This is a high precision/quality 3d denoise filter. It aims to reduce image noise, producing smooth images and making still images really still. It should enhance compressibility."
@@ -654,65 +459,48 @@ msgstr ""
 "hqdn3d:\n"
 "Este é um filtro de redução de ruído 3D, de alta precisão / qualidade. Seu objetivo é reduzir o ruído da imagem, produzindo imagens suaves e tornando as imagens estáticas realmente estáticas. Isso deve aumentar a compressibilidade."
 
-#: ../../vdms_dialogs/filter_scale.py:81
 msgid "View result"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:85
 msgid "New size in pixels"
 msgstr "Novo tamanho em pixels"
 
-#: ../../vdms_dialogs/filter_scale.py:89
 msgid "Width:"
 msgstr "Largura:"
 
-#: ../../vdms_dialogs/filter_scale.py:99
 msgid "Height:"
 msgstr "Altura:"
 
-#: ../../vdms_dialogs/filter_scale.py:115
 msgid "Constrain proportions (keep aspect ratio)"
 msgstr "Restringir proporções (manter proporção)"
 
-#: ../../vdms_dialogs/filter_scale.py:120
 msgid "Which dimension to adjust?"
 msgstr "Qual dimensão ajustar?"
 
-#: ../../vdms_dialogs/filter_scale.py:129
 msgid "Aspect Ratio"
 msgstr "Proporção da tela"
 
-#: ../../vdms_dialogs/filter_scale.py:132
 msgid "Setdar filter (display aspect ratio) example 16/9, 4/3 "
 msgstr "Filtro Setdar (proporção de exibição), exemplo 16/9, 4/3 "
 
-#: ../../vdms_dialogs/filter_scale.py:137
-#: ../../vdms_dialogs/filter_scale.py:171
 msgid "Numerator"
 msgstr "Numerador"
 
-#: ../../vdms_dialogs/filter_scale.py:162
-#: ../../vdms_dialogs/filter_scale.py:196
 msgid "Denominator"
 msgstr "Denominador"
 
-#: ../../vdms_dialogs/filter_scale.py:166
 msgid "Setsar filter (sample aspect ratio) example 1/1"
 msgstr "Filtro Setsar (proporção da amostra), exemplo 1/1"
 
-#: ../../vdms_dialogs/filter_scale.py:217
 msgid "Resize Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:218
 msgid "Scale filter, set to 0 to disable"
 msgstr "Filtro de escala, defina como 0 para desativar"
 
-#: ../../vdms_dialogs/filter_scale.py:221
 msgid "Display Aspect Ratio. Set to 0 to disable"
 msgstr "Proporção da tela. Defina como 0 para desativar"
 
-#: ../../vdms_dialogs/filter_scale.py:224
 msgid ""
 "Sample (aka Pixel) Aspect Ratio.\n"
 "Set to 0 to disable"
@@ -720,7 +508,6 @@ msgstr ""
 "Proporção de amostra (também conhecida como Pixel).\n"
 "Defina como 0 para desativar"
 
-#: ../../vdms_dialogs/filter_scale.py:366
 msgid ""
 "If you want to keep the aspect ratio, select \"Constrain proportions\" below and\n"
 "specify only one dimension, either width or height, and set the other dimension\n"
@@ -730,457 +517,350 @@ msgstr ""
 "especifique apenas uma dimensão, largura ou altura, e defina a outra dimensão\n"
 "para -1 ou -2 (alguns codecs exigem -2, então você deve fazer alguns testes primeiro)."
 
-#: ../../vdms_dialogs/filter_stab.py:81
 msgid "Enable stabilizer"
 msgstr "Ativar estabilizador"
 
-#: ../../vdms_dialogs/filter_stab.py:83
 msgid "Create a side-by-side comparison video"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:88
 #, fuzzy
 msgid "Create a snapshot"
 msgstr "Crie uma nova predefinição"
 
-#: ../../vdms_dialogs/filter_stab.py:106
-#: ../../vdms_panels/audio_encoders/acodecs.py:167
 msgid "Preview"
 msgstr "Pré-visualizar"
 
-#: ../../vdms_dialogs/filter_stab.py:109
 #, fuzzy
 msgid "Duration seconds:"
 msgstr "Duração"
 
-#: ../../vdms_dialogs/filter_stab.py:118
 msgid "Video Detect"
 msgstr "Detecção de vídeo"
 
-#: ../../vdms_dialogs/filter_stab.py:176
 msgid "[TRIPOD] Enable tripod mode if checked"
 msgstr "[TRIPÉ] Ative o modo tripé se estiver marcado"
 
-#: ../../vdms_dialogs/filter_stab.py:183
 msgid "Video transform"
 msgstr "Transformação de vídeo"
 
-#: ../../vdms_dialogs/filter_stab.py:202
 msgid "[OPTALGO] optimization algorithm"
 msgstr "[OPTALGO] Algoritmo de otimização"
 
-#: ../../vdms_dialogs/filter_stab.py:224
 msgid "[CROP] Specify how to deal with borders at movement compensation"
 msgstr "[CORTAR] Especifique como lidar com as bordas na compensação de movimento"
 
-#: ../../vdms_dialogs/filter_stab.py:231
 msgid "[INVERT] Invert transforms if checked"
 msgstr "[INVERTER] Inverter transformações se marcado"
 
-#: ../../vdms_dialogs/filter_stab.py:234
 msgid "[RELATIVE] Consider transforms as relative to previous frame if checked, absolute if unchecked"
 msgstr "[RELATIVO] Considere as transformações como relativas ao quadro anterior se marcado, absoluto se não marcado"
 
-#: ../../vdms_dialogs/filter_stab.py:279
 msgid "Specify type of interpolation"
 msgstr "Especifique o tipo de interpolação"
 
-#: ../../vdms_dialogs/filter_stab.py:287
 msgid "[TRIPOD2] virtual tripod mode, equivalent to relative=unchecked:smoothing=0"
 msgstr "[TRIPÉ2]modo de tripé virtual, equivalente a relativo = desmarcado: suavização = 0"
 
-#: ../../vdms_dialogs/filter_stab.py:294
 msgid "Unsharp filter:"
 msgstr "Filtro de nitidez:"
 
-#: ../../vdms_dialogs/filter_stab.py:323
 msgid "Seek to a position on the video."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:325
 msgid "Make a snapshot of the video with the settings made."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:327
 msgid "Set the snapshot duration from 3 to 15 seconds from the seek position, default is 5 seconds."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:331
 msgid "Set how shaky the video is and how quick the camera is. A value of 1 means little shakiness, a value of 10 means strong shakiness. Default value is 5."
 msgstr "Defina o quão trêmulo é o vídeo e a velocidade da câmera. Um valor de 1 significa pouca instabilidade, um valor de 10 significa instabilidade forte. O valor padrão é 5."
 
-#: ../../vdms_dialogs/filter_stab.py:335
 msgid "Set the accuracy of the detection process. A value of 1 means low accuracy, a value of 15 means high accuracy. Default value is 15."
 msgstr "Defina a precisão do processo de detecção. Um valor de 1 significa baixa precisão, um valor de 15 significa alta precisão. O valor padrão é 15."
 
-#: ../../vdms_dialogs/filter_stab.py:339
 msgid "Set stepsize of the search process. The region around minimum is scanned with 1 pixel resolution. Default value is 6."
 msgstr "Defina o tamanho da etapa do processo de pesquisa. A região em torno do mínimo é digitalizada com resolução de 1 pixel. O valor padrão é 6."
 
-#: ../../vdms_dialogs/filter_stab.py:343
 msgid "Set minimum contrast. Below this value a local measurement field is discarded. The range is 0-1. Default value is 0.25."
 msgstr "Defina o contraste mínimo. Abaixo desse valor, um campo de medição local é descartado. O intervalo é 0-1. O valor padrão é 0,25."
 
-#: ../../vdms_dialogs/filter_stab.py:346
 msgid "Set reference frame number for tripod mode. If enabled, the motion of the frames is compared to a reference frame in the filtered stream, identified by the specified number. The idea is to compensate all movements in a more-or-less static scene and keep the camera view absolutely still. The frames are counted starting from 1."
 msgstr "Defina o número do quadro de referência para o modo tripé. Se ativado, o movimento dos quadros é comparado a um quadro de referência no fluxo filtrado, identificado pelo número especificado. A ideia é compensar todos os movimentos em uma cena mais ou menos estática e manter a visão da câmera absolutamente imóvel. Os frames são contados a partir de 1."
 
-#: ../../vdms_dialogs/filter_stab.py:355
-msgid "Set the number of frames (value*2 + 1) used for lowpass filtering the camera movements. Default value is 15. For example a number of 10 means that 21 frames are used (10 in the past and 10 in the future) to smoothen the motion in the video. A larger value leads to a smoother video, but limits the acceleration of the camera (pan/tilt movements). 0 is a special case where a static camera is simulated."
-msgstr "Defina o número de quadros (valor * 2 + 1) usado para filtrar em lowpass os movimentos da câmera. O valor padrão é 15. Por exemplo, um número de 10 significa que 21 quadros são usados (10 no passado e 10 no futuro) para suavizar o movimento no vídeo. Um valor maior leva a um vídeo mais uniforme, mas limita a aceleração da câmera (movimentos de panorâmica / inclinação). 0 é um caso especial em que uma câmera estática é simulada."
+msgid ""
+"Set the number of frames (value*2 + 1) used for lowpass filtering the camera movements. Default value is 15. For example a number of 10 means that 21 frames are used (10 in the past and 10 in the future) to smoothen the motion in the video. A larger value leads to a smoother video, but limits the acceleration of the camera (pan/tilt movements). 0 is a special case where a static camera is "
+"simulated."
+msgstr ""
+"Defina o número de quadros (valor * 2 + 1) usado para filtrar em lowpass os movimentos da câmera. O valor padrão é 15. Por exemplo, um número de 10 significa que 21 quadros são usados (10 no passado e 10 no futuro) para suavizar o movimento no vídeo. Um valor maior leva a um vídeo mais uniforme, mas limita a aceleração da câmera (movimentos de panorâmica / inclinação). 0 é um caso especial em "
+"que uma câmera estática é simulada."
 
-#: ../../vdms_dialogs/filter_stab.py:363
 #, fuzzy
 msgid "Set the camera path optimization algorithm. Values are: `gauss`: gaussian kernel low-pass filter on camera motion (default), and `avg`: averaging on transformations"
 msgstr "Defina o caminho do algoritmo de otimização da câmera. Os valores são: ‘gauss’: filtro low-pass do kernel gaussiano no movimento da câmera (padrão), ‘avg’ Média nas transformações"
 
-#: ../../vdms_dialogs/filter_stab.py:367
 msgid "Set maximal angle in radians (degree*PI/180) to rotate frames. Default value is -1, meaning no limit."
 msgstr "Defina o ângulo máximo em radianos (grau * PI / 180) para girar os quadros. O valor padrão é -1, o que significa sem limite."
 
-#: ../../vdms_dialogs/filter_stab.py:370
 #, fuzzy
 msgid "Specify how to deal with borders that may be visible due to movement compensation. Values are: `keep` keep image information from previous frame (default), `black` fill the border black"
 msgstr "Especifique como lidar com bordas que podem ser visíveis devido à compensação de movimento. Os valores são: ‘manter’ manter as informações da imagem do quadro anterior (padrão), ‘preto’ preencher a borda preta"
 
-#: ../../vdms_dialogs/filter_stab.py:375
 msgid "Invert transforms if checked. Default is unchecked."
 msgstr "Inverter transformações se marcado. O padrão é desmarcado."
 
-#: ../../vdms_dialogs/filter_stab.py:377
 msgid "Consider transforms as relative to previous frame if checked, absolute if unchecked. Default is checked."
 msgstr "Considere as transformações como relativas ao quadro anterior se marcado, absoluto se desmarcado. O padrão é verificado."
 
-#: ../../vdms_dialogs/filter_stab.py:380
 msgid "Set percentage to zoom. A positive value will result in a zoom-in effect, a negative value in a zoom-out effect. Default value is 0 (no zoom)."
 msgstr "Defina a porcentagem para ampliar. Um valor positivo resultará em um efeito de mais zoom, um valor negativo em um efeito de menos zoom. O valor padrão é 0 (sem zoom)."
 
-#: ../../vdms_dialogs/filter_stab.py:384
 #, fuzzy
 msgid "Set optimal zooming to avoid borders. Accepted values are: `0` disabled, `1` optimal static zoom value is determined (only very strong movements will lead to visible borders) (default), `2` optimal adaptive zoom value is determined (no borders will be visible), see zoomspeed. Note that the value given at zoom is added to the one calculated here."
 msgstr "Defina o zoom ideal para evitar bordas. Os valores aceitos são: '0' desativado, o valor de zoom estático ideal '1' é determinado (apenas movimentos muito fortes levarão a bordas visíveis) (padrão), o valor de zoom adaptativo ideal '2' é determinado (nenhuma borda será visível), veja a velocidade do zoom. Observe que o valor fornecido no zoom é adicionado ao calculado aqui."
 
-#: ../../vdms_dialogs/filter_stab.py:391
 msgid "Set percent to zoom maximally each frame (enabled when optzoom is set to 2). Range is from 0 to 5, default value is 0.25."
 msgstr "Defina a porcentagem para aumentar ao máximo cada quadro (habilitado quando optzoom é definido como 2). O intervalo é de 0 a 5, o valor padrão é 0,25."
 
-#: ../../vdms_dialogs/filter_stab.py:395
 #, fuzzy
 msgid "Specify type of interpolation. Available values are: `no` no interpolation, `linear` linear only horizontal, `bilinear` linear in both directions (default), `bicubic` cubic in both directions (slow)"
 msgstr "Especifique o tipo de interpolação. Os valores disponíveis são: ‘não’ sem interpolação, ‘linear’ linear apenas horizontal, ‘bilinear’ linear em ambas as direções (padrão), ‘bicúbico’ cúbico em ambas as direções (lento)"
 
-#: ../../vdms_dialogs/filter_stab.py:400
 msgid "Enable virtual tripod mode if checked, which is equivalent to relative=0:smoothing=0. Default is unchecked. Use also tripod option of vidstabdetect."
 msgstr "Habilite o modo de tripé virtual se marcado, que é equivalente a relativo = 0: suavização = 0. O padrão é desmarcado. Use também a opção de tripé do vidstabdetect."
 
-#: ../../vdms_dialogs/filter_stab.py:405
 msgid "Sharpen or blur the input video. Note the use of the unsharp filter which is always recommended."
 msgstr "Tornar mais nítido ou mais desfocado o vídeo de entrada. Observe o uso do filtro unsharp que é sempre recomendado."
 
-#: ../../vdms_dialogs/filter_stab.py:409
 #, fuzzy
 msgid "Video Stabilizer Tool"
 msgstr "Filtro estabilizador de vídeo"
 
-#: ../../vdms_dialogs/filter_stab.py:541 ../../vdms_io/io_tools.py:73
 msgid "Videomass - Loading..."
 msgstr "Videomass - Carregando ..."
 
-#: ../../vdms_dialogs/filter_stab.py:542
 msgid ""
 "Please wait,\n"
 "This process will take a few seconds."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:80
-#: ../../vdms_dialogs/filter_transpose.py:293
 msgid "Default position"
 msgstr "Posição padrão"
 
-#: ../../vdms_dialogs/filter_transpose.py:86
 msgid "Rotation setting"
 msgstr "Configuração de rotação"
 
-#: ../../vdms_dialogs/filter_transpose.py:94
 msgid "90° (left)"
 msgstr "90 ° (esquerda)"
 
-#: ../../vdms_dialogs/filter_transpose.py:96
 msgid "90° (right)"
 msgstr "90 ° (direita)"
 
-#: ../../vdms_dialogs/filter_transpose.py:100
 msgid "180°"
 msgstr "180°"
 
-#: ../../vdms_dialogs/filter_transpose.py:115
 #, fuzzy
 msgid "Transpose Tool"
 msgstr "Filtro de transposição"
 
-#: ../../vdms_dialogs/filter_transpose.py:229
 msgid "Rotate 90 degrees right"
 msgstr "Girar 90 graus para a direita"
 
-#: ../../vdms_dialogs/filter_transpose.py:251
 msgid "Rotate 180 degrees"
 msgstr "Girar 180 graus"
 
-#: ../../vdms_dialogs/filter_transpose.py:272
 msgid "Rotate 90 degrees left"
 msgstr "Girar 90 graus para a esquerda"
 
-#: ../../vdms_dialogs/mediainfo.py:82
 #, fuzzy
 msgid "Format"
 msgstr "formato"
 
-#: ../../vdms_dialogs/mediainfo.py:96
 msgid "Video Stream"
 msgstr "Reprodução de Video"
 
-#: ../../vdms_dialogs/mediainfo.py:109
 msgid "Audio Streams"
 msgstr "Reprodução de áudio"
 
-#: ../../vdms_dialogs/mediainfo.py:122
 msgid "Subtitle Streams"
 msgstr "Reprodução de Legenda"
 
-#: ../../vdms_dialogs/mediainfo.py:126
 #, fuzzy
 msgid "Copy to clipboard"
 msgstr "Cortar na largura"
 
-#: ../../vdms_dialogs/mediainfo.py:137
 msgid "FILE SELECTION"
 msgstr "SELEÇÃO DE ARQUIVOS"
 
-#: ../../vdms_dialogs/mediainfo.py:139 ../../vdms_dialogs/mediainfo.py:142
-#: ../../vdms_dialogs/mediainfo.py:145 ../../vdms_dialogs/mediainfo.py:148
-#: ../../vdms_main/main_frame.py:1318
 #, fuzzy
 msgid "Properties"
 msgstr "Propriedades do Áudio"
 
-#: ../../vdms_dialogs/mediainfo.py:140 ../../vdms_dialogs/mediainfo.py:143
-#: ../../vdms_dialogs/mediainfo.py:146 ../../vdms_dialogs/mediainfo.py:149
 msgid "Values"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:152
 #, fuzzy
 msgid "Streams Properties"
 msgstr "Propriedades do Áudio"
 
-#: ../../vdms_dialogs/mediainfo.py:244
 msgid "Unable to open the clipboard on Format tab"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:263
 msgid "Unable to open the clipboard on Video Streams tab"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:283
 msgid "Unable to open the clipboard on Audio Streams tab"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:303
 msgid "Unable to open the clipboard on Subtitle Streams tab"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:90
 msgid "Where do you prefer to save your transcodes?"
 msgstr "Onde você prefere salvar suas transcodificações?"
 
-#: ../../vdms_dialogs/preferences.py:101 ../../vdms_dialogs/preferences.py:128
-#: ../../vdms_dialogs/preferences.py:149 ../../vdms_dialogs/preferences.py:161
-#: ../../vdms_dialogs/preferences.py:173 ../../vdms_panels/filedrop.py:284
 msgid "Change"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:103
-#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:602
-#: ../../vdms_panels/presets_manager.py:1050
 #, fuzzy
 msgid "Same destination paths as source files"
 msgstr "Crie uma nova predefinição"
 
-#: ../../vdms_dialogs/preferences.py:108
 #, fuzzy
 msgid "Assign optional suffix to destination file names:"
 msgstr "Atribua um sufixo opcional para nomes de arquivo de saída:"
 
-#: ../../vdms_dialogs/preferences.py:114
 #, fuzzy
 msgid "File removal preferences"
 msgstr "Preferências de arquivo"
 
-#: ../../vdms_dialogs/preferences.py:118
 msgid "Trash the source files after successful encoding"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:131
 msgid "File Preferences"
 msgstr "Preferências de arquivo"
 
-#: ../../vdms_dialogs/preferences.py:138
 #, fuzzy
 msgid "Location of executables"
 msgstr "Localizando executáveis FFmpeg\n"
 
-#: ../../vdms_dialogs/preferences.py:140
 msgid ""
 "FFmpeg can be built by enabling/disabling its options and this depends on your needs.\n"
 "For some use cases it is possible to provide a custom build of FFmpeg where you can specify\n"
 "it in this preferences tab."
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:147
 #, fuzzy
 msgid "Enable a custom location to run FFmpeg"
 msgstr "Habilite outro local para executar o FFmpeg"
 
-#: ../../vdms_dialogs/preferences.py:159
 #, fuzzy
 msgid "Enable a custom location to run FFprobe"
 msgstr "Habilite outro local para executar o FFprobe"
 
-#: ../../vdms_dialogs/preferences.py:171
 #, fuzzy
 msgid "Enable a custom location to run FFplay"
 msgstr "Habilite outro local para executar o FFplay"
 
-#: ../../vdms_dialogs/preferences.py:183
 msgid "FFmpeg"
 msgstr "FFmpeg"
 
-#: ../../vdms_dialogs/preferences.py:189
 msgid "Look and Feel (requires application restart)"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:194
 msgid "Icon themes"
 msgstr "Tema de ícones"
 
-#: ../../vdms_dialogs/preferences.py:208
 msgid "At the top of window (default)"
 msgstr "No topo da janela (padrão)"
 
-#: ../../vdms_dialogs/preferences.py:209
 msgid "At the bottom of window"
 msgstr "Na parte inferior da janela"
 
-#: ../../vdms_dialogs/preferences.py:210
 msgid "At the right of window"
 msgstr "À direita da janela"
 
-#: ../../vdms_dialogs/preferences.py:211
 msgid "At the left of window"
 msgstr "À esquerda da janela"
 
-#: ../../vdms_dialogs/preferences.py:213
 msgid "Place the toolbar"
 msgstr "Coloque a barra de ferramentas"
 
-#: ../../vdms_dialogs/preferences.py:222
 msgid "Toolbar's icons size:"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:236
 msgid "Application Language (requires application restart)"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:248
 msgid "Look and Language"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:254
 #, fuzzy
 msgid "Upon exiting the application"
 msgstr "Limpe o cache ao sair do aplicativo"
 
-#: ../../vdms_dialogs/preferences.py:259
 #, fuzzy
 msgid "Always ask me to confirm"
 msgstr "Por favor confirme"
 
-#: ../../vdms_dialogs/preferences.py:261
 #, fuzzy
 msgid "Clean the log files"
 msgstr "Nenhum arquivo selecionado"
 
-#: ../../vdms_dialogs/preferences.py:264
 #, fuzzy
 msgid "Remove cached files"
 msgstr "Adicionar arquivos"
 
-#: ../../vdms_dialogs/preferences.py:268
 #, fuzzy
 msgid "On operations completion"
 msgstr "opções nlmeans"
 
-#: ../../vdms_dialogs/preferences.py:271
 msgid "These settings will remain active until the application is closed, If necessary, remember to reactivate them."
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:276
 #, fuzzy
 msgid "Exit the application"
 msgstr "Limpe o cache ao sair do aplicativo"
 
-#: ../../vdms_dialogs/preferences.py:279
 msgid "Shutdown the system"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:283
 msgid "SUDO password:"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:292
 msgid "Exit and Shutdown"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:298
 msgid "Specify the character encoding format"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:301
 msgid ""
 "Although UTF-8 is the default and most widely used standard encoding format, it is not the only encoding format available.\n"
 "Some file metadata may still contain non-UTF-8 character encodings resulting in the error \"'utf-8' codec can't decode bytes...\".\n"
 "If you know the encoding format the file was written in, you can try specifying it here, e.g. ISO 8859-1, ISO 8859-16, etc."
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:311
 msgid "Character encoding:"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:320
 msgid "Default application directories"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:324
 #, fuzzy
 msgid "Configuration directory"
 msgstr "Pasta de configuração"
 
-#: ../../vdms_dialogs/preferences.py:337
 #, fuzzy
 msgid "Cache directory"
 msgstr "Pasta de cache"
 
-#: ../../vdms_dialogs/preferences.py:349
 #, fuzzy
 msgid "Log directory"
 msgstr "Pasta de log"
 
-#: ../../vdms_dialogs/preferences.py:363
 #, fuzzy
 msgid "Advanced"
 msgstr "Opções Avançadas"
 
-#: ../../vdms_dialogs/preferences.py:369
 #, fuzzy
 msgid ""
 "The following settings affect output messages and the log messages during transcoding processes.\n"
@@ -1191,165 +871,108 @@ msgstr ""
 "as mensagens de log durante os processos de transcodificação.\n"
 "Mude apenas se você souber o que está fazendo.\n"
 
-#: ../../vdms_dialogs/preferences.py:376
 msgid "Set logging level flags used by FFmpeg"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:383
 msgid "Set logging level flags used by FFplay"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:391
 msgid "FFmpeg logging levels"
 msgstr "Níveis de registro FFmpeg"
 
-#: ../../vdms_dialogs/preferences.py:437
 msgid "By assigning an additional suffix you could avoid overwriting files"
 msgstr "Ao atribuir um sufixo adicional, você pode evitar a substituição de arquivos"
 
-#: ../../vdms_dialogs/preferences.py:440
 msgid "Type sudo password here, only for Unix-like operating systems, not for MS Windows"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:443
 #, fuzzy
 msgid "Preferences"
 msgstr "Referencias"
 
-#: ../../vdms_dialogs/preferences.py:596 ../../vdms_dialogs/preferences.py:676
-#: ../../vdms_main/main_frame.py:879 ../../vdms_main/main_frame.py:1060
 #, fuzzy
 msgid "Choose Destination"
 msgstr "Diretório de destino"
 
-#: ../../vdms_dialogs/preferences.py:627
 msgid "Enter only alphanumeric characters. You can also use the hyphen (\"-\") and the underscore (\"_\"). Spaces are not allowed."
 msgstr "Insira apenas caracteres alfanuméricos. Você também pode usar o hífen (\"-\") e o sublinhado (\"_\"). Espaços em branco não são permitidos."
 
-#: ../../vdms_dialogs/preferences.py:642
-#: ../../vdms_dialogs/setting_profiles.py:257
-#: ../../vdms_dialogs/setting_profiles.py:264
-#: ../../vdms_dialogs/setting_profiles.py:286
-#: ../../vdms_dialogs/setting_profiles.py:309 ../../vdms_main/main_frame.py:399
-#: ../../vdms_main/main_frame.py:421 ../../vdms_panels/av_conversions.py:605
-#: ../../vdms_panels/av_conversions.py:612
-#: ../../vdms_panels/sequence_to_video.py:352
-#: ../../vdms_panels/video_to_sequence.py:399
 #, fuzzy
 msgid "Videomass - Warning!"
 msgstr "Videomass - Carregando ..."
 
-#: ../../vdms_dialogs/preferences.py:731 ../../vdms_dialogs/preferences.py:771
-#: ../../vdms_dialogs/preferences.py:811 ../../vdms_dialogs/wizard_dlg.py:365
-#: ../../vdms_dialogs/wizard_dlg.py:384 ../../vdms_dialogs/wizard_dlg.py:403
 #, fuzzy, python-brace-format
 msgid "{} location"
 msgstr "Escolha o {} executável"
 
-#: ../../vdms_dialogs/queue_edit.py:36
-#: ../../vdms_dialogs/setting_profiles.py:38
 msgid "One-Pass, Do not start with `ffmpeg -i filename`; do not end with `output-filename`"
 msgstr "Primeira passagem, não comece com `ffmpeg -i filename`; não termine com `output-filename"
 
-#: ../../vdms_dialogs/queue_edit.py:40
-#: ../../vdms_dialogs/setting_profiles.py:42
 msgid "Two-Pass (optional), Do not start with `ffmpeg -i filename`; do not end with `output-filename`"
 msgstr "Segunda passagem (opcional), não comece com `ffmpeg -i filename`; não termine com `output-filename"
 
-#: ../../vdms_dialogs/queue_edit.py:59
 #, fuzzy
 msgid "Videomass - Edit the selected item in the queue"
 msgstr "Reproduza os arquivos selecionados na lista"
 
-#: ../../vdms_dialogs/queue_edit.py:71
-#: ../../vdms_dialogs/setting_profiles.py:92
 msgid "Pre-input arguments for One-Pass (optional)"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:82
-#: ../../vdms_dialogs/setting_profiles.py:151
-#: ../../vdms_panels/presets_manager.py:255
 msgid "FFmpeg arguments for one-pass encoding"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:88
-#: ../../vdms_dialogs/setting_profiles.py:158
-#: ../../vdms_panels/presets_manager.py:259
 msgid "Any optional arguments to add before input file on the one-pass encoding, e.g required names of some hardware accelerations like -hwaccel to use with CUDA."
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:102
-#: ../../vdms_dialogs/setting_profiles.py:98
 msgid "Pre-input arguments for Two-Pass (optional)"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:113
-#: ../../vdms_dialogs/setting_profiles.py:152
-#: ../../vdms_panels/presets_manager.py:257
 msgid "FFmpeg arguments for two-pass encoding"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:120
-#: ../../vdms_dialogs/setting_profiles.py:162
-#: ../../vdms_panels/presets_manager.py:263
 msgid "Any optional arguments to add before input file on the two-pass encoding, e.g required names of some hardware accelerations like -hwaccel to use with CUDA."
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:65 ../../vdms_main/main_frame.py:508
-#: ../../vdms_panels/presets_manager.py:189
-#: ../../vdms_panels/video_to_sequence.py:171
 msgid "Edit"
 msgstr "Editar"
 
-#: ../../vdms_dialogs/queuedlg.py:68
 msgid "Remove"
 msgstr "Remover"
 
-#: ../../vdms_dialogs/queuedlg.py:71
 #, fuzzy
 msgid "Remove all"
 msgstr "Remover"
 
-#: ../../vdms_dialogs/queuedlg.py:74
 msgid ""
 "Export\n"
 "queue file"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:77
 #, fuzzy
 msgid ""
 "Import\n"
 "queue file"
 msgstr "Pasta de log"
 
-#: ../../vdms_dialogs/queuedlg.py:85 ../../vdms_panels/filedrop.py:273
 #, fuzzy
 msgid "Destination file name"
 msgstr "Índice de saída:"
 
-#: ../../vdms_dialogs/queuedlg.py:137
 #, fuzzy
 msgid "Remove all items in the queue"
 msgstr "Um arquivo de destino deve ser selecionado nos arquivos em fila"
 
-#: ../../vdms_dialogs/queuedlg.py:151
 #, fuzzy
 msgid "Videomass - Queue"
 msgstr "Videomass - URLs enfileirados"
 
-#: ../../vdms_dialogs/queuedlg.py:228
 #, fuzzy
 msgid "Export queue file"
 msgstr "Exportar selecionado"
 
-#: ../../vdms_dialogs/queuedlg.py:296 ../../vdms_panels/av_conversions.py:1192
-#: ../../vdms_panels/presets_manager.py:1044
-#: ../../vdms_panels/video_to_sequence.py:600
 msgid "Same as source"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:301
 #, fuzzy
 msgid ""
 "Source\n"
@@ -1374,188 +997,131 @@ msgstr ""
 "Período de tempo\n"
 "Mapa de entrada de áudio"
 
-#: ../../vdms_dialogs/renamer.py:76
 msgid "# will be replaced by ascending numbers starting with:"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:87
 msgid "Font Size"
 msgstr "Tamanho da fonte"
 
-#: ../../vdms_dialogs/set_timestamp.py:111
 msgid "Font Color"
 msgstr "Cor da fonte"
 
-#: ../../vdms_dialogs/set_timestamp.py:121
 msgid "Shadow Color"
 msgstr "Cor da sombra"
 
-#: ../../vdms_dialogs/set_timestamp.py:132
 msgid "Show text box"
 msgstr "Mostrar caixa de texto"
 
-#: ../../vdms_dialogs/set_timestamp.py:136
 msgid "Box Color"
 msgstr "Cor da Caixa"
 
-#: ../../vdms_dialogs/set_timestamp.py:156
 msgid "The timestamp size does not auto-adjust to the video size, you have to set the size here"
 msgstr "O tamanho do registro de data / hora não se ajusta automaticamente ao tamanho do vídeo, você deve definir o tamanho aqui"
 
-#: ../../vdms_dialogs/set_timestamp.py:160 ../../vdms_main/main_frame.py:559
 msgid "Timestamp settings"
 msgstr "Configurações de registro de data / hora"
 
-#: ../../vdms_dialogs/setting_profiles.py:46
 msgid "Supported Formats list (optional). Do not include the `.`"
 msgstr "Lista de formatos suportados (opcional). Não inclua o `.`"
 
-#: ../../vdms_dialogs/setting_profiles.py:47
 msgid "Output Format. Empty to copy format and codec. Do not include the `.`"
 msgstr "Formato de saída. Vazio para copiar o formato e o codec. Não inclua o `.`"
 
-#: ../../vdms_dialogs/setting_profiles.py:70
 msgid "Profile Name"
 msgstr "Nome do perfil"
 
-#: ../../vdms_dialogs/setting_profiles.py:74
-#: ../../vdms_panels/presets_manager.py:404
 msgid "Description"
 msgstr "Descrição"
 
-#: ../../vdms_dialogs/setting_profiles.py:149
 msgid "A short profile name"
 msgstr "Um nome de perfil curto"
 
-#: ../../vdms_dialogs/setting_profiles.py:150
 msgid "A long description of the profile"
 msgstr "Uma longa descrição do perfil"
 
-#: ../../vdms_dialogs/setting_profiles.py:153
 msgid "One or more comma-separated format names compatible with this profile"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:155
 msgid "Output format extension. Leave empty to copy codec and format"
 msgstr "Extensão do formato de saída. Deixe em branco para copiar o codec e formatar"
 
-#: ../../vdms_dialogs/setting_profiles.py:256
 msgid "Incomplete profile assignments"
 msgstr "Atribuições de perfil incompletas"
 
-#: ../../vdms_dialogs/setting_profiles.py:263
 msgid "Formats must be comma-separated"
 msgstr "Os formatos devem ser separados por vírgulas"
 
-#: ../../vdms_dialogs/setting_profiles.py:279
-#: ../../vdms_utils/queue_utils.py:80
 #, python-brace-format
 msgid ""
 "ERROR: Keys mismatched for requested data.\n"
 "Invalid file: «{0}»"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:285
-#: ../../vdms_dialogs/setting_profiles.py:308
 msgid "Profile already stored with same name"
 msgstr "Perfil já armazenado com o mesmo nome"
 
-#: ../../vdms_dialogs/setting_profiles.py:293
 #, fuzzy
 msgid "Profile stored successfully!"
 msgstr "Assistente concluído com sucesso!\n"
 
-#: ../../vdms_dialogs/setting_profiles.py:311
 msgid "Profile change successful!"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:80
 #, fuzzy
 msgid "Log file list"
 msgstr "Nenhum arquivo selecionado"
 
-#: ../../vdms_dialogs/showlogs.py:82 ../../vdms_dialogs/showlogs.py:116
 msgid "Log messages"
 msgstr "Mensagens de log"
 
-#: ../../vdms_dialogs/showlogs.py:105
 msgid "Refresh log messages"
 msgstr "Atualizar mensagens de log"
 
-#: ../../vdms_dialogs/showlogs.py:107
 msgid "Clear log messages"
 msgstr "Limpar mensagens de log"
 
-#: ../../vdms_dialogs/showlogs.py:160
 msgid "Select a log file"
 msgstr "Selecione um arquivo de log"
 
-#: ../../vdms_dialogs/showlogs.py:167
 msgid "Are you sure you want to clear the selected log file?"
 msgstr "Tem certeza de que deseja limpar o arquivo de log selecionado?"
 
-#: ../../vdms_dialogs/showlogs.py:168 ../../vdms_dialogs/wizard_dlg.py:251
-#: ../../vdms_io/checkup.py:68 ../../vdms_main/main_frame.py:205
-#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1685
-#: ../../vdms_panels/presets_manager.py:349
-#: ../../vdms_panels/presets_manager.py:550
-#: ../../vdms_panels/presets_manager.py:590
-#: ../../vdms_panels/presets_manager.py:649
-#: ../../vdms_panels/presets_manager.py:684
-#: ../../vdms_panels/presets_manager.py:749
-#: ../../vdms_panels/presets_manager.py:775
-#: ../../vdms_panels/presets_manager.py:874
-#: ../../vdms_panels/presets_manager.py:904
 msgid "Please confirm"
 msgstr "Por favor confirme"
 
-#: ../../vdms_dialogs/shownormlist.py:83
 msgid "File name"
 msgstr "Nome do Arquivo"
 
-#: ../../vdms_dialogs/shownormlist.py:84
 msgid "Max volume dBFS"
 msgstr "Volume máximo dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:85
 msgid "Mean volume dBFS"
 msgstr "Volume médio dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:86
 msgid "Offset dBFS"
 msgstr "Desvio dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:87
 msgid "Result dBFS"
 msgstr "Resultado dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:92
 msgid "Post-normalization references:"
 msgstr "Referências pós-normalização:"
 
-#: ../../vdms_dialogs/shownormlist.py:102
 msgid "=  Clipped peaks"
 msgstr "= Picos cortados"
 
-#: ../../vdms_dialogs/shownormlist.py:111
 msgid "=  No changes"
 msgstr "= Sem alterações"
 
-#: ../../vdms_dialogs/shownormlist.py:121
 msgid "=  Below max peak"
 msgstr "= Abaixo da altura máxima"
 
-#: ../../vdms_dialogs/shownormlist.py:166
-#: ../../vdms_panels/audio_encoders/acodecs.py:841
 msgid "RMS-based volume statistics"
 msgstr "Estatísticas de volume baseadas em RMS"
 
-#: ../../vdms_dialogs/shownormlist.py:191
-#: ../../vdms_panels/audio_encoders/acodecs.py:839
 msgid "PEAK-based volume statistics"
 msgstr "Estatísticas de volume baseadas em PEAK"
 
-#: ../../vdms_dialogs/shownormlist.py:216
 #, fuzzy
 msgid ""
 "...It means the resulting audio will be clipped,\n"
@@ -1564,37 +1130,31 @@ msgid ""
 "sound distorted."
 msgstr "... Isso significa que o áudio resultante será cortado, porque seu volume é superior ao nível máximo de 0 db. Isso resulta em perda de dados e o áudio pode parecer distorcido."
 
-#: ../../vdms_dialogs/shownormlist.py:242
 #, fuzzy
 msgid ""
 "...It means the resulting audio will not change,\n"
 "because it's equal to the source."
 msgstr "... Significa que o áudio resultante não mudará, pois é igual à fonte."
 
-#: ../../vdms_dialogs/shownormlist.py:266
 #, fuzzy
 msgid ""
 "...It means an audio signal will be produced with\n"
 "a lower volume than the source."
 msgstr "... Isso significa que um sinal de áudio será produzido com um volume mais baixo do que o original."
 
-#: ../../vdms_dialogs/videomass_check_version.py:63
 #, fuzzy
 msgid "Get Latest Version"
 msgstr "Mostrar a última versão ..."
 
-#: ../../vdms_dialogs/videomass_check_version.py:67
 msgid "Checking for newer version"
 msgstr "Verificando se há uma versão mais recente"
 
-#: ../../vdms_dialogs/videomass_check_version.py:95
 msgid ""
 "\n"
 "\n"
 "New releases fix bugs and offer new features."
 msgstr ""
 
-#: ../../vdms_dialogs/videomass_check_version.py:96
 #, python-brace-format
 msgid ""
 "\n"
@@ -1603,7 +1163,6 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../../vdms_dialogs/while_playing.py:37
 msgid ""
 "q, ESC\n"
 "f\n"
@@ -1645,65 +1204,51 @@ msgstr ""
 "clique com o botão direito do mouse\n"
 "clique duplo esquerdo do mouse"
 
-#: ../../vdms_dialogs/while_playing.py:92
 msgid "Shortcut keys while playing with FFplay"
 msgstr "Teclas de atalho ao reproduzir com FFplay"
 
-#: ../../vdms_dialogs/widget_utils.py:120 ../../vdms_main/main_frame.py:1326
 msgid "Stop"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:63
 msgid "Please take a moment to set up the application"
 msgstr "Reserve um momento para configurar o aplicativo"
 
-#: ../../vdms_dialogs/wizard_dlg.py:64
 msgid "Click the \"Next\" button to get started"
 msgstr "Clique no botão \"Avançar\" para começar"
 
-#: ../../vdms_dialogs/wizard_dlg.py:79
 msgid "Welcome to the Videomass Wizard!"
 msgstr "Bem-vindo ao Assistente do Videomass!"
 
-#: ../../vdms_dialogs/wizard_dlg.py:123
 msgid "Videomass is an application based on FFmpeg\n"
 msgstr "Videomass é um aplicativo baseado em FFmpeg\n"
 
-#: ../../vdms_dialogs/wizard_dlg.py:125
 msgid "If FFmpeg is not on your computer, this application will be unusable"
 msgstr "Se o FFmpeg não estiver no seu computador, este aplicativo ficará inutilizável"
 
-#: ../../vdms_dialogs/wizard_dlg.py:128
 msgid ""
 "If you have already installed FFmpeg on your operating system,\n"
 "click the \"Auto-detection\" button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:131
 msgid ""
 "If you want to use a version of FFmpeg located on your filesystem\n"
 "but not installed on your operating system,\n"
 "click the \"Locate\" button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:162
 msgid "Auto-detection"
 msgstr "Detecção automática"
 
-#: ../../vdms_dialogs/wizard_dlg.py:164
 msgid "Locate"
 msgstr "Localizar"
 
-#: ../../vdms_dialogs/wizard_dlg.py:214
 msgid "Click the \"Next\" button"
 msgstr "Clique no botão \"Avançar\""
 
-#: ../../vdms_dialogs/wizard_dlg.py:235
 #, python-brace-format
 msgid "'{}' is not installed on your computer. Install it or indicate another location by clicking the 'Locate' button."
 msgstr "'{}' não está instalado no seu computador. Instale-o ou indique outro local clicando no botão 'Localizar'."
 
-#: ../../vdms_dialogs/wizard_dlg.py:249
 msgid ""
 "Videomass already seems to include FFmpeg.\n"
 "\n"
@@ -1713,11 +1258,9 @@ msgstr ""
 "\n"
 "Você quer usá-lo?"
 
-#: ../../vdms_dialogs/wizard_dlg.py:275
 msgid "Locating FFmpeg executables\n"
 msgstr "Localizando executáveis FFmpeg\n"
 
-#: ../../vdms_dialogs/wizard_dlg.py:277
 msgid ""
 "\"ffmpeg\", \"ffprobe\" and \"ffplay\" are required. Complete all\n"
 "the text boxes below by clicking on the respective buttons."
@@ -1725,41 +1268,31 @@ msgstr ""
 "\"ffmpeg\", \"ffprobe\" e \"ffplay\" são obrigatórios. Complete tudo\n"
 "nas caixas de texto abaixo clicando nos respectivos botões."
 
-#: ../../vdms_dialogs/wizard_dlg.py:437
 msgid "Wizard completed successfully!\n"
 msgstr "Assistente concluído com sucesso!\n"
 
-#: ../../vdms_dialogs/wizard_dlg.py:438
 #, fuzzy
 msgid "Remember that you can always change these settings later, through the Preferences dialog."
 msgstr "Lembre-se de que você sempre pode alterar essas configurações posteriormente, por meio da caixa de diálogo Configuração."
 
-#: ../../vdms_dialogs/wizard_dlg.py:440
 msgid "Thank You!"
 msgstr "Obrigado!"
 
-#: ../../vdms_dialogs/wizard_dlg.py:441
 msgid "To exit click the \"Finish\" button"
 msgstr "Para sair, clique no botão \"Concluir\""
 
-#: ../../vdms_dialogs/wizard_dlg.py:527
 msgid "< Previous"
 msgstr "< Anterior"
 
-#: ../../vdms_dialogs/wizard_dlg.py:530 ../../vdms_dialogs/wizard_dlg.py:613
 msgid "Next >"
 msgstr "Avançar >"
 
-#: ../../vdms_dialogs/wizard_dlg.py:535
 msgid "Videomass Wizard"
 msgstr "Assistente do Videomass"
 
-#: ../../vdms_dialogs/wizard_dlg.py:563 ../../vdms_dialogs/wizard_dlg.py:586
-#: ../../vdms_dialogs/wizard_dlg.py:591
 msgid "Finish"
 msgstr "Concluir"
 
-#: ../../vdms_io/checkup.py:44 ../../vdms_io/checkup.py:92
 #, fuzzy, python-brace-format
 msgid ""
 "Output folder does not exist:\n"
@@ -1770,34 +1303,27 @@ msgstr ""
 "\n"
 "\"% s\"\n"
 
-#: ../../vdms_io/checkup.py:65
 #, fuzzy
 msgid "Files already exist, do you want to overwrite them?"
 msgstr "Já existe um arquivo com este nome, deseja substituí-lo?"
 
-#: ../../vdms_io/checkup.py:67
 msgid "Already exist"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:81
 msgid "Not found"
 msgstr "Não encontrado"
 
-#: ../../vdms_io/checkup.py:82 ../../vdms_panels/filedrop.py:196
 msgid "Error list"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:83
 #, fuzzy
 msgid "File(s) not found"
 msgstr "Não encontrado"
 
-#: ../../vdms_io/io_tools.py:56
 #, python-format
 msgid "File does not exist or is invalid:  %s"
 msgstr "O arquivo não existe ou é inválido:% s"
 
-#: ../../vdms_io/io_tools.py:74
 #, fuzzy
 msgid ""
 "Wait....\n"
@@ -1807,426 +1333,330 @@ msgstr ""
 "Aguarde....\n"
 "Análise de altura de áudio.\n"
 
-#: ../../vdms_io/io_tools.py:179
 msgid "Videomass - Downloading..."
 msgstr "Videomass - Baixando ..."
 
-#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1409
-#: ../../vdms_main/main_frame.py:1441
 msgid "Ready"
 msgstr "Pronto"
 
-#: ../../vdms_main/main_frame.py:203
 msgid ""
 "Not all items in the queue were completed.\n"
 "\n"
 "Would you like to keep them in the queue?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:224
 #, python-brace-format
 msgid "Queue ({0})"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:229 ../../vdms_main/main_frame.py:1334
 msgid "Queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:396 ../../vdms_main/main_frame.py:418
 msgid "There are still active windows with running processes, make sure you finish your work before exit."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:403
 #, fuzzy
 msgid "Are you sure you want to exit the application?"
 msgstr "Você tem certeza que deseja sair?"
 
-#: ../../vdms_main/main_frame.py:405
 msgid "Exit"
 msgstr "Sair"
 
-#: ../../vdms_main/main_frame.py:463
 #, fuzzy
 msgid "Import files\tCtrl+O"
 msgstr "Pasta de log"
 
-#: ../../vdms_main/main_frame.py:466
 #, fuzzy
 msgid "Open destination folder of encodings\tCtrl+D"
 msgstr "Crie uma nova predefinição"
 
-#: ../../vdms_main/main_frame.py:469
 msgid "Load queue file"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:470
 msgid "Load a previously exported queue file"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:473
 #, fuzzy
 msgid "Open trash"
 msgstr "Pasta de cache"
 
-#: ../../vdms_main/main_frame.py:474
 #, fuzzy
 msgid "Open the Videomass trash folder"
 msgstr "Abre a pasta de cache do Videomass, se houver"
 
-#: ../../vdms_main/main_frame.py:476
 #, fuzzy
 msgid "Empty trash"
 msgstr "Pasta de cache"
 
-#: ../../vdms_main/main_frame.py:477
 #, fuzzy
 msgid "Delete all files in the Videomass trash folder"
 msgstr "Exclua todos os arquivos da lista"
 
-#: ../../vdms_main/main_frame.py:480
 msgid "Exit\tCtrl+Q"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:481
 #, fuzzy
 msgid "Completely exit the application"
 msgstr "Limpe o cache ao sair do aplicativo"
 
-#: ../../vdms_main/main_frame.py:482
 msgid "File"
 msgstr "Arquivo"
 
-#: ../../vdms_main/main_frame.py:486 ../../vdms_panels/filedrop.py:340
-#: ../../vdms_panels/filedrop.py:381
 #, fuzzy
 msgid "Rename selected file\tCtrl+R"
 msgstr "Exclua o perfil selecionado"
 
-#: ../../vdms_main/main_frame.py:487
 #, fuzzy
 msgid "Rename the destination of the selected file"
 msgstr "Um arquivo de destino deve ser selecionado nos arquivos em fila"
 
-#: ../../vdms_main/main_frame.py:490 ../../vdms_panels/filedrop.py:341
-#: ../../vdms_panels/filedrop.py:384
 #, fuzzy
 msgid "Batch rename files\tCtrl+B"
 msgstr "Exibir Logs\tCtrl+L"
 
-#: ../../vdms_main/main_frame.py:491
 msgid "Numerically renames the destination of all items in the list"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:496 ../../vdms_panels/filedrop.py:343
-#: ../../vdms_panels/filedrop.py:388
 #, fuzzy
 msgid "Remove selected entry\tDEL"
 msgstr "Exclua o perfil selecionado"
 
-#: ../../vdms_main/main_frame.py:497
 #, fuzzy
 msgid "Remove the selected file from the list"
 msgstr "Remova o arquivo selecionado da lista"
 
-#: ../../vdms_main/main_frame.py:500 ../../vdms_panels/filedrop.py:344
-#: ../../vdms_panels/filedrop.py:391
 msgid "Clear list\tShift+DEL"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:501
 #, fuzzy
 msgid "Clear the file list"
 msgstr "Nenhum arquivo selecionado"
 
-#: ../../vdms_main/main_frame.py:506
 msgid "Preferences\tCtrl+P"
 msgstr "Preferências\tCtrl+P"
 
-#: ../../vdms_main/main_frame.py:507
 msgid "Application preferences"
 msgstr "Preferências do aplicativo"
 
-#: ../../vdms_main/main_frame.py:512
 #, fuzzy
 msgid "Find FFmpeg topics"
 msgstr "Tópicos de ajuda do FFmpeg"
 
-#: ../../vdms_main/main_frame.py:513
 msgid "A useful tool to search for FFmpeg help topics and options"
 msgstr "Uma ferramenta útil para pesquisar tópicos de ajuda e opções do FFmpeg"
 
-#: ../../vdms_main/main_frame.py:518
 #, fuzzy
 msgid "Check for preset updates"
 msgstr "Verifique se há novas predefinições"
 
-#: ../../vdms_main/main_frame.py:519
 #, fuzzy, python-brace-format
 msgid "Check for new presets updates from {0}"
 msgstr "Verifique se há novas predefinições"
 
-#: ../../vdms_main/main_frame.py:521
 #, fuzzy
 msgid "Get latest presets"
 msgstr "Crie uma nova predefinição"
 
-#: ../../vdms_main/main_frame.py:522
 #, fuzzy, python-brace-format
 msgid "Get the latest presets from {0}"
 msgstr "Verifique se há novas predefinições"
 
-#: ../../vdms_main/main_frame.py:525
 #, fuzzy
 msgid "Work notes\tCtrl+N"
 msgstr "Exibir Logs\tCtrl+L"
 
-#: ../../vdms_main/main_frame.py:526
 msgid "Read and write useful notes and reminders."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:528
 msgid "Tools"
 msgstr "Ferramentas"
 
-#: ../../vdms_main/main_frame.py:535
 msgid "Show FFmpeg's built-in configuration capabilities"
 msgstr "Mostra as capacidades de configuração integradas do FFmpeg"
 
-#: ../../vdms_main/main_frame.py:539
 #, fuzzy
 msgid "Muxers and demuxers available on your version of FFmpeg"
 msgstr "Muxers e demuxers disponíveis para o FFmpeg usado."
 
-#: ../../vdms_main/main_frame.py:543
 #, fuzzy
 msgid "Encoders available on your version of FFmpeg"
 msgstr "Mostra os codificadores disponíveis para FFmpeg"
 
-#: ../../vdms_main/main_frame.py:546
 #, fuzzy
 msgid "Decoders available on your version of FFmpeg"
 msgstr "Mostra os codificadores disponíveis para FFmpeg"
 
-#: ../../vdms_main/main_frame.py:550
 #, fuzzy
 msgid "Enable timestamps on playback"
 msgstr "Exibe registro de data / hora"
 
-#: ../../vdms_main/main_frame.py:551
 #, fuzzy
 msgid "Displays timestamp when playing media with FFplay"
 msgstr "Exibe registro de data / hora ao reproduzir filmes com FFplay"
 
-#: ../../vdms_main/main_frame.py:554
 msgid "Auto-exit after playback"
 msgstr "Sair automaticamente após a reprodução"
 
-#: ../../vdms_main/main_frame.py:555
 #, fuzzy
 msgid "If checked, the FFplay window will auto-close when playback is complete"
 msgstr "Se marcada, a janela FFplay será fechada automaticamente no final da reprodução"
 
-#: ../../vdms_main/main_frame.py:559
 msgid "Customize the timestamp style"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:562
 #, fuzzy
 msgid "While playing..."
 msgstr "Enquanto reproduz"
 
-#: ../../vdms_main/main_frame.py:563
 #, fuzzy
 msgid "Show useful shortcut keys when playing or previewing using FFplay"
 msgstr "Mostrar teclas de atalho úteis ao reproduzir ou pré-visualizar com FFplay"
 
-#: ../../vdms_main/main_frame.py:567
 #, fuzzy
 msgid "Show timeline editor\tCtrl+T"
 msgstr "Mostrar linha do tempo\tCtrl+T"
 
-#: ../../vdms_main/main_frame.py:568
 msgid "Set duration or trim slices of time to remove unwanted parts from your files"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:572
 msgid "View"
 msgstr "Ver"
 
-#: ../../vdms_main/main_frame.py:579
 #, fuzzy
 msgid "Home panel\tCtrl+Shift+H"
 msgstr "Painel inicial\tShift+H"
 
-#: ../../vdms_main/main_frame.py:580
 msgid "Go to the «Home» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:583
 #, fuzzy
 msgid "Presets Manager\tCtrl+Shift+P"
 msgstr "Gerenciador de predefinições\tShift+P"
 
-#: ../../vdms_main/main_frame.py:584
 msgid "Go to the «Presets Manager» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:586
 #, fuzzy
 msgid "A/V Conversions\tCtrl+Shift+V"
 msgstr "Conversões A/V\tShift+V"
 
-#: ../../vdms_main/main_frame.py:587
 msgid "Go to the «A/V Conversions» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:589
 #, fuzzy
 msgid "Concatenate Demuxer\tCtrl+Shift+D"
 msgstr "Concatenate Demuxer\tShift+D"
 
-#: ../../vdms_main/main_frame.py:590
 msgid "Go to the «Concatenate Demuxer» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:593
 msgid "Still Image Maker\tCtrl+Shift+I"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:594
 msgid "Go to the «Still Image Maker» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:596
 #, fuzzy
 msgid "From Movie to Pictures\tCtrl+Shift+S"
 msgstr "Videomass - Monitor de Saída"
 
-#: ../../vdms_main/main_frame.py:597
 msgid "Go to the «From Movie to Pictures» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:600
 #, fuzzy
 msgid "Output monitor\tCtrl+Shift+O"
 msgstr "Monitor de saída\tShift+O"
 
-#: ../../vdms_main/main_frame.py:601
 msgid "Keeps track of the output for debugging errors"
 msgstr "Mantém o controle da saída para erros de depuração"
 
-#: ../../vdms_main/main_frame.py:603
 #, fuzzy
 msgid "Go"
 msgstr "Ir para"
 
-#: ../../vdms_main/main_frame.py:607
 #, fuzzy
 msgid "User guide"
 msgstr "Manual"
 
-#: ../../vdms_main/main_frame.py:611
 #, fuzzy
 msgid "System version"
 msgstr "Mostrar a versão em uso"
 
-#: ../../vdms_main/main_frame.py:612
 msgid "Get version about your operating system, version of Python and wxPython."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:616
 #, fuzzy
 msgid "Show log files\tCtrl+L"
 msgstr "Exibir Logs\tCtrl+L"
 
-#: ../../vdms_main/main_frame.py:617
 msgid "Viewing log messages"
 msgstr "Ver mensagens de log"
 
-#: ../../vdms_main/main_frame.py:620
 msgid "Issue tracker"
 msgstr "Rastreador de problemas"
 
-#: ../../vdms_main/main_frame.py:624
 msgid "Contribute to the project"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:627
 msgid "Sponsor this project"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:628
 msgid "Become a developer supporter"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:629
 msgid "Donate"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:630
 msgid "Donate to the app developer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:634
 msgid "Other projects by the developer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:650
 msgid "About Videomass"
 msgstr "Sobre o Videomass"
 
-#: ../../vdms_main/main_frame.py:651
 msgid "Check for newer version"
 msgstr "Verifique se há uma versão mais recente"
 
-#: ../../vdms_main/main_frame.py:652
 #, fuzzy
 msgid "Check for the latest Videomass version"
 msgstr "Mostrar a última versão ..."
 
-#: ../../vdms_main/main_frame.py:654
 msgid "Help"
 msgstr "Ajuda"
 
-#: ../../vdms_main/main_frame.py:729
 #, fuzzy
 msgid "Import files"
 msgstr "Pasta de log"
 
-#: ../../vdms_main/main_frame.py:752
 msgid "No default folder has been set for the destination of the encodings. The current setting is \"Same destination paths as source files\"."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:784 ../../vdms_main/main_frame.py:809
 #, python-brace-format
 msgid ""
 "'{}':\n"
 "No such file or directory"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:797
 #, fuzzy
 msgid "Are you sure to empty trash folder?"
 msgstr "Você tem certeza que deseja sair?"
 
-#: ../../vdms_main/main_frame.py:805
 #, fuzzy, python-brace-format
 msgid ""
 "'{}':\n"
 "There are no files to delete."
 msgstr "Não há logs para mostrar."
 
-#: ../../vdms_main/main_frame.py:862
 #, python-brace-format
 msgid "Installed release v{0}. A new presets release is available {1}"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:866
 #, python-brace-format
 msgid "Installed release v{0}. No new updates found."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:896
 #, fuzzy
 msgid ""
 "Wait....\n"
@@ -2236,17 +1666,14 @@ msgstr ""
 "Aguarde....\n"
 "O arquivo está sendo baixado\n"
 
-#: ../../vdms_main/main_frame.py:908
 #, python-brace-format
 msgid "Successfully downloaded to \"{0}\""
 msgstr "Download com sucesso para \"{0}\""
 
-#: ../../vdms_main/main_frame.py:1120
 #, fuzzy
 msgid "Some changes require restarting the application."
 msgstr "Limpe o cache ao sair do aplicativo"
 
-#: ../../vdms_main/main_frame.py:1126
 #, fuzzy, python-brace-format
 msgid ""
 "{0}\n"
@@ -2254,234 +1681,179 @@ msgid ""
 "Do you want to restart the application now?"
 msgstr "Você tem certeza que deseja sair?"
 
-#: ../../vdms_main/main_frame.py:1128
 #, fuzzy
 msgid "Restart Videomass?"
 msgstr "Videomass"
 
-#: ../../vdms_main/main_frame.py:1207
 #, fuzzy, python-brace-format
 msgid "A new release is available - v.{0}\n"
 msgstr "Há uma nova versão disponível {0}"
 
-#: ../../vdms_main/main_frame.py:1210
 msgid "You are using a development version that has not yet been released!\n"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1213
 #, fuzzy
 msgid "Congratulation! You are already using the latest version.\n"
 msgstr "Você está usando a versão youtube-dl {}"
 
-#: ../../vdms_main/main_frame.py:1301
 #, fuzzy
 msgid "Previous panel"
 msgstr "Vá para o painel anterior"
 
-#: ../../vdms_main/main_frame.py:1302
 msgid "Back"
 msgstr "Voltar"
 
-#: ../../vdms_main/main_frame.py:1305
 #, fuzzy
 msgid "Next panel"
 msgstr "Avançar >"
 
-#: ../../vdms_main/main_frame.py:1306
 msgid "Next"
 msgstr "Avançar"
 
-#: ../../vdms_main/main_frame.py:1309
 #, fuzzy
 msgid "Home panel"
 msgstr "Vá para o próximo painel"
 
-#: ../../vdms_main/main_frame.py:1310
 msgid "Home"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1313
 #, fuzzy
 msgid "Play the selected imput file"
 msgstr "Exclua o perfil selecionado"
 
-#: ../../vdms_main/main_frame.py:1314
 msgid "Play"
 msgstr "Reproduzir"
 
-#: ../../vdms_main/main_frame.py:1317
 #, fuzzy
 msgid "Get informative data about imported media streams"
 msgstr "Reúne informações de fluxos de multimídia"
 
-#: ../../vdms_main/main_frame.py:1321
 msgid "Start batch processing"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1325
 msgid "Stops current process"
 msgstr "Para o processo atual"
 
-#: ../../vdms_main/main_frame.py:1329
 msgid "Add an item to Queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1330
 msgid "Add to Queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1333
 msgid "Show queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1408 ../../vdms_panels/presets_manager.py:569
 msgid "Videomass"
 msgstr "Videomass"
 
-#: ../../vdms_main/main_frame.py:1442
 #, fuzzy
 msgid "Videomass - File List"
 msgstr "Videomass - arquivos enfileirados"
 
-#: ../../vdms_main/main_frame.py:1459
 msgid "Videomass - AV Conversions"
 msgstr "Videomass - Conversões AV"
 
-#: ../../vdms_main/main_frame.py:1488
 msgid "Videomass - Presets Manager"
 msgstr "Videomass - Gerenciador de predefinições"
 
-#: ../../vdms_main/main_frame.py:1518
 msgid "Videomass - Concatenate Demuxer"
 msgstr "Videomass - Concatenate Demuxer"
 
-#: ../../vdms_main/main_frame.py:1547
 #, fuzzy
 msgid "Videomass - From Movie to Pictures"
 msgstr "Videomass - Monitor de Saída"
 
-#: ../../vdms_main/main_frame.py:1576
 #, fuzzy
 msgid "Videomass - Still Image Maker"
 msgstr "Videomass - Gerenciador de predefinições"
 
-#: ../../vdms_main/main_frame.py:1660 ../../vdms_panels/av_conversions.py:577
-#: ../../vdms_panels/filedrop.py:500 ../../vdms_panels/filedrop.py:616
-#: ../../vdms_panels/sequence_to_video.py:322
-#: ../../vdms_panels/video_to_sequence.py:369
-#: ../../vdms_panels/video_to_sequence.py:501
 #, fuzzy
 msgid "Have to select an item in the file list first"
 msgstr "Primeiro selecione um perfil na lista"
 
-#: ../../vdms_main/main_frame.py:1682
 msgid ""
 "An item with the same destination file already exists.\n"
 "\n"
 "Do you want to replace it by adding the new item to the queue?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1703
 #, fuzzy
 msgid "Videomass - FFmpeg Message Monitoring"
 msgstr "Videomass - Monitor de Saída"
 
-#: ../../vdms_main/main_frame.py:1828
 #, python-brace-format
 msgid "The system will turn off in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1829
 #, fuzzy
 msgid "Videomass - Shutdown!"
 msgstr "Videomass - Carregando ..."
 
-#: ../../vdms_main/main_frame.py:1836
 msgid "Error while shutting down. Please see file log for details."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1848
 #, python-brace-format
 msgid "Exiting the application in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1849
 #, fuzzy
 msgid "Videomass - Exiting!"
 msgstr "Videomass - Carregando ..."
 
-#: ../../vdms_miniframes/timeline.py:46
 #, fuzzy
 msgid "Start point adjustment"
 msgstr "Inicia"
 
-#: ../../vdms_miniframes/timeline.py:48
 msgid "End point adjustment"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:105
 msgid "Hours"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:106
 #, fuzzy
 msgid "Minutes"
 msgstr "Inicia"
 
-#: ../../vdms_miniframes/timeline.py:107
 msgid "Seconds"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:108
 msgid "Milliseconds"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:189 ../../vdms_miniframes/timeline.py:312
 msgid "No source duration:"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:208 ../../vdms_miniframes/timeline.py:298
-#: ../../vdms_miniframes/timeline.py:333 ../../vdms_miniframes/timeline.py:338
-#: ../../vdms_miniframes/timeline.py:441
 #, python-brace-format
 msgid "{0} {1}  |  Segment Duration: {2}"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:260 ../../vdms_miniframes/timeline.py:277
 msgid "End adjustment"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:261 ../../vdms_miniframes/timeline.py:279
 #, fuzzy
 msgid "Start adjustment"
 msgstr "Inicia"
 
-#: ../../vdms_miniframes/timeline.py:320
 #, fuzzy
 msgid "Source duration:"
 msgstr "Duração"
 
-#: ../../vdms_miniframes/timeline.py:387
 msgid "WARNING: Invalid selection, out of range."
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:461
 msgid ""
 "Start by dragging the bottom left handle,\n"
 "or right-click for options."
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:497
 #, fuzzy
 msgid "Start"
 msgstr "Inicia"
 
-#: ../../vdms_miniframes/timeline.py:498
 #, fuzzy
 msgid "End"
 msgstr "Ativado"
 
-#: ../../vdms_miniframes/timeline.py:548
 msgid ""
 "The timeline editor is a tool that allows you to trim slices of time on selected imported media (see File List panel).\n"
 "\n"
@@ -2494,44 +1866,35 @@ msgid ""
 "The \"Start\"/\"End\" duration values always refer to the initial position of the timeline: 00:00:00.000. For other informations as the segment duration and warnings, please refer to the status bar messages."
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:565
 #, fuzzy
 msgid "Timeline Editor Usage"
 msgstr "Mostrar linha do tempo\tCtrl+T"
 
-#: ../../vdms_panels/av_conversions.py:153
 msgid "Media:"
 msgstr "Mídia:"
 
-#: ../../vdms_panels/av_conversions.py:169
 msgid "Container:"
 msgstr "Contêiner:"
 
-#: ../../vdms_panels/av_conversions.py:180
 #, fuzzy
 msgid "Save profile"
 msgstr "Salve o novo perfil em ..."
 
-#: ../../vdms_panels/av_conversions.py:183
 #, fuzzy
 msgid "Target"
 msgstr "Nível alvo:"
 
-#: ../../vdms_panels/av_conversions.py:316
 msgid "Miscellaneous"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:323
 #, fuzzy
 msgid "Save as a new profile of the Presets Manager."
 msgstr "Remova a predefinição selecionada do Gerenciador de Predefinições"
 
-#: ../../vdms_panels/av_conversions.py:325
 #, fuzzy
 msgid "Available video encoders. \"Copy\" means that the video stream will not be re-encoded and will allow you (depending on the encoder) to change the container, audio codec and a few other parameters."
 msgstr "Codecs de vídeo disponíveis. \"Copiar\" não é um codec, mas indica que a reprodução de vídeo não deve ser recodificada e permite alterar o formato ou outros parâmetros"
 
-#: ../../vdms_panels/av_conversions.py:330
 msgid ""
 "Container format. It is usually represented by the file extension (output format).\n"
 "\n"
@@ -2540,79 +1903,59 @@ msgid ""
 "If the media target is set to \"Audio\", you can extract only the audio streams from videos, or simply convert audio source files."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:338
 msgid ""
 "Set output files target: \"Video\" to save output files as video files; \"Audio\" to save files using an audio encoder and format.\n"
 "\n"
 "Note that by using \"Audio\" as the target, you will still be able to work on the video source files but you will only be able to extract the audio streams, convert them and apply audio filters such as normalization."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:346
 msgid "Preview video filters"
 msgstr "Filtros de pré-visualização de vídeo"
 
-#: ../../vdms_panels/av_conversions.py:347
 #, fuzzy
 msgid "Disable active filters"
 msgstr "Desabilitado"
 
-#: ../../vdms_panels/av_conversions.py:348
-#: ../../vdms_panels/sequence_to_video.py:156
-#: ../../vdms_panels/video_to_sequence.py:113
 #, fuzzy
 msgid "Resize"
 msgstr "Redimensionamento"
 
-#: ../../vdms_panels/av_conversions.py:349
 #, fuzzy
 msgid "Crop"
 msgstr "Recorte"
 
-#: ../../vdms_panels/av_conversions.py:350
 #, fuzzy
 msgid "Transpose"
 msgstr "Filtro de transposição"
 
-#: ../../vdms_panels/av_conversions.py:352
 #, fuzzy
 msgid "Denoise"
 msgstr "Redução de ruído"
 
-#: ../../vdms_panels/av_conversions.py:353
 #, fuzzy
 msgid "Stabilize"
 msgstr "Estabilizador"
 
-#: ../../vdms_panels/av_conversions.py:354
 msgid "Equalize"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:517
 msgid "Unable to preview Video Stabilizer filter"
 msgstr "Não é possível visualizar o filtro de estabilizador de vídeo"
 
-#: ../../vdms_panels/av_conversions.py:602
 msgid ""
 "Unsupported file:\n"
 "Missing decoder or library? Check FFmpeg configuration."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:611
-#: ../../vdms_panels/sequence_to_video.py:351
-#: ../../vdms_panels/video_to_sequence.py:398
 msgid "The file is not a frame or a video file"
 msgstr "O arquivo não é um frame ou um arquivo de vídeo"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:434
-#: ../../vdms_panels/av_conversions.py:861
 msgid "Undetected volume values! Click the \"Volume detect\" button to analyze audio volume data."
 msgstr "Valores de volume não detectados! Clique no botão \"Detecção de volume\" para analisar os dados de volume do áudio."
 
-#: ../../vdms_panels/av_conversions.py:1186
 msgid "Off"
 msgstr "Desligado"
 
-#: ../../vdms_panels/av_conversions.py:1203
 #, fuzzy
 msgid ""
 "Batch processing items\n"
@@ -2641,114 +1984,86 @@ msgstr ""
 "Período de tempo\n"
 "Mapa de entrada de áudio"
 
-#: ../../vdms_panels/av_conversions.py:1246
-#: ../../vdms_panels/presets_manager.py:814
 #, python-brace-format
 msgid "Write profile on «{0}»"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1266
-#: ../../vdms_panels/presets_manager.py:513
 msgid "Enter name for new preset"
 msgstr "Insira o nome para a nova predefinição"
 
-#: ../../vdms_panels/av_conversions.py:1276
-#: ../../vdms_panels/presets_manager.py:524
 msgid "Invalid file name, make sure to provide a valid name including the «.json» extension"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1284
 #, fuzzy, python-brace-format
 msgid "Cannot save current data in file «{}»."
 msgstr "Não é possível salvar os dados atuais no arquivo '{}'."
 
-#: ../../vdms_panels/av_conversions.py:1289
 #, fuzzy
 msgid "Open Videomass preset"
 msgstr "Sair do Videomass"
 
-#: ../../vdms_panels/av_conversions.py:1307
 #, fuzzy
 msgid "Videomass - Save new profile"
 msgstr "Criar um perfil novo"
 
-#: ../../vdms_panels/av_conversions.py:1308
 #, fuzzy
 msgid "Where do you want to save this profile?"
 msgstr " Você quer habilitar este recurso?"
 
-#: ../../vdms_panels/av_conversions.py:1309
 #, fuzzy
 msgid "Save the profile to a new preset"
 msgstr "Crie um novo perfil na predefinição \"% s\""
 
-#: ../../vdms_panels/av_conversions.py:1310
 #, fuzzy
 msgid "Save the profile to an existing preset"
 msgstr "Crie um novo perfil na predefinição \"% s\""
 
-#: ../../vdms_panels/choose_topic.py:69
 msgid "Welcome to Videomass"
 msgstr "Bem-vindo ao Videomass"
 
-#: ../../vdms_panels/choose_topic.py:71
 #, python-brace-format
 msgid "Version {}"
 msgstr "Versão {}"
 
-#: ../../vdms_panels/choose_topic.py:82
 msgid "Presets Manager"
 msgstr "Gerenciador de predefinições"
 
-#: ../../vdms_panels/choose_topic.py:85
 msgid "AV-Conversions"
 msgstr "Conversões A/V"
 
-#: ../../vdms_panels/choose_topic.py:88
 msgid "Concatenate media files"
 msgstr "Unir arquivos de mídia"
 
-#: ../../vdms_panels/choose_topic.py:91
 msgid "Still Image Maker"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:94
 msgid "From Movie to Pictures"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:123
 msgid "Create, edit and use quickly your favorite FFmpeg presets and profiles with full formats support and codecs."
 msgstr "Crie, edite e use rapidamente suas predefinições favoritas e perfis FFmpeg com suporte completo de formatos e codecs."
 
-#: ../../vdms_panels/choose_topic.py:127
 msgid "A set of useful tools for audio and video conversions. Save your profiles and reuse them with Presets Manager."
 msgstr "Um conjunto de ferramentas úteis para conversões de áudio e vídeo. Salve seus perfis e reutilize-os com o Gerenciador de predefinições."
 
-#: ../../vdms_panels/choose_topic.py:131
 msgid "Concatenate multiple media files based on import order without re-encoding"
 msgstr "Unir vários arquivos de mídia com base na ordem de importação sem recodificar"
 
-#: ../../vdms_panels/choose_topic.py:134
 msgid "Create video from a sequence of images, based on import order, with the ability to add an audio file."
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:137
 msgid "Extract images (frames) from your movies in JPG, PNG, BMP, GIF formats."
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:47
 msgid "At least two files are required to perform concatenation."
 msgstr "São necessários pelo menos dois arquivos para realizar a concatenação."
 
-#: ../../vdms_panels/concatenate.py:63
 msgid "Invalid data found"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:68
 msgid "The files do not have the same \"codec_types\", same \"sample_rate\" or same \"width\" or \"height\". Unable to proceed."
 msgstr "Os arquivos não possuem os mesmos \"tipos de codec\", mesma \"taxa de amostragem\" ou mesma \"largura\" ou \"altura\". Incapaz de prosseguir."
 
-#: ../../vdms_panels/concatenate.py:84
 #, fuzzy
 msgid ""
 "\n"
@@ -2778,17 +2093,12 @@ msgstr ""
 "\n"
 "- Os arquivos de áudio devem ter exatamente os mesmos formatos, mesmos codecs e mesma taxa de amostragem."
 
-#: ../../vdms_panels/concatenate.py:125
 msgid "Videomass Documentation:"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:136
-#: ../../vdms_panels/sequence_to_video.py:212
-#: ../../vdms_panels/video_to_sequence.py:181
 msgid "Official FFmpeg documentation:"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:253
 #, fuzzy
 msgid ""
 "Items to concatenate\n"
@@ -2805,277 +2115,215 @@ msgstr ""
 "Formato de saída\n"
 "Período de tempo"
 
-#: ../../vdms_panels/filedrop.py:45
 msgid "File has illegal characters like:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:46
 msgid "Invalid character found in path name: (\")"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:47
 msgid "Directories are not allowed, just add files, please."
 msgstr "Diretórios não são permitidos, apenas adicione arquivos, por favor."
 
-#: ../../vdms_panels/filedrop.py:48
 msgid "File without format extension: please give an appropriate extension to the file name, example '.mkv', '.avi', '.mp3', etc."
 msgstr "Arquivo sem extensão de formato: forneça uma extensão apropriada para o nome do arquivo, por exemplo '.mkv', '.avi', '.mp3', etc."
 
-#: ../../vdms_panels/filedrop.py:84
 #, python-brace-format
 msgid "Name has illegal characters like: {0}"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:85
 msgid "Name already in use:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:185
 msgid "Duplicate file, it has already been added to the list."
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:197
 #, fuzzy
 msgid "Rejected files"
 msgstr "Adicionar arquivos"
 
-#: ../../vdms_panels/filedrop.py:269
 #, fuzzy
 msgid "Source file"
 msgstr "Preferências de arquivo"
 
-#: ../../vdms_panels/filedrop.py:270
 msgid "Duration"
 msgstr "Duração"
 
-#: ../../vdms_panels/filedrop.py:271
 msgid "Media type"
 msgstr "Tipo de mídia"
 
-#: ../../vdms_panels/filedrop.py:272
 msgid "Size"
 msgstr "Tamanho"
 
-#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:405
 msgid "Drag one or more files below"
 msgstr "Arraste um ou mais arquivos abaixo"
 
-#: ../../vdms_panels/filedrop.py:282
 #, fuzzy
 msgid "Save to:"
 msgstr "Ajuste"
 
-#: ../../vdms_panels/filedrop.py:306
 #, fuzzy
 msgid "Set a new destination folder for encodings"
 msgstr "Crie uma nova predefinição"
 
-#: ../../vdms_panels/filedrop.py:308
 #, fuzzy
 msgid "Encodings destination folder"
 msgstr "Pasta de configuração"
 
-#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:394
 #, fuzzy
 msgid "Play file"
 msgstr "Perfil"
 
-#: ../../vdms_panels/filedrop.py:408
 #, fuzzy
 msgid "Drag two or more Audio/Video files below"
 msgstr "Arraste um ou mais arquivos abaixo"
 
-#: ../../vdms_panels/filedrop.py:412
 #, fuzzy
 msgid "Drag one or more Image files below"
 msgstr "Arraste um ou mais arquivos abaixo"
 
-#: ../../vdms_panels/filedrop.py:415
 #, fuzzy
 msgid "Drag one or more Video files below"
 msgstr "Arraste um ou mais arquivos abaixo"
 
-#: ../../vdms_panels/filedrop.py:623
 #, fuzzy
 msgid "Rename the file destination"
 msgstr "Restaurar as pastas de destino padrão"
 
-#: ../../vdms_panels/filedrop.py:624
 #, fuzzy
 msgid "Rename the selected file to:"
 msgstr "Exclua o perfil selecionado"
 
-#: ../../vdms_panels/filedrop.py:638 ../../vdms_panels/filedrop.py:648
-#: ../../vdms_panels/filedrop.py:679
 msgid "Add Files"
 msgstr "Adicionar arquivos"
 
-#: ../../vdms_panels/filedrop.py:655
 msgid "Rename in batch"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:656
 #, python-brace-format
 msgid "Rename the {0} items to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:658
 #, fuzzy
 msgid "New Name #"
 msgstr "Nome do arquivo"
 
-#: ../../vdms_panels/long_processing_task.py:114
 msgid "Sorry, all task failed !"
 msgstr "Desculpe, a tarefa falhou!"
 
-#: ../../vdms_panels/long_processing_task.py:115
 msgid "The process was stopped due to a fatal error."
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:116
 msgid "Interrupted Process !"
 msgstr "Desculpe, a tarefa falhou!"
 
-#: ../../vdms_panels/long_processing_task.py:117
 msgid "Successfully completed !"
 msgstr "Concluído com sucesso!"
 
-#: ../../vdms_panels/long_processing_task.py:118
 msgid "Not everything was successful."
 msgstr "Nem tudo foi bem-sucedido."
 
-#: ../../vdms_panels/long_processing_task.py:148
 msgid "Encoding Status"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:152
 #, fuzzy
 msgid "Current Log"
 msgstr "Caminho atual:"
 
-#: ../../vdms_panels/long_processing_task.py:354
 msgid "Fatal Error !"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:363
 msgid "Get your files at the destination you specified"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:377
 msgid "For more details please read the Current Log."
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:380
 msgid "...Finished"
 msgstr "...Finalizado"
 
-#: ../../vdms_panels/long_processing_task.py:399
 #, fuzzy
 msgid "Please wait... interruption in progress"
 msgstr "aguarde ... encerrando"
 
-#: ../../vdms_panels/long_processing_task.py:402
 msgid "...Interrupted"
 msgstr "Interrompido"
 
-#: ../../vdms_panels/presets_manager.py:166
 msgid "Presets"
 msgstr "Ajustes"
 
-#: ../../vdms_panels/presets_manager.py:180
 msgid "Write"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:184
 msgid "Delete"
 msgstr "Excluir"
 
-#: ../../vdms_panels/presets_manager.py:194
 msgid "Duplicate"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:199
 msgid "Profiles"
 msgstr "Perfis"
 
-#: ../../vdms_panels/presets_manager.py:206
 #, fuzzy
 msgid "One-Pass Encoding"
 msgstr "Primeira passagem"
 
-#: ../../vdms_panels/presets_manager.py:218
 #, fuzzy
 msgid "Two-Pass Encoding"
 msgstr "Segunda passagem"
 
-#: ../../vdms_panels/presets_manager.py:232
 msgid "Choose a preset and view its profiles"
 msgstr "Escolha uma predefinição e veja seus perfis"
 
-#: ../../vdms_panels/presets_manager.py:233
 #, fuzzy
 msgid "Write a new profile and save it in the selected preset"
 msgstr "Crie um novo perfil e salve-o na predefinição selecionada"
 
-#: ../../vdms_panels/presets_manager.py:235
 msgid "Delete the selected profile"
 msgstr "Exclua o perfil selecionado"
 
-#: ../../vdms_panels/presets_manager.py:236
 msgid "Edit the selected profile"
 msgstr "Editar o perfil selecionado"
 
-#: ../../vdms_panels/presets_manager.py:237
 #, fuzzy
 msgid "Duplicate the selected profile"
 msgstr "Exclua o perfil selecionado"
 
-#: ../../vdms_panels/presets_manager.py:238
 #, fuzzy
 msgid "Create new preset"
 msgstr "Crie uma nova predefinição"
 
-#: ../../vdms_panels/presets_manager.py:240
 #, fuzzy
 msgid "Remove selected preset"
 msgstr "Exclua o perfil selecionado"
 
-#: ../../vdms_panels/presets_manager.py:242
 #, fuzzy
 msgid "Backup selected preset"
 msgstr "Exportar predefinição selecionada como cópia"
 
-#: ../../vdms_panels/presets_manager.py:244
 #, fuzzy
 msgid "Backup the presets folder"
 msgstr "Importar uma nova pasta de predefinições"
 
-#: ../../vdms_panels/presets_manager.py:246
 #, fuzzy
 msgid "Restore a preset"
 msgstr "Exportar selecionado"
 
-#: ../../vdms_panels/presets_manager.py:248
 #, fuzzy
 msgid "Restore a presets folder"
 msgstr "Importar uma nova pasta de predefinições"
 
-#: ../../vdms_panels/presets_manager.py:250
 #, fuzzy
 msgid "Resets the selected preset to default values"
 msgstr "Substitua a predefinição selecionada pela padrão do Videomass"
 
-#: ../../vdms_panels/presets_manager.py:252
 #, fuzzy
 msgid "Reset all presets to default values"
 msgstr "Recupere todas as predefinições padrão do Videomass"
 
-#: ../../vdms_panels/presets_manager.py:254
 #, fuzzy
 msgid "Refresh the presets list"
 msgstr "Atualize a lista de predefinições"
 
-#: ../../vdms_panels/presets_manager.py:338
 #, python-brace-format
 msgid ""
 "Outdated presets version found: v{1}\n"
@@ -3089,28 +2337,22 @@ msgid ""
 "Do you want to perform this update now?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:403
 msgid "Name"
 msgstr "Nome"
 
-#: ../../vdms_panels/presets_manager.py:405
 msgid "Output Format"
 msgstr "Formato de saída"
 
-#: ../../vdms_panels/presets_manager.py:406
 msgid "Supported Format List"
 msgstr "Lista de formatos suportados"
 
-#: ../../vdms_panels/presets_manager.py:531
 #, python-brace-format
 msgid "Cannot save current data in file '{}'."
 msgstr "Não é possível salvar os dados atuais no arquivo '{}'."
 
-#: ../../vdms_panels/presets_manager.py:535
 msgid "You just successfully created a new preset!"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:547
 #, fuzzy, python-brace-format
 msgid ""
 "Are you sure you want to remove \"{}\" preset?\n"
@@ -3121,7 +2363,6 @@ msgstr ""
 "\n"
 "Ela será movida para a subpasta \"Removals\" da pasta de predefinições."
 
-#: ../../vdms_panels/presets_manager.py:558
 #, python-brace-format
 msgid ""
 "{}\n"
@@ -3132,32 +2373,24 @@ msgstr ""
 "\n"
 "Desculpe, a remoção falhou, não é possível continuar .."
 
-#: ../../vdms_panels/presets_manager.py:568
 #, python-brace-format
 msgid "The preset \"{0}\" was successfully removed"
 msgstr "A predefinição \"{0}\" foi removida com sucesso"
 
-#: ../../vdms_panels/presets_manager.py:583
-#: ../../vdms_panels/presets_manager.py:612
 #, fuzzy
 msgid "Open a destination folder"
 msgstr "Diretório de destino"
 
-#: ../../vdms_panels/presets_manager.py:588
 msgid "A file with this name already exists, do you want to overwrite it?"
 msgstr "Já existe um arquivo com este nome, deseja substituí-lo?"
 
-#: ../../vdms_panels/presets_manager.py:602
-#: ../../vdms_panels/presets_manager.py:622
 #, fuzzy
 msgid "Backup completed successfully"
 msgstr "Assistente concluído com sucesso!\n"
 
-#: ../../vdms_panels/presets_manager.py:631
 msgid "Open the preset you want to restore"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:645
 msgid ""
 "This preset already exists and is about to be updated. Don't worry, it will keep all your saved profiles.\n"
 "\n"
@@ -3167,12 +2400,10 @@ msgstr ""
 "\n"
 "Você quer continuar?"
 
-#: ../../vdms_panels/presets_manager.py:663
 #, fuzzy
 msgid "Restore successful"
 msgstr "Assistente concluído com sucesso!\n"
 
-#: ../../vdms_panels/presets_manager.py:681
 msgid ""
 "This will update the presets database. Don't worry, it will keep all your saved profiles.\n"
 "\n"
@@ -3182,21 +2413,17 @@ msgstr ""
 "\n"
 "Você quer continuar?"
 
-#: ../../vdms_panels/presets_manager.py:689
 #, fuzzy
 msgid "Open the presets folder to restore"
 msgstr "Importar uma nova pasta de predefinições"
 
-#: ../../vdms_panels/presets_manager.py:725
 msgid "The presets database has been successfully updated"
 msgstr "O banco de dados de predefinições foi atualizado com sucesso"
 
-#: ../../vdms_panels/presets_manager.py:740
 #, fuzzy
 msgid "The selected preset is not part of Videomass's default presets."
 msgstr "Substitua a predefinição selecionada pela padrão do Videomass"
 
-#: ../../vdms_panels/presets_manager.py:745
 msgid ""
 "Be careful! The selected preset will be overwritten with the default one. Your profiles may be deleted!\n"
 "\n"
@@ -3206,12 +2433,9 @@ msgstr ""
 "\n"
 "Você quer continuar?"
 
-#: ../../vdms_panels/presets_manager.py:760
-#: ../../vdms_panels/presets_manager.py:794
 msgid "Successful recovery"
 msgstr "Recuperação bem sucedida"
 
-#: ../../vdms_panels/presets_manager.py:769
 #, fuzzy
 msgid ""
 "Be careful! This action will restore all presets to default ones. Your profiles may be deleted!\n"
@@ -3224,20 +2448,16 @@ msgstr ""
 "\n"
 "Você quer continuar?"
 
-#: ../../vdms_panels/presets_manager.py:833
 #, fuzzy, python-brace-format
 msgid "Edit profile on «{0}»"
 msgstr "Edite o perfil da predefinição \"% s\": "
 
-#: ../../vdms_panels/presets_manager.py:872
 msgid "Are you sure you want to delete the selected profile? It will no longer be possible to recover it."
 msgstr "Tem certeza de que deseja excluir o perfil selecionado? Não será mais possível recuperá-lo."
 
-#: ../../vdms_panels/presets_manager.py:891
 msgid "First select a profile in the list"
 msgstr "Primeiro selecione um perfil na lista"
 
-#: ../../vdms_panels/presets_manager.py:899
 msgid ""
 "The selected profile command has been changed manually.\n"
 "Do you want to apply it during the conversion process?"
@@ -3245,11 +2465,9 @@ msgstr ""
 "O comando de perfil selecionado foi alterado manualmente.\n"
 "Quer aplicá-lo durante o processo de conversão?"
 
-#: ../../vdms_panels/presets_manager.py:909
 msgid "Don't show this dialog again"
 msgstr "Não mostrar esta caixa de diálogo novamente"
 
-#: ../../vdms_panels/presets_manager.py:1054
 #, fuzzy
 msgid ""
 "Batch processing items\n"
@@ -3275,11 +2493,9 @@ msgstr ""
 "Período de tempo\n"
 "Mapa de entrada de áudio"
 
-#: ../../vdms_panels/sequence_to_video.py:54
 msgid "Images need to be resized, please use Resize function."
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:73
 msgid ""
 "\n"
 "1. Import one or more image files such as JPG, PNG and BMP formats, then select one.\n"
@@ -3297,39 +2513,30 @@ msgid ""
 "will be saved in a folder named 'Still_Images' with a progressive digit, in the path you specify."
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:129
 msgid "Enable a single still image"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:162
 msgid ""
 "Force original aspect ratio using\n"
 "padding rather than stretching"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:170
 msgid "Include audio file"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:173
 msgid "Play the video until audio track finishes"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:180
-#: ../../vdms_panels/sequence_to_video.py:439
 msgid "Open audio file"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:199
 msgid "Additional arguments"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:454
 #, fuzzy
 msgid "Open Audio File"
 msgstr "Arraste um ou mais arquivos abaixo"
 
-#: ../../vdms_panels/sequence_to_video.py:466
 #, fuzzy, python-brace-format
 msgid ""
 "Invalid file: '{}'\n"
@@ -3337,7 +2544,6 @@ msgid ""
 "{}"
 msgstr "URL inválido: \"{}\""
 
-#: ../../vdms_panels/sequence_to_video.py:471
 #, python-brace-format
 msgid ""
 "Invalid file: '{}'\n"
@@ -3345,21 +2551,14 @@ msgid ""
 "It doesn't appear to be an audio file."
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:560
-#: ../../vdms_panels/sequence_to_video.py:587
-#: ../../vdms_panels/video_to_sequence.py:511
 #, fuzzy, python-brace-format
 msgid "Invalid file: '{}'"
 msgstr "URL inválido: \"{}\""
 
-#: ../../vdms_panels/sequence_to_video.py:570
-#: ../../vdms_panels/sequence_to_video.py:595
 #, fuzzy, python-brace-format
 msgid "Unsupported format '{}'"
 msgstr "Lista de formatos suportados"
 
-#: ../../vdms_panels/sequence_to_video.py:576
-#: ../../vdms_panels/sequence_to_video.py:600
 #, fuzzy, python-brace-format
 msgid ""
 "File does not exist:\n"
@@ -3370,15 +2569,9 @@ msgstr ""
 "\n"
 "\"% s\"\n"
 
-#: ../../vdms_panels/sequence_to_video.py:577
 msgid "ERROR"
 msgstr "ERRO"
 
-#: ../../vdms_panels/sequence_to_video.py:707
-msgid "Shortest"
-msgstr ""
-
-#: ../../vdms_panels/sequence_to_video.py:715
 #, fuzzy
 msgid ""
 "Items to concatenate\n"
@@ -3408,7 +2601,6 @@ msgstr ""
 "Período de tempo\n"
 "Mapa de entrada de áudio"
 
-#: ../../vdms_panels/video_to_sequence.py:50
 msgid ""
 "\n"
 "1. Import one or more video files, then select one.\n"
@@ -3425,51 +2617,39 @@ msgid ""
 "with a progressive digit, in the path you specify."
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:86
 msgid "Create thumbnails"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:87
 msgid "Create tiled mosaics"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:88
 msgid "Create animated GIF"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:90
 msgid "Options"
 msgstr "Opções"
 
-#: ../../vdms_panels/video_to_sequence.py:119
 msgid "Output format:"
 msgstr "Formato de saída:"
 
-#: ../../vdms_panels/video_to_sequence.py:131
 msgid "Rows:"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:141
 msgid "Columns:"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:205
 msgid "Other unofficial resources:"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:229
 msgid "Set FPS control from 0.1 to 30.0 fps. The higher this value, the more images will be extracted."
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:232
 msgid "Spaces around the mosaic tiles. From 0 to 32 pixels"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:234
 msgid "Spaces around the mosaic borders. From 0 to 32 pixels"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:626
 msgid ""
 "Selected File\n"
 "Output Format\n"
@@ -3485,58 +2665,45 @@ msgid ""
 "Duration"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:118
 msgid "Audio encoder settings, mapping and filters"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:128
 msgid "Audio Encoder"
 msgstr "Codificador de Áudio"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:137
 msgid "Settings"
 msgstr "Configurações"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:148
 msgid "Index Selection:"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:157
 msgid "Map:"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:180
 msgid "Normalization"
 msgstr "Normalização"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:191
 msgid "Volume detect"
 msgstr "Detecção de volume"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:195
 msgid "Volume Statistics"
 msgstr "Estatísticas de volume"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:199
 msgid "Target level:"
 msgstr "Nível alvo:"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:264
 msgid "Gets maximum volume and average volume data in dBFS, then calculates the offset amount for audio normalization."
 msgstr "Obtém o volume máximo e os dados de volume médio em dBFS e, a seguir, calcula o valor de deslocamento para a normalização de áudio."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:267
 msgid "Limiter for the maximum peak level or the mean level (when switch to RMS) in dBFS. From -99.0 to +0.0; default for PEAK level is -1.0; default for RMS is -20.0"
 msgstr "Limitador para o nível máximo de altura, ou o nível médio (quando alternar para RMS) em dBFS. De -99,0 a +0,0; o padrão para o nível PEAK é -1,0; o padrão para RMS é -20,0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:271
 msgid ""
 "Normally on a video with correctly indexed streams and having one or more audio streams, the first audio stream should be indexed at \"1\", the second at \"2\" and so on (the video stream on the other hand is always indexed at \"0\"). In this case it is recommended to select the desired stream by setting a specific index, e.g \"1\" for for the first available audio stream.\n"
 "\n"
 "Set this control to \"Auto\" if the source file is simply an audio track."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:280
 msgid ""
 "\"Auto\" keeps all audio streams and processes only the one selected by the \"Index Selection\" control.\n"
 "\n"
@@ -3545,77 +2712,62 @@ msgid ""
 "\"Index Only\" processes only the audio stream selected by the \"Index Selection\" control and removes all others from the video"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:288
 #, fuzzy
 msgid "Integrated Loudness Target in LUFS. From -70.0 to -5.0, default is -16.0"
 msgstr "Ponto de intensidade integrada em LUFS. De -70,0 a -5,0, o padrão é -24,0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:291
 #, fuzzy
 msgid "Maximum True Peak in dBTP. From -1.5 to +0.0, default is -2.0"
 msgstr "Altura máxima real em dBTP. De -9,0 a +0,0, o padrão é -2,0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:294
 #, fuzzy
 msgid "Loudness Range Target in LUFS. From +1.0 to +20.0, default is +11.0"
 msgstr "Ponto da faixa de intensidade em LUFS. De +1,0 a +20,0, o padrão é +7,0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:297
 msgid "Play the audio stream selected in the \"Index Selection\" control. Using this function you can test the result of audio normalization."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:503
 msgid "Selected index does not exist or does not contain any audio streams"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:508
 #, python-brace-format
 msgid ""
 "ERROR: Missing audio stream:\n"
 "\"{}\""
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:726
 #, fuzzy
 msgid "PEAK level normalization, which will produce a maximum peak level equal to the set target level."
 msgstr "Ative a normalização de nível de altura, que produzirá um nível de altura máximo igual ao nível de destino definido."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:729
 #, fuzzy
 msgid "RMS-based normalization, which according to mean volume calculates the amount of gain to reach same average power signal."
 msgstr "Ative a normalização baseada em RMS, que de acordo com o volume médio calcula a quantidade de ganho para atingir o mesmo sinal de potência média."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:733
 #, fuzzy
 msgid ""
 "Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements the EBU R128 algorithm.\n"
 "Ideal for live normalization. It produces worse results than the High-quality two-pass Loudnorm normalization, but is faster."
 msgstr "Ative a normalização de duas passagens. Ele normaliza o volume percebido usando o filtro \"loudnorm\", que implementa o algoritmo EBU R128."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:740
 #, fuzzy
 msgid ""
 "High-quality two-pass Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements\n"
 "the EBU R128 algorithm. Ideal for postprocessing."
 msgstr "Ative a normalização de duas passagens. Ele normaliza o volume percebido usando o filtro \"loudnorm\", que implementa o algoritmo EBU R128."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:789
 msgid "You need to import at least one file"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:63
 msgid "Subtitle Mapping:"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:77
 msgid "Copy Chapters"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:79
 msgid "Copy Metadata"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:85
 msgid ""
 "Select \"All\" to include any source file subtitles in the output video.\n"
 "\n"
@@ -3624,158 +2776,74 @@ msgid ""
 "This option is automatically ignored for output audio files."
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:90
 msgid "Copy the chapter markers as is from source file. This option is automatically ignored for output audio files."
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:93
 msgid "Copy all incoming metadata from source file, such as audio/video tags, titles, unique marks, and so on."
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:108
 #, fuzzy
 msgid "Additional options"
 msgstr "mostrar mais opções"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:89
-#: ../../vdms_panels/video_encoders/av1_svt.py:120
-#: ../../vdms_panels/video_encoders/avc_x264.py:90
-#: ../../vdms_panels/video_encoders/hevc_x265.py:98
-#: ../../vdms_panels/video_encoders/mpeg4.py:71
-#: ../../vdms_panels/video_encoders/vp9_webm.py:131
 #, fuzzy
 msgid "Reload"
 msgstr "Recarregar"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:101
-#: ../../vdms_panels/video_encoders/av1_svt.py:129
-#: ../../vdms_panels/video_encoders/avc_x264.py:101
-#: ../../vdms_panels/video_encoders/hevc_x265.py:109
-#: ../../vdms_panels/video_encoders/mpeg4.py:82
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:97
-#: ../../vdms_panels/video_encoders/vp9_webm.py:141
 #, fuzzy
 msgid "Optimize for Web"
 msgstr "Use para a web"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:247
-#: ../../vdms_panels/video_encoders/av1_svt.py:313
-#: ../../vdms_panels/video_encoders/avc_x264.py:242
-#: ../../vdms_panels/video_encoders/hevc_x265.py:250
-#: ../../vdms_panels/video_encoders/mpeg4.py:198
-#: ../../vdms_panels/video_encoders/vp9_webm.py:288
 msgid "Reloads the selected video encoder settings. Changes will be discarded."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:250
-#: ../../vdms_panels/video_encoders/avc_x264.py:273
-#: ../../vdms_panels/video_encoders/hevc_x265.py:277
-#: ../../vdms_panels/video_encoders/vp9_webm.py:291
 #, fuzzy
 msgid "Constant rate factor. Lower values correspond to higher quality and greater file size. Set to -1 to disable this control."
 msgstr "Fator de taxa constante. Valores mais baixos = qualidade superior e um tamanho de arquivo maior. Defina -1 para desativar este controle."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:254
-#: ../../vdms_panels/video_encoders/av1_svt.py:357
-#: ../../vdms_panels/video_encoders/vp9_webm.py:295
 msgid "Number of tile rows to use, default changes per resolution"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:256
-#: ../../vdms_panels/video_encoders/av1_svt.py:359
-#: ../../vdms_panels/video_encoders/vp9_webm.py:297
 msgid "Number of tile columns to use, default changes per resolution"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:259
-#: ../../vdms_panels/video_encoders/av1_svt.py:368
-#: ../../vdms_panels/video_encoders/avc_x264.py:253
-#: ../../vdms_panels/video_encoders/hevc_x265.py:261
-#: ../../vdms_panels/video_encoders/mpeg4.py:201
-#: ../../vdms_panels/video_encoders/vp9_webm.py:300
 #, fuzzy
 msgid "Set the Group Of Picture (GOP). Set to -1 to disable this control."
 msgstr "Especifica uma tolerância mínima a ser usada"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:262
-#: ../../vdms_panels/video_encoders/av1_svt.py:371
-#: ../../vdms_panels/video_encoders/avc_x264.py:256
-#: ../../vdms_panels/video_encoders/hevc_x265.py:264
-#: ../../vdms_panels/video_encoders/mpeg4.py:204
-#: ../../vdms_panels/video_encoders/vp9_webm.py:303
 msgid "It can reduce the file size, but takes longer."
 msgstr "Isso pode reduzir o tamanho do arquivo, mas leva mais tempo."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:264
-#: ../../vdms_panels/video_encoders/av1_svt.py:373
-#: ../../vdms_panels/video_encoders/avc_x264.py:258
-#: ../../vdms_panels/video_encoders/hevc_x265.py:266
-#: ../../vdms_panels/video_encoders/mpeg4.py:206
-#: ../../vdms_panels/video_encoders/vp9_webm.py:305
 #, fuzzy
 msgid "Set minimum bitrate tolerance. Most useful in setting up a CBR encode. It is of little use otherwise. Set to -1 to disable this control."
 msgstr "Especifica uma tolerância máxima. Isso só é usado em conjunto com o tamanho do buffer"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:268
-#: ../../vdms_panels/video_encoders/av1_svt.py:377
-#: ../../vdms_panels/video_encoders/avc_x264.py:262
-#: ../../vdms_panels/video_encoders/hevc_x265.py:270
-#: ../../vdms_panels/video_encoders/mpeg4.py:210
-#: ../../vdms_panels/video_encoders/vp9_webm.py:309
 #, fuzzy
 msgid "Specifies a maximum tolerance. Requires bufsize to be set. Set to -1 to disable this control."
 msgstr "Especifica uma tolerância mínima a ser usada"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:271
-#: ../../vdms_panels/video_encoders/av1_svt.py:380
-#: ../../vdms_panels/video_encoders/avc_x264.py:265
-#: ../../vdms_panels/video_encoders/hevc_x265.py:273
-#: ../../vdms_panels/video_encoders/mpeg4.py:213
-#: ../../vdms_panels/video_encoders/vp9_webm.py:312
 #, fuzzy
 msgid "Set ratecontrol buffer size, which determines the variability of the output bitrate. Set to -1 to disable this control."
 msgstr "Especifica o tamanho do buffer do decodificador, que determina a variabilidade da taxa de bits de saída "
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:275
-#: ../../vdms_panels/video_encoders/av1_svt.py:384
-#: ../../vdms_panels/video_encoders/avc_x264.py:277
-#: ../../vdms_panels/video_encoders/hevc_x265.py:281
-#: ../../vdms_panels/video_encoders/mpeg4.py:231
-#: ../../vdms_panels/video_encoders/vp9_webm.py:316
 #, fuzzy
 msgid "Specifies the target (average) bit rate for the encoder to use. Higher value = higher quality. Set -1 to disable this control."
 msgstr "especifica a taxa de bits desejada (média) para o codificador usar. Maior valor = maior qualidade. Defina -1 para desativar este controle."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:279
-#: ../../vdms_panels/video_encoders/av1_svt.py:388
-#: ../../vdms_panels/video_encoders/avc_x264.py:281
-#: ../../vdms_panels/video_encoders/hevc_x265.py:285
-#: ../../vdms_panels/video_encoders/mpeg4.py:235
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:131
-#: ../../vdms_panels/video_encoders/vp9_webm.py:320
 msgid "Video width and video height ratio."
 msgstr "Largura do vídeo e proporção da altura do vídeo."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:281
-#: ../../vdms_panels/video_encoders/av1_svt.py:390
-#: ../../vdms_panels/video_encoders/avc_x264.py:283
-#: ../../vdms_panels/video_encoders/hevc_x265.py:287
-#: ../../vdms_panels/video_encoders/mpeg4.py:237
-#: ../../vdms_panels/video_encoders/vp9_webm.py:322
 #, fuzzy
 msgid "Frame rate (frames per second). Frames repeat a given number of times per second. In some countries this is 30 for NTSC, other countries (like Italy) use 25 for PAL"
 msgstr "Os quadros se repetem um determinado número de vezes por segundo. Em alguns países, é 30 para NTSC, outros países (como a Itália) usam 25 para PAL"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:285
 msgid "Quality/Speed ratio modifier. CPU Used sets how efficient the compression will be. Lower values mean slower encoding with better quality, and vice-versa. Valid values are from 0 to 8 inclusive."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:290
 #, fuzzy
 msgid "Quality and compression efficiency vs speed trade-off. \"good\" is the default and recommended for most applications; \"realtime\" is recommended for live/fast encoding (live streaming, video conferencing, etc); \"allintra\" for All Intra encoding."
 msgstr "\"bom\" é o padrão e recomendado para a maioria dos aplicativos; \"melhor\" é recomendado se você tiver muito tempo e quiser a melhor eficiência de compressão; \"tempo real\" é recomendado para codificação ao vivo / rápida"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:297
 msgid ""
 "Row Multi-Threading enables row-based multi-threading which maximizes CPU usage.\n"
 "\n"
@@ -3784,7 +2852,6 @@ msgid ""
 "Enabling Row Multi-Threading is only faster when the CPU has more threads than the number of encoded tiles."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:316
 msgid ""
 "presets 1-3 represent extremely high efficiency, for use when encode time is not important and quality/size of the resulting video file is critical.\n"
 "\n"
@@ -3795,7 +2862,6 @@ msgid ""
 "Preset 13 is even faster but not intended for direct human consumption--it can be used, for example, as a per-scene quality metric in VOD applications. One should use the lowest preset that is tolerable."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:327
 msgid ""
 "Constant rate factor. This parameter governs the quality/size trade-off.\n"
 "\n"
@@ -3806,7 +2872,6 @@ msgid ""
 "Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:334
 msgid ""
 "The \"Film Grain\" parameter allows SVT-AV1 to detect and delete film grain from the source video, and replace it with synthetic grain of the same character, resulting in significant bitrate savings.\n"
 "\n"
@@ -3819,81 +2884,58 @@ msgid ""
 "If the source video does not have natural grain, this parameter can be set to -1 to disable it or at least 0."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:346
 msgid ""
 "If enabled, the \"Film Grain Denoiser\" option can mitigate the detail removal caused by high \"Film Grain\" values required to preserve the look of very grainy films\n"
 "\n"
 "By default, the denoised frames are passed to be encoded as the final pictures, enabling this feature will lead to the original frames to be used instead. "
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:353
 msgid "Enables encoder optimization to produce faster (less CPU intensive) bit streams to decode, similar to the fastdecode tuning in x264 and x265."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:362
-#: ../../vdms_panels/video_encoders/avc_x264.py:247
-#: ../../vdms_panels/video_encoders/hevc_x265.py:255
 msgid "Set profile restrictions"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:364
-#: ../../vdms_panels/video_encoders/avc_x264.py:249
-#: ../../vdms_panels/video_encoders/hevc_x265.py:257
 #, fuzzy
 msgid "Specify level for a selected profile"
 msgstr "Exclua o perfil selecionado"
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:366
-#: ../../vdms_panels/video_encoders/avc_x264.py:251
-#: ../../vdms_panels/video_encoders/hevc_x265.py:259
 msgid "Tune the encoding params"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/avc_x264.py:245
-#: ../../vdms_panels/video_encoders/hevc_x265.py:253
 msgid "Set the encoding preset (default \"medium\")"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/avc_x264.py:269
 msgid "specifies the target (average) bit rate for the encoder to use. Higher value = higher quality. Set -1 to disable this control."
 msgstr "especifica a taxa de bits desejada (média) para o codificador usar. Maior valor = maior qualidade. Defina -1 para desativar este controle."
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:217
 msgid "Variable Bit Rate. From 0-30, with 1 being highest quality/largest filesize and 30 being the lowest quality/smallest filesize. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:222
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:133
 msgid "Frames repeat a given number of times per second. In some countries this is 30 for NTSC, other countries (like Italy) use 25 for PAL"
 msgstr "Os quadros se repetem um determinado número de vezes por segundo. Em alguns países, é 30 para NTSC, outros países (como a Itália) usam 25 para PAL"
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:226
 msgid "The default FourCC stored in an MPEG-4-coded file will be FMP4. If you want a different FourCC, set this option to xvid to force the FourCC xvid to be stored as the video FourCC rather than the default."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:162
 msgid "Copy Video Codec"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:163
 msgid ""
 "This will just copy the video track as is, without any video re-encoding.\n"
 "You will only be able to change output format, select other audio encoders and\n"
 "a few other options."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_no_enc.py:74
 msgid "Video export disabled"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_no_enc.py:75
 msgid ""
 "The Media target you just selected will only allow you to export files as audio tracks.\n"
 "You can then process audio source files only or extract indexed audio streams on\n"
 "video files."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:326
 msgid ""
 "Speed sets how efficient the compression will be.\n"
 "\n"
@@ -3906,7 +2948,6 @@ msgid ""
 "When the Quality is set to realtime, the available values for Speed are 0 to 8."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:335
 #, fuzzy
 msgid ""
 "Time to spend encoding.\n"
@@ -3918,25 +2959,22 @@ msgid ""
 "\"realtime\" is recommended for live / fast encoding."
 msgstr "\"bom\" é o padrão e recomendado para a maioria dos aplicativos; \"melhor\" é recomendado se você tiver muito tempo e quiser a melhor eficiência de compressão; \"tempo real\" é recomendado para codificação ao vivo / rápida"
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:341
-msgid "If enabled, adds support for row based multithreading which greatly enhances the number of threads the encoder can utilise. This improves encoding speed significantly on systems that are otherwise underutilised when encoding VP9. Since the amount of additional threads depends on the number of \"tiles\", which itself depends on the video resolution, encoding higher resolution videos will see a larger performance improvement."
+msgid ""
+"If enabled, adds support for row based multithreading which greatly enhances the number of threads the encoder can utilise. This improves encoding speed significantly on systems that are otherwise underutilised when encoding VP9. Since the amount of additional threads depends on the number of \"tiles\", which itself depends on the video resolution, encoding higher resolution videos will see a "
+"larger performance improvement."
 msgstr ""
 
-#: ../../vdms_utils/presets_manager_utils.py:46
 #, python-brace-format
 msgid "Supports ({0}) formats only, not ({1})"
 msgstr ""
 
-#: ../../vdms_utils/presets_manager_utils.py:49
 #, fuzzy
 msgid "File formats not supported by the selected profile"
 msgstr "Primeira passagem do perfil selecionado"
 
-#: ../../vdms_utils/presets_manager_utils.py:52
 msgid "Warning"
 msgstr "Aviso"
 
-#: ../../vdms_utils/presets_manager_utils.py:90
 msgid ""
 "No presets found.\n"
 "\n"
@@ -3946,12 +2984,10 @@ msgstr ""
 "\n"
 "Solução possível: abra o painel Gerenciador de predefinições, vá para a coluna de predefinições e tente clicar no botão \"Restaurar tudo ...\""
 
-#: ../../vdms_utils/queue_utils.py:54
 #, fuzzy
 msgid "Import queue file"
 msgstr "Pasta de log"
 
-#: ../../vdms_utils/queue_utils.py:89
 #, python-brace-format
 msgid ""
 "ERROR: invalid data found loading queue file.\n"
@@ -3960,26 +2996,21 @@ msgid ""
 "Cannot contain multiple occurrences in `destination` keys value."
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:118
 #, fuzzy
 msgid "Videomass - Add Items to Queue"
 msgstr "Videomass - URLs enfileirados"
 
-#: ../../vdms_utils/queue_utils.py:119
 msgid ""
 "Multiple items with identical names and destination paths cannot coexist.\n"
 "Please choose one of the following actions:"
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:123
 msgid "Replace occurrences with items from the imported queue."
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:124
 msgid "Add only the currently missing items to the queue."
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:125
 msgid "Remove the current queue and replace it with the imported one."
 msgstr ""
 
@@ -3991,4 +3022,7 @@ msgstr ""
 
 #~ msgid "Subtitle Mapping"
 #~ msgstr "Mapa de Legendas"
+
+#~ msgid "Shortest"
+#~ msgstr ""
 

--- a/videomass/data/locale/ru_RU/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/ru_RU/LC_MESSAGES/videomass.po
@@ -1,25 +1,23 @@
-# Russian translation for Videomass.
-# Copyleft -  2025 Gianluca Pernigotto
-# This file is distributed under the same license as the Videomass package
-# FIRST AUTHOR ChourS <chours2008@yandex.ru>, 2020.
+# Russian (Russia) translations for Videomass.
+# Copyright (C) 2025 ORGANIZATION
+# This file is distributed under the same license as the Videomass project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Videomass 6.1.13\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-26 15:04+0200\n"
+"POT-Creation-Date: 2025-07-30 11:02+0200\n"
 "PO-Revision-Date: 2025-07-27 12:27+0300\n"
 "Last-Translator: ChourS <ChourS2008@yandex.ru>\n"
-"Language-Team: Chour <ChourS2008@yandex.ru>\n"
 "Language: ru_RU\n"
+"Language-Team: Chour <ChourS2008@yandex.ru>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.17.0\n"
-"X-Generator: Poedit 3.6\n"
 
-#: ../../gui_app.py:196
 #, python-brace-format
 msgid ""
 "Unexpected error while deleting file contents:\n"
@@ -30,162 +28,111 @@ msgstr ""
 "\n"
 "{0}"
 
-#: ../../vdms_dialogs/about_dialog.py:52
 msgid "Cross-platform graphical user interface for FFmpeg\n"
 msgstr "Кроссплатформенный графический интерфейс пользователя для FFmpeg\n"
 
-#: ../../vdms_dialogs/audioproperties.py:224
 msgid "Videomass supports mono and stereo audio channels. If you are not sure set to \"Auto\" and source values will be copied."
 msgstr "Videomass поддерживает моно и стерео аудиоканалы. Если вы не уверены, установите «Авто», исходные значения будут скопированы."
 
-#: ../../vdms_dialogs/audioproperties.py:228
 msgid "The audio Rate (or sample-rate) is the sound sampling frequency and is measured in Hertz. The higher the frequency, the more true it will be to the sound source and the more the file will increase in size. For audio CD playback, set a sampling frequency of 44100 kHz. If you are not sure, set to \"Auto\" and source values will be copied."
 msgstr "Частота дискретизации звука (или частота дискретизации) - это частота дискретизации звука, которая измеряется в герцах. Чем выше частота, тем более верным будет источник звука и тем больше будет увеличиваться размер файла. Для воспроизведения аудио CD установите частоту дискретизации 44100 кГц. Если вы не уверены, установите значение «Авто», и исходные значения будут скопированы."
 
-#: ../../vdms_dialogs/audioproperties.py:237
 msgid "The audio bitrate affects the file compression and thus the quality of listening. The higher the value, the higher the quality."
 msgstr "Битрейт звука влияет на сжатие файла и, следовательно, на качество прослушивания. Чем выше значение, тем выше качество."
 
-#: ../../vdms_dialogs/audioproperties.py:241
 msgid "Bit depth is the number of bits of information in each sample, and it directly corresponds to the resolution of each sample. Bit depth is only meaningful in reference to a PCM digital signal. Non-PCM formats, such as lossy compression formats, do not have associated bit depths."
 msgstr "Битовая глубина - это количество бит информации в каждом образце, и она напрямую соответствует разрешению каждого образца. Битовая глубина имеет значение только в отношении цифрового сигнала PCM. Форматы без PCM, такие как форматы сжатия с потерями, не имеют связанной битовой глубины."
 
-#: ../../vdms_dialogs/epilogue.py:74 ../../vdms_dialogs/queuedlg.py:120
 msgid "When finished, once the operations have been completed successfully:"
 msgstr "По завершении, как только операции будут успешно завершены:"
 
-#: ../../vdms_dialogs/epilogue.py:80 ../../vdms_dialogs/queuedlg.py:126
 msgid "Trash the source files"
 msgstr "Удалить исходные файлы в корзину"
 
-#: ../../vdms_dialogs/epilogue.py:84 ../../vdms_dialogs/queuedlg.py:130
 msgid "Clear the File List"
 msgstr "Очистить список файлов"
 
-#: ../../vdms_dialogs/epilogue.py:91 ../../vdms_dialogs/queuedlg.py:142
-#: ../../vdms_main/main_frame.py:1322
 msgid "Run"
 msgstr "Запуск"
 
-#: ../../vdms_dialogs/epilogue.py:97
 msgid "Videomass - Batch Mode"
 msgstr "Videomass - Пакетный режим"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:47
 msgid "FFmpeg encoders"
 msgstr "Кодировщики FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:48
 msgid "supported encoders"
 msgstr "поддерживаемые кодеры"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:50
 msgid "FFmpeg decoders"
 msgstr "Декодеры FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:51
 msgid "supported decoders"
 msgstr "поддерживаемые декодеры"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:77
-#: ../../vdms_panels/av_conversions.py:293
 msgid "Video"
 msgstr "Видео"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:87
-#: ../../vdms_panels/av_conversions.py:305
 msgid "Audio"
 msgstr "Аудио"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:97
 msgid "Subtitle"
 msgstr "Субтитры"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:114
-#: ../../vdms_dialogs/ffmpeg_codecs.py:123
-#: ../../vdms_dialogs/ffmpeg_codecs.py:132
-#: ../../vdms_dialogs/ffmpeg_formats.py:112
-#: ../../vdms_dialogs/ffmpeg_formats.py:115
-#: ../../vdms_dialogs/ffmpeg_formats.py:118
 msgid "description"
 msgstr "описание"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:72
 msgid "Informations"
 msgstr "Информация"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:83
 msgid "Flags settings"
 msgstr "Настройки флагов"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:93
 msgid "Flags enabled"
 msgstr "Флаги включены"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:103
 msgid "Flags disabled"
 msgstr "Флаги отключены"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:116
 msgid "FFmpeg configuration"
 msgstr "Конфигурация FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:124
 msgid "flags"
 msgstr "флаги"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:125 ../../vdms_dialogs/ffmpeg_conf.py:129
-#: ../../vdms_dialogs/ffmpeg_conf.py:133
 msgid "options"
 msgstr "параметры"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:128 ../../vdms_dialogs/ffmpeg_conf.py:132
 msgid "status"
 msgstr "статус"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:167
 msgid "FFprobe   ...not found !"
 msgstr "FFprobe   ...не найдено !"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:175
 msgid "FFplay   ...not found !"
 msgstr "FFplay   ...не найдено !"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:205
-#: ../../vdms_panels/sequence_to_video.py:706
-#: ../../vdms_panels/video_to_sequence.py:606
 msgid "Enabled"
 msgstr "Включено"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:216
-#: ../../vdms_panels/sequence_to_video.py:706
-#: ../../vdms_panels/video_to_sequence.py:610
 msgid "Disabled"
 msgstr "Отключено"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:71
 msgid "Demuxing only"
 msgstr "Только демультиплексирование"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:82
 msgid "Muxing only"
 msgstr "Только мультиплексирование"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:93
 msgid "Demuxing/Muxing support"
 msgstr "Поддержка демультиплексирования/мультиплексирования"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:104
 msgid "FFmpeg file formats"
 msgstr "Форматы файлов FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:111
-#: ../../vdms_dialogs/ffmpeg_formats.py:114
-#: ../../vdms_dialogs/ffmpeg_formats.py:117
 msgid "supported formats"
 msgstr "поддерживаемые форматы"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:46
 msgid ""
 "Contextual help based on the argument entered in the additional text field.\n"
 "Each argument consists of the type and a type-specific name.\n"
@@ -211,117 +158,84 @@ msgstr ""
 "\n"
 "Некоторые примеры:"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:68 ../../vdms_dialogs/ffmpeg_help.py:301
-#: ../../vdms_dialogs/ffmpeg_help.py:315
 msgid "Help topic"
 msgstr "Раздел справки"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:69
 msgid "List basic options"
 msgstr "Список основных опций"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:70
 msgid "List more options"
 msgstr "Список дополнительных опций"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:71
 msgid "List all options (very long)"
 msgstr "Список всех вариантов (очень длинный)"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:72
 msgid "Show available devices"
 msgstr "Показать доступные устройства"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:73
 msgid "Show available bit stream filters"
 msgstr "Показать доступные фильтры битового потока"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:74
 msgid "Show available protocols"
 msgstr "Показать доступные протоколы"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:75
 msgid "Show available filters"
 msgstr "Показать доступные фильтры"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:76
 msgid "Show available pixel formats"
 msgstr "Показать доступные форматы пикселей"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:77
 msgid "Show available audio sample formats"
 msgstr "Показать доступные форматы аудио образцов"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:78
 msgid "Show available color names"
 msgstr "Показать доступные названия цветов"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:79
 msgid "List sources of the input device"
 msgstr "Список источников устройства ввода"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:80
 msgid "List sinks of the output device"
 msgstr "Список sinks выходного устройства"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:81
 msgid "Show available HW acceleration methods"
 msgstr "Показать доступные методы аппаратного ускорения"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:82
 msgid "Show license"
 msgstr "Показать лицензию"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:117 ../../vdms_dialogs/filter_scale.py:76
-#: ../../vdms_dialogs/shownormlist.py:98 ../../vdms_dialogs/shownormlist.py:107
-#: ../../vdms_dialogs/shownormlist.py:116 ../../vdms_miniframes/timeline.py:263
-#: ../../vdms_miniframes/timeline.py:283 ../../vdms_panels/concatenate.py:117
-#: ../../vdms_panels/sequence_to_video.py:117
-#: ../../vdms_panels/video_to_sequence.py:81
 msgid "Read me"
 msgstr "Прочти меня"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:123 ../../vdms_main/main_frame.py:534
 msgid "Show configuration"
 msgstr "Показать конфигурацию"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:127 ../../vdms_main/main_frame.py:542
 msgid "Encoders"
 msgstr "Кодеры"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:131 ../../vdms_main/main_frame.py:545
 msgid "Decoders"
 msgstr "Декодеры"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:135 ../../vdms_main/main_frame.py:538
 msgid "Muxers and Demuxers"
 msgstr "Мультиплексоры и Демультиплексоры"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:165
 msgid "help topic list"
 msgstr "список тем справки"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:184
 msgid "Type the argument here and confirm with the enter key on your keyboard"
 msgstr "Введите здесь аргумент и подтвердите нажатием клавиши ввода на клавиатуре"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:192
 msgid "The search function allows you to find entries in the current topic"
 msgstr "Функция поиска позволяет находить записи в текущей теме"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:195
 msgid "Ignore case"
 msgstr "Игнорировать регистр"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:196
 msgid "Ignore case distinctions: characters with different case will match."
 msgstr "Не обращайте внимания на различие в регистре: символы с другим регистром будут совпадать."
 
-#: ../../vdms_dialogs/ffmpeg_help.py:206
 msgid "FFmpeg help topics"
 msgstr "Разделы справки FFmpeg"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:254
 msgid ""
 "This is a multifunctional search tool useful for local help searches\n"
 "on multiple FFmpeg topics and options. The search control, to\n"
@@ -341,8 +255,6 @@ msgstr ""
 "Если вы не найдете поддержку определенного кодека или другой функции, \n"
 "вероятно, ваша версия FFmpeg устарела или не поддерживает эти функции."
 
-#: ../../vdms_dialogs/ffmpeg_help.py:320 ../../vdms_dialogs/ffmpeg_help.py:345
-#: ../../vdms_dialogs/ffmpeg_help.py:371
 msgid ""
 "\n"
 "  ..Nothing available"
@@ -350,7 +262,6 @@ msgstr ""
 "\n"
 "  ..Данные недоступны"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:391
 msgid ""
 "\n"
 "  ..Not found"
@@ -358,218 +269,122 @@ msgstr ""
 "\n"
 "  ..Не найдено"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:91
 msgid "Before"
 msgstr "До"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:97
 msgid "After"
 msgstr "После"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:103
-#: ../../vdms_dialogs/filter_crop.py:239
 msgid "Search for a specific frame"
 msgstr "Поиск определенного кадра"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:117
-#: ../../vdms_dialogs/filter_crop.py:253
 msgid "Load"
 msgstr "Загрузить"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:120
 msgid "Color EQ"
 msgstr "Цвет EQ"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:126
 msgid "Contrast:"
 msgstr "Контраст:"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:134
-#: ../../vdms_dialogs/filter_colorcorrection.py:148
 msgid "-100 to +100, default value 0"
 msgstr "от -100 до +100, значение по умолчанию 0"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:139
 msgid "Brightness:"
 msgstr "Яркость:"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:158
 msgid "Saturation:"
 msgstr "Насыщенность:"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:166
 msgid "0 to 300, default value 100"
 msgstr "от 0 до 300, значение по умолчанию 100"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:170
 msgid "Gamma:"
 msgstr "Гамма:"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:179
 msgid "0 to 100, default value 10"
 msgstr "от 0 до 100, значение по умолчанию 10"
 
 # Перевод всех отмеченных изменений на значение по умолчанию
-#: ../../vdms_dialogs/filter_colorcorrection.py:187
-#: ../../vdms_dialogs/filter_crop.py:306
-#: ../../vdms_dialogs/filter_deinterlace.py:209
-#: ../../vdms_dialogs/filter_denoisers.py:110
-#: ../../vdms_dialogs/filter_scale.py:210 ../../vdms_dialogs/filter_stab.py:316
-#: ../../vdms_dialogs/filter_transpose.py:105
-#: ../../vdms_miniframes/timeline.py:262 ../../vdms_miniframes/timeline.py:281
 msgid "Reset"
 msgstr "Сброс"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:207
 msgid "Color Correction EQ Tool"
 msgstr "Эквалайзер для цветокоррекции"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:343
-#: ../../vdms_dialogs/filter_colorcorrection.py:383
-#: ../../vdms_dialogs/filter_colorcorrection.py:390
-#: ../../vdms_dialogs/filter_crop.py:417 ../../vdms_dialogs/filter_scale.py:287
-#: ../../vdms_dialogs/filter_scale.py:394 ../../vdms_dialogs/filter_stab.py:473
-#: ../../vdms_dialogs/filter_stab.py:483 ../../vdms_dialogs/filter_stab.py:494
-#: ../../vdms_dialogs/filter_transpose.py:182
-#: ../../vdms_dialogs/mediainfo.py:245 ../../vdms_dialogs/mediainfo.py:265
-#: ../../vdms_dialogs/mediainfo.py:285 ../../vdms_dialogs/mediainfo.py:305
-#: ../../vdms_dialogs/setting_profiles.py:281
-#: ../../vdms_dialogs/setting_profiles.py:289 ../../vdms_io/checkup.py:45
-#: ../../vdms_io/checkup.py:93 ../../vdms_io/io_tools.py:144
-#: ../../vdms_main/main_frame.py:904 ../../vdms_main/main_frame.py:939
-#: ../../vdms_main/main_frame.py:961 ../../vdms_main/main_frame.py:979
-#: ../../vdms_main/main_frame.py:999
-#: ../../vdms_panels/audio_encoders/acodecs.py:510
-#: ../../vdms_panels/audio_encoders/acodecs.py:800
-#: ../../vdms_panels/concatenate.py:186
-#: ../../vdms_panels/long_processing_task.py:60
-#: ../../vdms_panels/presets_manager.py:426
-#: ../../vdms_panels/presets_manager.py:490
-#: ../../vdms_panels/presets_manager.py:560
-#: ../../vdms_panels/presets_manager.py:599
-#: ../../vdms_panels/presets_manager.py:619
-#: ../../vdms_panels/presets_manager.py:657
-#: ../../vdms_panels/presets_manager.py:701
-#: ../../vdms_panels/presets_manager.py:714
-#: ../../vdms_panels/presets_manager.py:721
-#: ../../vdms_panels/presets_manager.py:756
-#: ../../vdms_panels/presets_manager.py:785
-#: ../../vdms_panels/presets_manager.py:791
-#: ../../vdms_panels/sequence_to_video.py:467
-#: ../../vdms_panels/sequence_to_video.py:473
-#: ../../vdms_panels/sequence_to_video.py:561
-#: ../../vdms_panels/sequence_to_video.py:571
-#: ../../vdms_panels/sequence_to_video.py:588
-#: ../../vdms_panels/sequence_to_video.py:596
-#: ../../vdms_panels/sequence_to_video.py:602
-#: ../../vdms_panels/sequence_to_video.py:643
-#: ../../vdms_panels/sequence_to_video.py:689
-#: ../../vdms_panels/video_to_sequence.py:512
-#: ../../vdms_panels/video_to_sequence.py:583
-#: ../../vdms_threads/ffplay_file.py:43
-#: ../../vdms_utils/presets_manager_utils.py:86
-#: ../../vdms_utils/presets_manager_utils.py:95
-#: ../../vdms_utils/queue_utils.py:68 ../../vdms_utils/queue_utils.py:82
-#: ../../vdms_utils/queue_utils.py:95
 msgid "Videomass - Error!"
 msgstr "Videomass - Ошибка!"
 
-#: ../../vdms_dialogs/filter_crop.py:228 ../../vdms_dialogs/filter_scale.py:109
 #, python-brace-format
 msgid "Source size: {0} x {1} pixels"
 msgstr "Размер источника: {0} x {1} пикселей"
 
-#: ../../vdms_dialogs/filter_crop.py:236
 msgid "Crop color"
 msgstr "Цвет обрезки"
 
-#: ../../vdms_dialogs/filter_crop.py:256
 msgid "Cropping area selection "
 msgstr "Выбор области обрезки "
 
-#: ../../vdms_dialogs/filter_crop.py:261 ../../vdms_dialogs/filter_scale.py:121
 msgid "Height"
 msgstr "Высота"
 
-#: ../../vdms_dialogs/filter_crop.py:281
 msgid "Center"
 msgstr "Центр"
 
-#: ../../vdms_dialogs/filter_crop.py:292 ../../vdms_dialogs/filter_scale.py:121
 msgid "Width"
 msgstr "Ширина"
 
-#: ../../vdms_dialogs/filter_crop.py:334
 msgid "Crop Tool"
 msgstr "Инструмент обрезки"
 
-#: ../../vdms_dialogs/filter_crop.py:335
 msgid "Choose the color to draw the cropping area"
 msgstr "Выберите цвет, чтобы нарисовать область обрезки"
 
-#: ../../vdms_dialogs/filter_crop.py:337
 msgid "Crop to width"
 msgstr "Обрезать по ширине"
 
-#: ../../vdms_dialogs/filter_crop.py:338
 msgid "Move vertically (set to -1 to center the vertical axis)"
 msgstr "Перемещение по вертикали (установите значение -1 для центрирования вертикальной оси)"
 
-#: ../../vdms_dialogs/filter_crop.py:340
 msgid "Move horizontally (set to -1 to center the horizontal axis)"
 msgstr "Перемещение по горизонтали (установите значение -1, чтобы центрировать горизонтальную ось)"
 
-#: ../../vdms_dialogs/filter_crop.py:342
 msgid "Crop to height"
 msgstr "Обрезать по высоте"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:56
 msgid "Advanced Options"
 msgstr "Расширенные настройки"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:57
-#: ../../vdms_panels/av_conversions.py:351
 msgid "Deinterlace"
 msgstr "Деинтерлейсинг"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:59
 msgid "Interlace"
 msgstr "Чересстрочная"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:63
 msgid "Deinterlaces with w3fdif filter"
 msgstr "Деинтерлейсинг с фильтром w3fdif"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:77
 msgid "Deinterlaces with yadif filter"
 msgstr "Деинтерлейсинг c фильтром 'yadif'"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:101
 msgid "Interlaces with interlace filter"
 msgstr "Чересстрочная с фильтром 'interlace'"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:118
 msgid "Deinterlacing and Interlacing"
 msgstr "Деинтерлейсинг(прогрессивная) и чересстрочная развёртка"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:144
 msgid "Deinterlace the input video with `w3fdif` filter"
 msgstr "Деинтерлейсинг входного видео с помощью фильтра `w3fdif`"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:146
 msgid "Set the interlacing filter coefficients."
 msgstr "Устанавливает коэффициенты чересстрочного фильтра."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:148
-#: ../../vdms_dialogs/filter_deinterlace.py:158
 msgid "Specify which frames to deinterlace."
 msgstr "Укажите кадры для деинтерлейсинга."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:150
 msgid "Deinterlace the input video with `yadif` filter. Using FFmpeg, this is the best and fastest choice"
 msgstr "Деинтерлейсируйте входное видео с помощью фильтра yadif. Используя FFmpeg, это лучший и самый быстрый выбор"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:153
 msgid ""
 "mode\n"
 "The interlacing mode to adopt."
@@ -577,7 +392,6 @@ msgstr ""
 "mode\n"
 "Используемый режим чересстрочной развертки."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:155
 msgid ""
 "parity\n"
 "The picture field parity assumed for the input interlaced video."
@@ -585,11 +399,9 @@ msgstr ""
 "четность\n"
 "Предполагаемая четность поля изображения для входного чересстрочного видео."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:160
 msgid "Simple interlacing filter from progressive contents."
 msgstr "Простой фильтр с чересстрочной разверткой из прогрессивного содержимого."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:162
 msgid ""
 "scan:\n"
 "determines whether the interlaced frame is taken from the even (tff - default) or odd (bff) lines of the progressive frame."
@@ -597,7 +409,6 @@ msgstr ""
 "scan:\n"
 "определяет, взят ли чересстрочный кадр из четных (tff - по умолчанию) или нечетных (bff) строк прогрессивного кадра."
 
-#: ../../vdms_dialogs/filter_deinterlace.py:166
 msgid ""
 "lowpass:\n"
 "Enable (default) or disable the vertical lowpass filter to avoid twitter interlacing and reduce moire patterns.\n"
@@ -607,33 +418,26 @@ msgstr ""
 "Включите (по умолчанию) или отключите вертикальный фильтр нижних частот, чтобы избежать чересстрочной развертки твиттера и уменьшить муаровые узоры.\n"
 "По умолчанию настройка отсутствует."
 
-#: ../../vdms_dialogs/filter_denoisers.py:56
 msgid "Denoiser Filters"
 msgstr "Фильтры шумоподавления"
 
-#: ../../vdms_dialogs/filter_denoisers.py:60
 msgid "Enable nlmeans denoiser"
 msgstr "Включить фильтр nlmeans"
 
 # Особенности русской фразы
-#: ../../vdms_dialogs/filter_denoisers.py:73
 msgid "nlmeans options"
 msgstr "Параметры фильтра nlmeans"
 
-#: ../../vdms_dialogs/filter_denoisers.py:82
 msgid "Enable hqdn3d denoiser"
 msgstr "Включить фильтр hqdn3d"
 
 # Особенности русской фразы
-#: ../../vdms_dialogs/filter_denoisers.py:91
 msgid "hqdn3d options"
 msgstr "Параметры фильтра hqdn3d"
 
-#: ../../vdms_dialogs/filter_denoisers.py:116
 msgid "Denoiser Tool"
 msgstr "Инструмент Denoiser(шумоподавитель)"
 
-#: ../../vdms_dialogs/filter_denoisers.py:117
 msgid ""
 "nlmeans:\n"
 "Denoise frames using Non-Local Means algorithm is capable of restoring video sequences, even with strong noise. It is ideal for enhancing the quality of old VHS tapes."
@@ -641,7 +445,6 @@ msgstr ""
 "nlmeans:\n"
 "Удаление шума из кадров с использованием алгоритма нелокальных средств позволяет восстанавливать видеопоследовательности даже с сильным шумом. Он идеально подходит для улучшения качества старых кассет VHS."
 
-#: ../../vdms_dialogs/filter_denoisers.py:122
 msgid ""
 "hqdn3d:\n"
 "This is a high precision/quality 3d denoise filter. It aims to reduce image noise, producing smooth images and making still images really still. It should enhance compressibility."
@@ -649,65 +452,48 @@ msgstr ""
 "hqdn3d:\n"
 " Это высокоточный и качественный трехмерный шумоподавляющий фильтр. Стремится уменьшить шум изображения, создать плавные изображения и сделать статическиеизображения неподвижными. Понятно, что это должно улучшить визуальное качество."
 
-#: ../../vdms_dialogs/filter_scale.py:81
 msgid "View result"
 msgstr "Посмотреть результат"
 
-#: ../../vdms_dialogs/filter_scale.py:85
 msgid "New size in pixels"
 msgstr "Новый размер в пикселях"
 
-#: ../../vdms_dialogs/filter_scale.py:89
 msgid "Width:"
 msgstr "Ширина:"
 
-#: ../../vdms_dialogs/filter_scale.py:99
 msgid "Height:"
 msgstr "Высота:"
 
-#: ../../vdms_dialogs/filter_scale.py:115
 msgid "Constrain proportions (keep aspect ratio)"
 msgstr "Сохраните пропорции (сохраните соотношение сторон)"
 
-#: ../../vdms_dialogs/filter_scale.py:120
 msgid "Which dimension to adjust?"
 msgstr "Какой размер отрегулировать?"
 
-#: ../../vdms_dialogs/filter_scale.py:129
 msgid "Aspect Ratio"
 msgstr "Пропорции"
 
-#: ../../vdms_dialogs/filter_scale.py:132
 msgid "Setdar filter (display aspect ratio) example 16/9, 4/3 "
 msgstr "Setdar (соотношение сторон экрана) "
 
-#: ../../vdms_dialogs/filter_scale.py:137
-#: ../../vdms_dialogs/filter_scale.py:171
 msgid "Numerator"
 msgstr "Числитель"
 
-#: ../../vdms_dialogs/filter_scale.py:162
-#: ../../vdms_dialogs/filter_scale.py:196
 msgid "Denominator"
 msgstr "Знаменатель"
 
-#: ../../vdms_dialogs/filter_scale.py:166
 msgid "Setsar filter (sample aspect ratio) example 1/1"
 msgstr "SetSar(примерное соотношение сторон)"
 
-#: ../../vdms_dialogs/filter_scale.py:217
 msgid "Resize Tool"
 msgstr "Инструмент изменения размера"
 
-#: ../../vdms_dialogs/filter_scale.py:218
 msgid "Scale filter, set to 0 to disable"
 msgstr "Масштабный фильтр, установите 0, чтобы отключить"
 
-#: ../../vdms_dialogs/filter_scale.py:221
 msgid "Display Aspect Ratio. Set to 0 to disable"
 msgstr "Соотношение сторон дисплея. Установите 0, чтобы отключить"
 
-#: ../../vdms_dialogs/filter_scale.py:224
 msgid ""
 "Sample (aka Pixel) Aspect Ratio.\n"
 "Set to 0 to disable"
@@ -715,7 +501,6 @@ msgstr ""
 "Образец (в пикселях) соотношения сторон.\n"
 "Установите 0, чтобы отключить"
 
-#: ../../vdms_dialogs/filter_scale.py:366
 msgid ""
 "If you want to keep the aspect ratio, select \"Constrain proportions\" below and\n"
 "specify only one dimension, either width or height, and set the other dimension\n"
@@ -727,156 +512,123 @@ msgstr ""
 "значение -1 или -2 (для некоторых кодеков требуется -2, \n"
 "так что сначала вы должны провести некоторое тестирование)"
 
-#: ../../vdms_dialogs/filter_stab.py:81
 msgid "Enable stabilizer"
 msgstr "Включить stabilizer"
 
-#: ../../vdms_dialogs/filter_stab.py:83
 msgid "Create a side-by-side comparison video"
 msgstr "Создайте видео для параллельного сравнения"
 
-#: ../../vdms_dialogs/filter_stab.py:88
 msgid "Create a snapshot"
 msgstr "Создать снимок"
 
-#: ../../vdms_dialogs/filter_stab.py:106
-#: ../../vdms_panels/audio_encoders/acodecs.py:167
 msgid "Preview"
 msgstr "Предпросмотр"
 
-#: ../../vdms_dialogs/filter_stab.py:109
 msgid "Duration seconds:"
 msgstr "Продолжительность секунд:"
 
-#: ../../vdms_dialogs/filter_stab.py:118
 msgid "Video Detect"
 msgstr "Обнаружение видео"
 
-#: ../../vdms_dialogs/filter_stab.py:176
 msgid "[TRIPOD] Enable tripod mode if checked"
 msgstr "[ШТАТИВ] Включите режим штатива, если установлен флажок"
 
-#: ../../vdms_dialogs/filter_stab.py:183
 msgid "Video transform"
 msgstr "Преобразование видео"
 
-#: ../../vdms_dialogs/filter_stab.py:202
 msgid "[OPTALGO] optimization algorithm"
 msgstr "[OPTALGO] алгоритм оптимизации"
 
-#: ../../vdms_dialogs/filter_stab.py:224
 msgid "[CROP] Specify how to deal with borders at movement compensation"
 msgstr "[ОБРЕЗАТЬ] Укажите, как работать с границами при компенсации движения"
 
-#: ../../vdms_dialogs/filter_stab.py:231
 msgid "[INVERT] Invert transforms if checked"
 msgstr "[ИНВЕРТИРОВАТЬ] Инвертировать преобразования, если отмечено"
 
-#: ../../vdms_dialogs/filter_stab.py:234
 msgid "[RELATIVE] Consider transforms as relative to previous frame if checked, absolute if unchecked"
 msgstr "[RELATIVE] Считать преобразования относительно предыдущего кадра, если отмечен; абсолютные, если не отмечен"
 
-#: ../../vdms_dialogs/filter_stab.py:279
 msgid "Specify type of interpolation"
 msgstr "Укажите тип интерполяции"
 
-#: ../../vdms_dialogs/filter_stab.py:287
 msgid "[TRIPOD2] virtual tripod mode, equivalent to relative=unchecked:smoothing=0"
 msgstr "[ШТАТИВ2] виртуальный режим штатива, эквивалентный relative=unchecked:smoothing=0"
 
-#: ../../vdms_dialogs/filter_stab.py:294
 msgid "Unsharp filter:"
 msgstr "Фильтр Нерезкость:"
 
-#: ../../vdms_dialogs/filter_stab.py:323
 msgid "Seek to a position on the video."
 msgstr "Найти позицию на видео."
 
-#: ../../vdms_dialogs/filter_stab.py:325
 msgid "Make a snapshot of the video with the settings made."
 msgstr "Сделайте снимок видео со сделанными настройками."
 
-#: ../../vdms_dialogs/filter_stab.py:327
 msgid "Set the snapshot duration from 3 to 15 seconds from the seek position, default is 5 seconds."
 msgstr "Установите продолжительность снимка от 3 до 15 секунд от позиции поиска, по умолчанию 5 секунд."
 
-#: ../../vdms_dialogs/filter_stab.py:331
 msgid "Set how shaky the video is and how quick the camera is. A value of 1 means little shakiness, a value of 10 means strong shakiness. Default value is 5."
 msgstr "Установите, насколько тряским будет видео и насколько быстрая камера. Значение 1 означает небольшую неустойчивость, значение 10 означает сильную неустойчивость. Значение по умолчанию - 5."
 
-#: ../../vdms_dialogs/filter_stab.py:335
 msgid "Set the accuracy of the detection process. A value of 1 means low accuracy, a value of 15 means high accuracy. Default value is 15."
 msgstr "Установите точность процесса обнаружения. Значение 1 означает низкую точность, значение 15 означает высокую точность. Значение по умолчанию - 15."
 
-#: ../../vdms_dialogs/filter_stab.py:339
 msgid "Set stepsize of the search process. The region around minimum is scanned with 1 pixel resolution. Default value is 6."
 msgstr "Установите размер шага процесса поиска. Область около минимума сканируется с разрешением 1 пиксель. Значение по умолчанию - 6."
 
-#: ../../vdms_dialogs/filter_stab.py:343
 msgid "Set minimum contrast. Below this value a local measurement field is discarded. The range is 0-1. Default value is 0.25."
 msgstr "Установите минимальный контраст. Ниже этого значения локальное поле измерения отбрасывается. Диапазон 0-1. Значение по умолчанию - 0,25."
 
-#: ../../vdms_dialogs/filter_stab.py:346
 msgid "Set reference frame number for tripod mode. If enabled, the motion of the frames is compared to a reference frame in the filtered stream, identified by the specified number. The idea is to compensate all movements in a more-or-less static scene and keep the camera view absolutely still. The frames are counted starting from 1."
 msgstr "Установите номер опорного кадра для штатива режима. Если этот параметр включен, движение кадров сравнивается с опорным кадром в отфильтрованном потоке, идентифицируемым указанным номером. Идея состоит в том, чтобы компенсировать все движения в более или менее статичной сцене и сохранять неподвижность обзора камеры. Фреймы считаются начиная с 1."
 
-#: ../../vdms_dialogs/filter_stab.py:355
-msgid "Set the number of frames (value*2 + 1) used for lowpass filtering the camera movements. Default value is 15. For example a number of 10 means that 21 frames are used (10 in the past and 10 in the future) to smoothen the motion in the video. A larger value leads to a smoother video, but limits the acceleration of the camera (pan/tilt movements). 0 is a special case where a static camera is simulated."
-msgstr "Установите количество кадров (значение * 2 + 1), используемых для фильтрации нижних частот движений камеры. Значение по умолчанию - 15. Например, число 10 означает, что используется 21 кадр (10 в прошлом и 10 в будущем) для сглаживания движения в видео. Большее значение приводит к более плавному видео, но ограничивает ускорение камеры (движения панорамирования / наклона). 0 - это особый случай, когда моделируется статическая камера."
+msgid ""
+"Set the number of frames (value*2 + 1) used for lowpass filtering the camera movements. Default value is 15. For example a number of 10 means that 21 frames are used (10 in the past and 10 in the future) to smoothen the motion in the video. A larger value leads to a smoother video, but limits the acceleration of the camera (pan/tilt movements). 0 is a special case where a static camera is "
+"simulated."
+msgstr ""
+"Установите количество кадров (значение * 2 + 1), используемых для фильтрации нижних частот движений камеры. Значение по умолчанию - 15. Например, число 10 означает, что используется 21 кадр (10 в прошлом и 10 в будущем) для сглаживания движения в видео. Большее значение приводит к более плавному видео, но ограничивает ускорение камеры (движения панорамирования / наклона). 0 - это особый случай,"
+" когда моделируется статическая камера."
 
-#: ../../vdms_dialogs/filter_stab.py:363
 msgid "Set the camera path optimization algorithm. Values are: `gauss`: gaussian kernel low-pass filter on camera motion (default), and `avg`: averaging on transformations"
 msgstr "Установите алгоритм оптимизации пути камеры. Значения: «gauss»: фильтр нижних частот ядра Гаусса при движении камеры (по умолчанию) и «avg»: усреднение при преобразованиях"
 
-#: ../../vdms_dialogs/filter_stab.py:367
 msgid "Set maximal angle in radians (degree*PI/180) to rotate frames. Default value is -1, meaning no limit."
 msgstr "Установите максимальный угол в радианах (градусы * PI / 180) для поворота кадров. Значение по умолчанию -1, что означает отсутствие ограничений."
 
-#: ../../vdms_dialogs/filter_stab.py:370
 msgid "Specify how to deal with borders that may be visible due to movement compensation. Values are: `keep` keep image information from previous frame (default), `black` fill the border black"
 msgstr "Укажите, как работать с границами, которые могут быть видны из-за компенсации движения. Возможные значения: «keep» сохранить информацию об изображении из предыдущего кадра (по умолчанию), «black» заполнить границу чёрным"
 
-#: ../../vdms_dialogs/filter_stab.py:375
 msgid "Invert transforms if checked. Default is unchecked."
 msgstr "Инвертировать преобразования, если отмечено. По умолчанию флажок не установлен."
 
-#: ../../vdms_dialogs/filter_stab.py:377
 msgid "Consider transforms as relative to previous frame if checked, absolute if unchecked. Default is checked."
 msgstr "Считайте преобразования относительно предыдущего кадра, если отмечен, и абсолютными, если не отмечен. По умолчанию отмечен."
 
-#: ../../vdms_dialogs/filter_stab.py:380
 msgid "Set percentage to zoom. A positive value will result in a zoom-in effect, a negative value in a zoom-out effect. Default value is 0 (no zoom)."
 msgstr "Установите процент для увеличения. Положительное значение приведет к эффекту увеличения, отрицательное значение - к эффекту уменьшения. Значение по умолчанию - 0 (без увеличения)."
 
-#: ../../vdms_dialogs/filter_stab.py:384
 msgid "Set optimal zooming to avoid borders. Accepted values are: `0` disabled, `1` optimal static zoom value is determined (only very strong movements will lead to visible borders) (default), `2` optimal adaptive zoom value is determined (no borders will be visible), see zoomspeed. Note that the value given at zoom is added to the one calculated here."
-msgstr "Установите оптимальное масштабирование, чтобы избежать границ. Допустимые значения: «0» отключено, «1» определяется оптимальное значение статического масштабирования (только очень сильные движения приведут к видимым границам) (по умолчанию), «2» определяется оптимальное значение адаптивного масштабирования (границы не видны), см. zoomspeed. Обратите внимание, что значение, указанное при увеличении, добавляется к рассчитанному здесь."
+msgstr ""
+"Установите оптимальное масштабирование, чтобы избежать границ. Допустимые значения: «0» отключено, «1» определяется оптимальное значение статического масштабирования (только очень сильные движения приведут к видимым границам) (по умолчанию), «2» определяется оптимальное значение адаптивного масштабирования (границы не видны), см. zoomspeed. Обратите внимание, что значение, указанное при "
+"увеличении, добавляется к рассчитанному здесь."
 
-#: ../../vdms_dialogs/filter_stab.py:391
 msgid "Set percent to zoom maximally each frame (enabled when optzoom is set to 2). Range is from 0 to 5, default value is 0.25."
 msgstr "Установите процент для максимального увеличения каждого кадра (активируется, когда для optzoom установлено значение 2). Диапазон от 0 до 5, значение по умолчанию - 0,25."
 
-#: ../../vdms_dialogs/filter_stab.py:395
 msgid "Specify type of interpolation. Available values are: `no` no interpolation, `linear` linear only horizontal, `bilinear` linear in both directions (default), `bicubic` cubic in both directions (slow)"
 msgstr "Укажите тип интерполяции. Доступные значения: «no» без интерполяции, «linear», линейный, только горизонтальный, «bilinear», линейный в обоих направлениях (по умолчанию), «bicubic», кубический в обоих направлениях (медленно)."
 
-#: ../../vdms_dialogs/filter_stab.py:400
 msgid "Enable virtual tripod mode if checked, which is equivalent to relative=0:smoothing=0. Default is unchecked. Use also tripod option of vidstabdetect."
 msgstr "Включите режим виртуального штатива, если этот флажок установлен, что эквивалентно relative=0:smoothing=0. По умолчанию флажок не установлен. Используйте также вариант штатива в vidstabdetect."
 
-#: ../../vdms_dialogs/filter_stab.py:405
 msgid "Sharpen or blur the input video. Note the use of the unsharp filter which is always recommended."
 msgstr "Увеличьте резкость или размытие входного видео. Обратите внимание на использование нерезкого фильтра, который всегда рекомендуется."
 
-#: ../../vdms_dialogs/filter_stab.py:409
 msgid "Video Stabilizer Tool"
 msgstr "Инструмент Video Stabilizer"
 
-#: ../../vdms_dialogs/filter_stab.py:541 ../../vdms_io/io_tools.py:73
 msgid "Videomass - Loading..."
 msgstr "Videomass - Загрузка..."
 
-#: ../../vdms_dialogs/filter_stab.py:542
 msgid ""
 "Please wait,\n"
 "This process will take a few seconds."
@@ -884,136 +636,97 @@ msgstr ""
 "Пожалуйста, подождите.\n"
 "Этот процесс займет несколько секунд."
 
-#: ../../vdms_dialogs/filter_transpose.py:80
-#: ../../vdms_dialogs/filter_transpose.py:293
 msgid "Default position"
 msgstr "Положение по умолчанию"
 
-#: ../../vdms_dialogs/filter_transpose.py:86
 msgid "Rotation setting"
 msgstr "Настройка вращения"
 
-#: ../../vdms_dialogs/filter_transpose.py:94
 msgid "90° (left)"
 msgstr "90° (влево)"
 
-#: ../../vdms_dialogs/filter_transpose.py:96
 msgid "90° (right)"
 msgstr "90° (вправо)"
 
-#: ../../vdms_dialogs/filter_transpose.py:100
 msgid "180°"
 msgstr "180°"
 
-#: ../../vdms_dialogs/filter_transpose.py:115
 msgid "Transpose Tool"
 msgstr "Инструмент поворота кадра"
 
-#: ../../vdms_dialogs/filter_transpose.py:229
 msgid "Rotate 90 degrees right"
 msgstr "Повернуть на 90 градусов вправо"
 
-#: ../../vdms_dialogs/filter_transpose.py:251
 msgid "Rotate 180 degrees"
 msgstr "Повернуть на 180 градусов"
 
-#: ../../vdms_dialogs/filter_transpose.py:272
 msgid "Rotate 90 degrees left"
 msgstr "Повернуть на 90 градусов влево"
 
-#: ../../vdms_dialogs/mediainfo.py:82
 msgid "Format"
 msgstr "Формат"
 
-#: ../../vdms_dialogs/mediainfo.py:96
 msgid "Video Stream"
 msgstr "Видео поток"
 
-#: ../../vdms_dialogs/mediainfo.py:109
 msgid "Audio Streams"
 msgstr "Аудио потоки"
 
-#: ../../vdms_dialogs/mediainfo.py:122
 msgid "Subtitle Streams"
 msgstr "Потоки субтитров"
 
-#: ../../vdms_dialogs/mediainfo.py:126
 msgid "Copy to clipboard"
 msgstr "Скопировать в буфер обмена"
 
-#: ../../vdms_dialogs/mediainfo.py:137
 msgid "FILE SELECTION"
 msgstr "ВЫБОР ФАЙЛА"
 
-#: ../../vdms_dialogs/mediainfo.py:139 ../../vdms_dialogs/mediainfo.py:142
-#: ../../vdms_dialogs/mediainfo.py:145 ../../vdms_dialogs/mediainfo.py:148
-#: ../../vdms_main/main_frame.py:1318
 msgid "Properties"
 msgstr "Характеристики"
 
-#: ../../vdms_dialogs/mediainfo.py:140 ../../vdms_dialogs/mediainfo.py:143
-#: ../../vdms_dialogs/mediainfo.py:146 ../../vdms_dialogs/mediainfo.py:149
 msgid "Values"
 msgstr "Значения"
 
-#: ../../vdms_dialogs/mediainfo.py:152
 msgid "Streams Properties"
 msgstr "Свойства потоков"
 
-#: ../../vdms_dialogs/mediainfo.py:244
 msgid "Unable to open the clipboard on Format tab"
 msgstr "Не удается открыть буфер обмена на вкладке «Формат»"
 
-#: ../../vdms_dialogs/mediainfo.py:263
 msgid "Unable to open the clipboard on Video Streams tab"
 msgstr "Невозможно открыть буфер обмена на вкладке «Видеопотоки»"
 
-#: ../../vdms_dialogs/mediainfo.py:283
 msgid "Unable to open the clipboard on Audio Streams tab"
 msgstr "Невозможно открыть буфер обмена на вкладке «Аудиопотоки»"
 
-#: ../../vdms_dialogs/mediainfo.py:303
 msgid "Unable to open the clipboard on Subtitle Streams tab"
 msgstr "Невозможно открыть буфер обмена на вкладке «Потоки субтитров»"
 
-#: ../../vdms_dialogs/preferences.py:90
 msgid "Where do you prefer to save your transcodes?"
 msgstr "Где вы предпочитаете сохранять перекодировки?"
 
-#: ../../vdms_dialogs/preferences.py:101 ../../vdms_dialogs/preferences.py:128
-#: ../../vdms_dialogs/preferences.py:149 ../../vdms_dialogs/preferences.py:161
-#: ../../vdms_dialogs/preferences.py:173 ../../vdms_panels/filedrop.py:284
 msgid "Change"
 msgstr "Изменить"
 
-#: ../../vdms_dialogs/preferences.py:103
-#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:602
-#: ../../vdms_panels/presets_manager.py:1050
 msgid "Same destination paths as source files"
 msgstr "Те же пути назначения, что и у исходных файлов"
 
-#: ../../vdms_dialogs/preferences.py:108
 msgid "Assign optional suffix to destination file names:"
 msgstr "Присвойте необязательный суффикс именам файлов назначения:"
 
-#: ../../vdms_dialogs/preferences.py:114
 msgid "File removal preferences"
 msgstr "Настройки удаления файлов"
 
-#: ../../vdms_dialogs/preferences.py:118
 msgid "Trash the source files after successful encoding"
 msgstr "Удалить исходные файлы после успешного кодирования"
 
 # Изменил 14-5-2021
-#: ../../vdms_dialogs/preferences.py:131
 msgid "File Preferences"
 msgstr "Файл"
 
-#: ../../vdms_dialogs/preferences.py:138
 msgid "Location of executables"
 msgstr "Расположение исполняемых файлов"
 
-#: ../../vdms_dialogs/preferences.py:140
 msgid ""
 "FFmpeg can be built by enabling/disabling its options and this depends on your needs.\n"
 "For some use cases it is possible to provide a custom build of FFmpeg where you can specify\n"
@@ -1023,111 +736,85 @@ msgstr ""
 "Для некоторых случаев использования можно предоставить собственную сборку FFmpeg, \n"
 "которую вы можете указать на этой вкладке настроек."
 
-#: ../../vdms_dialogs/preferences.py:147
 msgid "Enable a custom location to run FFmpeg"
 msgstr "Включите собственное местоположение для запуска FFmpeg"
 
-#: ../../vdms_dialogs/preferences.py:159
 msgid "Enable a custom location to run FFprobe"
 msgstr "Включите пользовательское местоположение для запуска FFprobe"
 
-#: ../../vdms_dialogs/preferences.py:171
 msgid "Enable a custom location to run FFplay"
 msgstr "Включите пользовательское местоположение для запуска FFplay"
 
-#: ../../vdms_dialogs/preferences.py:183
 msgid "FFmpeg"
 msgstr "FFmpeg"
 
-#: ../../vdms_dialogs/preferences.py:189
 msgid "Look and Feel (requires application restart)"
 msgstr "Внешний вид (требуется перезапуск Videomass)"
 
-#: ../../vdms_dialogs/preferences.py:194
 msgid "Icon themes"
 msgstr "Темы значков"
 
-#: ../../vdms_dialogs/preferences.py:208
 msgid "At the top of window (default)"
 msgstr "Вверху (по умолчанию)"
 
-#: ../../vdms_dialogs/preferences.py:209
 msgid "At the bottom of window"
 msgstr "Внизу"
 
-#: ../../vdms_dialogs/preferences.py:210
 msgid "At the right of window"
 msgstr "Справа"
 
 # слева от окна или в левой части окна?
-#: ../../vdms_dialogs/preferences.py:211
 msgid "At the left of window"
 msgstr "Слева"
 
-#: ../../vdms_dialogs/preferences.py:213
 msgid "Place the toolbar"
 msgstr "Разместите панель инструментов"
 
-#: ../../vdms_dialogs/preferences.py:222
 msgid "Toolbar's icons size:"
 msgstr "Размер значков панели инструментов:"
 
-#: ../../vdms_dialogs/preferences.py:236
 msgid "Application Language (requires application restart)"
 msgstr "Язык приложения (требуется перезапуск Videomass)"
 
-#: ../../vdms_dialogs/preferences.py:248
 msgid "Look and Language"
 msgstr "Внешний вид и язык"
 
-#: ../../vdms_dialogs/preferences.py:254
 msgid "Upon exiting the application"
 msgstr "При выходе из приложения"
 
-#: ../../vdms_dialogs/preferences.py:259
 msgid "Always ask me to confirm"
 msgstr "Всегда просить подтверждения"
 
-#: ../../vdms_dialogs/preferences.py:261
 msgid "Clean the log files"
 msgstr "Очистите файлы log-журналов"
 
-#: ../../vdms_dialogs/preferences.py:264
 msgid "Remove cached files"
 msgstr "Удалить кэшированные файлы"
 
 # Особенности русской фразы
-#: ../../vdms_dialogs/preferences.py:268
 msgid "On operations completion"
 msgstr "По завершению операции"
 
-#: ../../vdms_dialogs/preferences.py:271
 msgid "These settings will remain active until the application is closed, If necessary, remember to reactivate them."
 msgstr ""
 "Эти настройки будут оставаться активными до тех пор, пока приложение не будет закрыто. \n"
 "При необходимости не забудьте повторно активировать их."
 
-#: ../../vdms_dialogs/preferences.py:276
 msgid "Exit the application"
 msgstr "Выйти из приложения"
 
-#: ../../vdms_dialogs/preferences.py:279
 msgid "Shutdown the system"
 msgstr "Выключить систему"
 
-#: ../../vdms_dialogs/preferences.py:283
 msgid "SUDO password:"
 msgstr "SUDO пароль:"
 
-#: ../../vdms_dialogs/preferences.py:292
 msgid "Exit and Shutdown"
 msgstr "Выход и завершение работы"
 
-#: ../../vdms_dialogs/preferences.py:298
 msgid "Specify the character encoding format"
 msgstr "Укажите формат кодировки символов"
 
-#: ../../vdms_dialogs/preferences.py:301
 msgid ""
 "Although UTF-8 is the default and most widely used standard encoding format, it is not the only encoding format available.\n"
 "Some file metadata may still contain non-UTF-8 character encodings resulting in the error \"'utf-8' codec can't decode bytes...\".\n"
@@ -1140,31 +827,24 @@ msgstr ""
 "Если вы знаете формат кодировки, в котором был записан файл, вы можете \n"
 "попробовать указать его здесь, например. ИСО 8859-1, ИСО 8859-16 и т. д."
 
-#: ../../vdms_dialogs/preferences.py:311
 msgid "Character encoding:"
 msgstr "Кодировка символов:"
 
-#: ../../vdms_dialogs/preferences.py:320
 msgid "Default application directories"
 msgstr "Каталоги приложений по умолчанию"
 
-#: ../../vdms_dialogs/preferences.py:324
 msgid "Configuration directory"
 msgstr "Каталог конфигурации"
 
-#: ../../vdms_dialogs/preferences.py:337
 msgid "Cache directory"
 msgstr "Каталог кэша"
 
-#: ../../vdms_dialogs/preferences.py:349
 msgid "Log directory"
 msgstr "Папка log-журнала"
 
-#: ../../vdms_dialogs/preferences.py:363
 msgid "Advanced"
 msgstr "Расширенные настройки"
 
-#: ../../vdms_dialogs/preferences.py:369
 msgid ""
 "The following settings affect output messages and the log messages during transcoding processes.\n"
 "Be careful, by changing these settings some functions of the application may not work correctly,\n"
@@ -1175,121 +855,73 @@ msgstr ""
 "Будьте внимательны, при изменении этих настроек некоторые функции приложения \n"
 "могут работать некорректно, изменяйте, только если вы знаете, что делаете.\n"
 
-#: ../../vdms_dialogs/preferences.py:376
 msgid "Set logging level flags used by FFmpeg"
 msgstr "Установите флаги уровня ведения журнала, используемые FFmpeg"
 
-#: ../../vdms_dialogs/preferences.py:383
 msgid "Set logging level flags used by FFplay"
 msgstr "Установите флаги уровня ведения журнала, используемые FFplay"
 
-#: ../../vdms_dialogs/preferences.py:391
 msgid "FFmpeg logging levels"
 msgstr "Комплект log-журналов FFmpeg"
 
-#: ../../vdms_dialogs/preferences.py:437
 msgid "By assigning an additional suffix you could avoid overwriting files"
 msgstr "Назначив дополнительный суффикс, вы можете избежать перезаписи файлов"
 
-#: ../../vdms_dialogs/preferences.py:440
 msgid "Type sudo password here, only for Unix-like operating systems, not for MS Windows"
 msgstr "Введите здесь пароль sudo, только для Unix-подобных операционных систем, но не для MS Windows"
 
-#: ../../vdms_dialogs/preferences.py:443
 msgid "Preferences"
 msgstr "Настройки"
 
-#: ../../vdms_dialogs/preferences.py:596 ../../vdms_dialogs/preferences.py:676
-#: ../../vdms_main/main_frame.py:879 ../../vdms_main/main_frame.py:1060
 msgid "Choose Destination"
 msgstr "Выберите папку назначения"
 
-#: ../../vdms_dialogs/preferences.py:627
 msgid "Enter only alphanumeric characters. You can also use the hyphen (\"-\") and the underscore (\"_\"). Spaces are not allowed."
 msgstr "Вводите только буквенно-цифровые символы. Вы также можете использовать дефис (\"-\") и подчеркивание (\"_\"). Пробелы не допускаются."
 
-#: ../../vdms_dialogs/preferences.py:642
-#: ../../vdms_dialogs/setting_profiles.py:257
-#: ../../vdms_dialogs/setting_profiles.py:264
-#: ../../vdms_dialogs/setting_profiles.py:286
-#: ../../vdms_dialogs/setting_profiles.py:309 ../../vdms_main/main_frame.py:399
-#: ../../vdms_main/main_frame.py:421 ../../vdms_panels/av_conversions.py:605
-#: ../../vdms_panels/av_conversions.py:612
-#: ../../vdms_panels/sequence_to_video.py:352
-#: ../../vdms_panels/video_to_sequence.py:399
 msgid "Videomass - Warning!"
 msgstr "Videomass - Предупреждение!"
 
-#: ../../vdms_dialogs/preferences.py:731 ../../vdms_dialogs/preferences.py:771
-#: ../../vdms_dialogs/preferences.py:811 ../../vdms_dialogs/wizard_dlg.py:365
-#: ../../vdms_dialogs/wizard_dlg.py:384 ../../vdms_dialogs/wizard_dlg.py:403
 #, python-brace-format
 msgid "{} location"
 msgstr "{} исполняемый файл"
 
-#: ../../vdms_dialogs/queue_edit.py:36
-#: ../../vdms_dialogs/setting_profiles.py:38
 msgid "One-Pass, Do not start with `ffmpeg -i filename`; do not end with `output-filename`"
 msgstr "Первый проход, Не начинайте с: `ffmpeg -i filename`; не заканчивайте `output-filename`"
 
-#: ../../vdms_dialogs/queue_edit.py:40
-#: ../../vdms_dialogs/setting_profiles.py:42
 msgid "Two-Pass (optional), Do not start with `ffmpeg -i filename`; do not end with `output-filename`"
 msgstr "Второй проход (по желанию), Не начинайте с `ffmpeg -i filename`; не заканчивайте `output-filename`"
 
-#: ../../vdms_dialogs/queue_edit.py:59
 msgid "Videomass - Edit the selected item in the queue"
 msgstr "Videomass - Редактировать выбранный элемент в очереди"
 
-#: ../../vdms_dialogs/queue_edit.py:71
-#: ../../vdms_dialogs/setting_profiles.py:92
 msgid "Pre-input arguments for One-Pass (optional)"
 msgstr "Аргументы предварительного ввода для One-Pass (необязательно)"
 
-#: ../../vdms_dialogs/queue_edit.py:82
-#: ../../vdms_dialogs/setting_profiles.py:151
-#: ../../vdms_panels/presets_manager.py:255
 msgid "FFmpeg arguments for one-pass encoding"
 msgstr "Аргументы FFmpeg для однопроходного кодирования"
 
-#: ../../vdms_dialogs/queue_edit.py:88
-#: ../../vdms_dialogs/setting_profiles.py:158
-#: ../../vdms_panels/presets_manager.py:259
 msgid "Any optional arguments to add before input file on the one-pass encoding, e.g required names of some hardware accelerations like -hwaccel to use with CUDA."
 msgstr "Любые необязательные аргументы, добавляемые перед входным файлом при однопроходном кодировании, например, обязательные имена некоторых аппаратных ускорений, таких как -hwaccel, для использования с CUDA."
 
-#: ../../vdms_dialogs/queue_edit.py:102
-#: ../../vdms_dialogs/setting_profiles.py:98
 msgid "Pre-input arguments for Two-Pass (optional)"
 msgstr "Аргументы предварительного ввода для двухпроходного режима (необязательно)"
 
-#: ../../vdms_dialogs/queue_edit.py:113
-#: ../../vdms_dialogs/setting_profiles.py:152
-#: ../../vdms_panels/presets_manager.py:257
 msgid "FFmpeg arguments for two-pass encoding"
 msgstr "Аргументы FFmpeg для двухпроходного кодирования"
 
-#: ../../vdms_dialogs/queue_edit.py:120
-#: ../../vdms_dialogs/setting_profiles.py:162
-#: ../../vdms_panels/presets_manager.py:263
 msgid "Any optional arguments to add before input file on the two-pass encoding, e.g required names of some hardware accelerations like -hwaccel to use with CUDA."
 msgstr "Любые необязательные аргументы, добавляемые перед входным файлом при двухпроходном кодировании, например, обязательные имена некоторых аппаратных ускорений, таких как -hwaccel, для использования с CUDA."
 
-#: ../../vdms_dialogs/queuedlg.py:65 ../../vdms_main/main_frame.py:508
-#: ../../vdms_panels/presets_manager.py:189
-#: ../../vdms_panels/video_to_sequence.py:171
 msgid "Edit"
 msgstr "Редактировать"
 
-#: ../../vdms_dialogs/queuedlg.py:68
 msgid "Remove"
 msgstr "Удалить"
 
-#: ../../vdms_dialogs/queuedlg.py:71
 msgid "Remove all"
 msgstr "Удалить все"
 
-#: ../../vdms_dialogs/queuedlg.py:74
 msgid ""
 "Export\n"
 "queue file"
@@ -1297,7 +929,6 @@ msgstr ""
 "Экспорт\n"
 "файла очереди(.json)"
 
-#: ../../vdms_dialogs/queuedlg.py:77
 msgid ""
 "Import\n"
 "queue file"
@@ -1305,29 +936,21 @@ msgstr ""
 "Импортировать\n"
 "файл очереди"
 
-#: ../../vdms_dialogs/queuedlg.py:85 ../../vdms_panels/filedrop.py:273
 msgid "Destination file name"
 msgstr "Имя файла назначения"
 
-#: ../../vdms_dialogs/queuedlg.py:137
 msgid "Remove all items in the queue"
 msgstr "Удалить все элементы в очереди"
 
-#: ../../vdms_dialogs/queuedlg.py:151
 msgid "Videomass - Queue"
 msgstr "Videomass - Очередь"
 
-#: ../../vdms_dialogs/queuedlg.py:228
 msgid "Export queue file"
 msgstr "Экспортировать файл очереди(.json)"
 
-#: ../../vdms_dialogs/queuedlg.py:296 ../../vdms_panels/av_conversions.py:1192
-#: ../../vdms_panels/presets_manager.py:1044
-#: ../../vdms_panels/video_to_sequence.py:600
 msgid "Same as source"
 msgstr "Так же, как источник"
 
-#: ../../vdms_dialogs/queuedlg.py:301
 msgid ""
 "Source\n"
 "File destination\n"
@@ -1345,84 +968,63 @@ msgstr ""
 "Начало сегмента\n"
 "Продолжительность клипа"
 
-#: ../../vdms_dialogs/renamer.py:76
 msgid "# will be replaced by ascending numbers starting with:"
 msgstr "# будут заменены возрастающими числами, начинающимися с:"
 
-#: ../../vdms_dialogs/set_timestamp.py:87
 msgid "Font Size"
 msgstr "Размер шрифта"
 
-#: ../../vdms_dialogs/set_timestamp.py:111
 msgid "Font Color"
 msgstr "Цвет шрифта"
 
-#: ../../vdms_dialogs/set_timestamp.py:121
 msgid "Shadow Color"
 msgstr "Цвет тени"
 
-#: ../../vdms_dialogs/set_timestamp.py:132
 msgid "Show text box"
 msgstr "Показать текстовое поле"
 
 # изменено 21-2-2021
 # Field color
-#: ../../vdms_dialogs/set_timestamp.py:136
 msgid "Box Color"
 msgstr "Цвет поля"
 
-#: ../../vdms_dialogs/set_timestamp.py:156
 msgid "The timestamp size does not auto-adjust to the video size, you have to set the size here"
 msgstr "Размер шкалы времени воспроизведения не подстраивается автоматически под размер видео, вы должны установить размер здесь"
 
 # непонятная timestamp
-#: ../../vdms_dialogs/set_timestamp.py:160 ../../vdms_main/main_frame.py:559
 msgid "Timestamp settings"
 msgstr "Настройки шкалы времени воспроизведения"
 
-#: ../../vdms_dialogs/setting_profiles.py:46
 msgid "Supported Formats list (optional). Do not include the `.`"
 msgstr "Список поддерживаемых форматов (необязательно). Не указывать точку `.`"
 
-#: ../../vdms_dialogs/setting_profiles.py:47
 msgid "Output Format. Empty to copy format and codec. Do not include the `.`"
 msgstr "Выходной формат. Пусто для копирования формата и кодека. Не указывать точку `.`"
 
-#: ../../vdms_dialogs/setting_profiles.py:70
 msgid "Profile Name"
 msgstr "Имя профиля"
 
-#: ../../vdms_dialogs/setting_profiles.py:74
-#: ../../vdms_panels/presets_manager.py:404
 msgid "Description"
 msgstr "Описание"
 
-#: ../../vdms_dialogs/setting_profiles.py:149
 msgid "A short profile name"
 msgstr "Краткое имя профиля"
 
-#: ../../vdms_dialogs/setting_profiles.py:150
 msgid "A long description of the profile"
 msgstr "Подробное описание профиля"
 
-#: ../../vdms_dialogs/setting_profiles.py:153
 msgid "One or more comma-separated format names compatible with this profile"
 msgstr "Одно или несколько названий форматов, разделенных запятыми, совместимых с этим профилем"
 
-#: ../../vdms_dialogs/setting_profiles.py:155
 msgid "Output format extension. Leave empty to copy codec and format"
 msgstr "Расширение формата вывода. Оставьте пустым, чтобы скопировать кодек и формат"
 
-#: ../../vdms_dialogs/setting_profiles.py:256
 msgid "Incomplete profile assignments"
 msgstr "Неполные данные профиля"
 
-#: ../../vdms_dialogs/setting_profiles.py:263
 msgid "Formats must be comma-separated"
 msgstr "Форматы должны быть разделены запятыми"
 
-#: ../../vdms_dialogs/setting_profiles.py:279
-#: ../../vdms_utils/queue_utils.py:80
 #, python-brace-format
 msgid ""
 "ERROR: Keys mismatched for requested data.\n"
@@ -1431,105 +1033,69 @@ msgstr ""
 "ОШИБКА: Ключи не соответствуют запрошенным данным.\n"
 "Неверный файл: «{0}»"
 
-#: ../../vdms_dialogs/setting_profiles.py:285
-#: ../../vdms_dialogs/setting_profiles.py:308
 msgid "Profile already stored with same name"
 msgstr "Профиль с таким именем уже сохранен"
 
-#: ../../vdms_dialogs/setting_profiles.py:293
 msgid "Profile stored successfully!"
 msgstr "Profile stored successfully!"
 
-#: ../../vdms_dialogs/setting_profiles.py:311
 msgid "Profile change successful!"
 msgstr "Смена профиля прошла успешно!"
 
-#: ../../vdms_dialogs/showlogs.py:80
 msgid "Log file list"
 msgstr "Список log-файлов"
 
-#: ../../vdms_dialogs/showlogs.py:82 ../../vdms_dialogs/showlogs.py:116
 msgid "Log messages"
 msgstr "Log-журнал"
 
-#: ../../vdms_dialogs/showlogs.py:105
 msgid "Refresh log messages"
 msgstr "Обновить log-журналы"
 
-#: ../../vdms_dialogs/showlogs.py:107
 msgid "Clear log messages"
 msgstr "Очистить log-журналы"
 
-#: ../../vdms_dialogs/showlogs.py:160
 msgid "Select a log file"
 msgstr "Выберите файл журнала"
 
-#: ../../vdms_dialogs/showlogs.py:167
 msgid "Are you sure you want to clear the selected log file?"
 msgstr "Вы действительно хотите удалить выбранный файл log-журнала?"
 
-#: ../../vdms_dialogs/showlogs.py:168 ../../vdms_dialogs/wizard_dlg.py:251
-#: ../../vdms_io/checkup.py:68 ../../vdms_main/main_frame.py:205
-#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1685
-#: ../../vdms_panels/presets_manager.py:349
-#: ../../vdms_panels/presets_manager.py:550
-#: ../../vdms_panels/presets_manager.py:590
-#: ../../vdms_panels/presets_manager.py:649
-#: ../../vdms_panels/presets_manager.py:684
-#: ../../vdms_panels/presets_manager.py:749
-#: ../../vdms_panels/presets_manager.py:775
-#: ../../vdms_panels/presets_manager.py:874
-#: ../../vdms_panels/presets_manager.py:904
 msgid "Please confirm"
 msgstr "Пожалуйста, подтвердите"
 
-#: ../../vdms_dialogs/shownormlist.py:83
 msgid "File name"
 msgstr "Имя файла"
 
-#: ../../vdms_dialogs/shownormlist.py:84
 msgid "Max volume dBFS"
 msgstr "Максимальная громкость dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:85
 msgid "Mean volume dBFS"
 msgstr "Средняя громкость dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:86
 msgid "Offset dBFS"
 msgstr "Смещение dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:87
 msgid "Result dBFS"
 msgstr "Результат DBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:92
 msgid "Post-normalization references:"
 msgstr "Ссылки после нормализации:"
 
-#: ../../vdms_dialogs/shownormlist.py:102
 msgid "=  Clipped peaks"
 msgstr "=  Clipped peaks"
 
-#: ../../vdms_dialogs/shownormlist.py:111
 msgid "=  No changes"
 msgstr "=  Без изменений"
 
-#: ../../vdms_dialogs/shownormlist.py:121
 msgid "=  Below max peak"
 msgstr "=  Ниже максимального пика"
 
-#: ../../vdms_dialogs/shownormlist.py:166
-#: ../../vdms_panels/audio_encoders/acodecs.py:841
 msgid "RMS-based volume statistics"
 msgstr "Статистика звука на основе RMS"
 
-#: ../../vdms_dialogs/shownormlist.py:191
-#: ../../vdms_panels/audio_encoders/acodecs.py:839
 msgid "PEAK-based volume statistics"
 msgstr "Статистика звука на основе PEAK"
 
-#: ../../vdms_dialogs/shownormlist.py:216
 msgid ""
 "...It means the resulting audio will be clipped,\n"
 "because its volume is higher than the maximum 0 db\n"
@@ -1541,7 +1107,6 @@ msgstr ""
 "максимальный уровень 0 дБ. Это приводит к \n"
 "потере данных и искажению звука."
 
-#: ../../vdms_dialogs/shownormlist.py:242
 msgid ""
 "...It means the resulting audio will not change,\n"
 "because it's equal to the source."
@@ -1549,7 +1114,6 @@ msgstr ""
 "...Это означает, что результирующий звук не\n"
 "изменится, потому что он равен источнику."
 
-#: ../../vdms_dialogs/shownormlist.py:266
 msgid ""
 "...It means an audio signal will be produced with\n"
 "a lower volume than the source."
@@ -1557,15 +1121,12 @@ msgstr ""
 "...Это означает, что аудиосигнал будет воспроизводиться\n"
 "с меньшей громкостью, чем исходный."
 
-#: ../../vdms_dialogs/videomass_check_version.py:63
 msgid "Get Latest Version"
 msgstr "Получить последнюю версию"
 
-#: ../../vdms_dialogs/videomass_check_version.py:67
 msgid "Checking for newer version"
 msgstr "Проверить последнюю версию"
 
-#: ../../vdms_dialogs/videomass_check_version.py:95
 msgid ""
 "\n"
 "\n"
@@ -1575,7 +1136,6 @@ msgstr ""
 "\n"
 "Новые выпуски исправляют ошибки и предлагают новые функции."
 
-#: ../../vdms_dialogs/videomass_check_version.py:96
 #, python-brace-format
 msgid ""
 "\n"
@@ -1588,7 +1148,6 @@ msgstr ""
 "Это Videomass v.{0}\n"
 "\n"
 
-#: ../../vdms_dialogs/while_playing.py:37
 msgid ""
 "q, ESC\n"
 "f\n"
@@ -1630,37 +1189,29 @@ msgstr ""
 "щелчок правой кнопкой мыши\n"
 "двойной щелчок левой кнопкой мыши"
 
-#: ../../vdms_dialogs/while_playing.py:92
 msgid "Shortcut keys while playing with FFplay"
 msgstr "Сочетания клавиш во время проигрывания с FFplay"
 
-#: ../../vdms_dialogs/widget_utils.py:120 ../../vdms_main/main_frame.py:1326
 msgid "Stop"
 msgstr "Стоп"
 
-#: ../../vdms_dialogs/wizard_dlg.py:63
 msgid "Please take a moment to set up the application"
 msgstr "Пожалуйста, найдите время, чтобы настроить приложение"
 
-#: ../../vdms_dialogs/wizard_dlg.py:64
 msgid "Click the \"Next\" button to get started"
 msgstr "Нажмите кнопку \"Следующий\", чтобы начать"
 
-#: ../../vdms_dialogs/wizard_dlg.py:79
 msgid "Welcome to the Videomass Wizard!"
 msgstr "Добро пожаловать в Помощник Videomass!"
 
-#: ../../vdms_dialogs/wizard_dlg.py:123
 msgid "Videomass is an application based on FFmpeg\n"
 msgstr "Videomass - это приложение на основе FFmpeg\n"
 
-#: ../../vdms_dialogs/wizard_dlg.py:125
 msgid "If FFmpeg is not on your computer, this application will be unusable"
 msgstr ""
 "Если FFmpeg отсутствует на вашем компьютере, это приложение\n"
 "будет невозможно использовать"
 
-#: ../../vdms_dialogs/wizard_dlg.py:128
 msgid ""
 "If you have already installed FFmpeg on your operating system,\n"
 "click the \"Auto-detection\" button."
@@ -1668,7 +1219,6 @@ msgstr ""
 "Если вы уже установили FFmpeg в свою операционную систему, \n"
 "нажмите кнопку \"Автоматическое определение\"."
 
-#: ../../vdms_dialogs/wizard_dlg.py:131
 msgid ""
 "If you want to use a version of FFmpeg located on your filesystem\n"
 "but not installed on your operating system,\n"
@@ -1677,24 +1227,19 @@ msgstr ""
 "Если вы хотите использовать версию FFmpeg, расположенную в вашей файловой системе, \n"
 "но не установленную в вашей операционной системе, нажмите кнопку \"Найти\"."
 
-#: ../../vdms_dialogs/wizard_dlg.py:162
 msgid "Auto-detection"
 msgstr "Автоматическое определение"
 
-#: ../../vdms_dialogs/wizard_dlg.py:164
 msgid "Locate"
 msgstr "Найдите"
 
-#: ../../vdms_dialogs/wizard_dlg.py:214
 msgid "Click the \"Next\" button"
 msgstr "Нажмите кнопку \"Следующий\""
 
-#: ../../vdms_dialogs/wizard_dlg.py:235
 #, python-brace-format
 msgid "'{}' is not installed on your computer. Install it or indicate another location by clicking the 'Locate' button."
 msgstr "'{}' не установлен на вашем компьютере. Установите его или укажите другое место, нажав кнопку 'Найти'."
 
-#: ../../vdms_dialogs/wizard_dlg.py:249
 msgid ""
 "Videomass already seems to include FFmpeg.\n"
 "\n"
@@ -1704,11 +1249,9 @@ msgstr ""
 "\n"
 "Вы хотите использовать это?"
 
-#: ../../vdms_dialogs/wizard_dlg.py:275
 msgid "Locating FFmpeg executables\n"
 msgstr "Поиск исполняемых файлов FFmpeg\n"
 
-#: ../../vdms_dialogs/wizard_dlg.py:277
 msgid ""
 "\"ffmpeg\", \"ffprobe\" and \"ffplay\" are required. Complete all\n"
 "the text boxes below by clicking on the respective buttons."
@@ -1716,41 +1259,31 @@ msgstr ""
 "\"ffmpeg\", \"ffprobe\" и \"ffplay\" обязательны. Заполните все\n"
 "текстовые поля ниже, нажав соответствующие кнопки."
 
-#: ../../vdms_dialogs/wizard_dlg.py:437
 msgid "Wizard completed successfully!\n"
 msgstr "Помощник успешно завершен!\n"
 
-#: ../../vdms_dialogs/wizard_dlg.py:438
 msgid "Remember that you can always change these settings later, through the Preferences dialog."
 msgstr "Помните, что вы всегда можете изменить эти настройки позже через диалоговое окно «Настройки»."
 
-#: ../../vdms_dialogs/wizard_dlg.py:440
 msgid "Thank You!"
 msgstr "Благодарю вас!"
 
 # сделал одинарные кавычки
-#: ../../vdms_dialogs/wizard_dlg.py:441
 msgid "To exit click the \"Finish\" button"
 msgstr "Для выхода нажмите кнопку \"Завершено\""
 
-#: ../../vdms_dialogs/wizard_dlg.py:527
 msgid "< Previous"
 msgstr "< Предыдущий"
 
-#: ../../vdms_dialogs/wizard_dlg.py:530 ../../vdms_dialogs/wizard_dlg.py:613
 msgid "Next >"
 msgstr "Следующий >"
 
-#: ../../vdms_dialogs/wizard_dlg.py:535
 msgid "Videomass Wizard"
 msgstr "Videomass Помощник"
 
-#: ../../vdms_dialogs/wizard_dlg.py:563 ../../vdms_dialogs/wizard_dlg.py:586
-#: ../../vdms_dialogs/wizard_dlg.py:591
 msgid "Finish"
 msgstr "Завершено"
 
-#: ../../vdms_io/checkup.py:44 ../../vdms_io/checkup.py:92
 #, python-brace-format
 msgid ""
 "Output folder does not exist:\n"
@@ -1761,32 +1294,25 @@ msgstr ""
 "\n"
 "\"{}\"\n"
 
-#: ../../vdms_io/checkup.py:65
 msgid "Files already exist, do you want to overwrite them?"
 msgstr "Файлы уже существуют, перезаписать их?"
 
-#: ../../vdms_io/checkup.py:67
 msgid "Already exist"
 msgstr "Уже существует"
 
-#: ../../vdms_io/checkup.py:81
 msgid "Not found"
 msgstr "Не найдено"
 
-#: ../../vdms_io/checkup.py:82 ../../vdms_panels/filedrop.py:196
 msgid "Error list"
 msgstr "Список ошибок"
 
-#: ../../vdms_io/checkup.py:83
 msgid "File(s) not found"
 msgstr "Файл(ы) не найден"
 
-#: ../../vdms_io/io_tools.py:56
 #, python-format
 msgid "File does not exist or is invalid:  %s"
 msgstr "Файл не существует или недействителен:  %s"
 
-#: ../../vdms_io/io_tools.py:74
 msgid ""
 "Wait....\n"
 "Audio peak analysis."
@@ -1794,16 +1320,12 @@ msgstr ""
 "Пожалуйста, подождите....\n"
 "Анализ звуковых пиков."
 
-#: ../../vdms_io/io_tools.py:179
 msgid "Videomass - Downloading..."
 msgstr "Videomass - Скачивание..."
 
-#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1409
-#: ../../vdms_main/main_frame.py:1441
 msgid "Ready"
 msgstr "Готово"
 
-#: ../../vdms_main/main_frame.py:203
 msgid ""
 "Not all items in the queue were completed.\n"
 "\n"
@@ -1813,348 +1335,261 @@ msgstr ""
 "\n"
 "Хотите оставить их в очереди?"
 
-#: ../../vdms_main/main_frame.py:224
 #, python-brace-format
 msgid "Queue ({0})"
 msgstr "Очередь ({0})"
 
-#: ../../vdms_main/main_frame.py:229 ../../vdms_main/main_frame.py:1334
 msgid "Queue"
 msgstr "Очередь"
 
-#: ../../vdms_main/main_frame.py:396 ../../vdms_main/main_frame.py:418
 msgid "There are still active windows with running processes, make sure you finish your work before exit."
 msgstr "Еще есть активные окна с запущенными процессами, перед выходом обязательно завершите работу."
 
-#: ../../vdms_main/main_frame.py:403
 msgid "Are you sure you want to exit the application?"
 msgstr "Вы уверены, что хотите выйти из приложения?"
 
-#: ../../vdms_main/main_frame.py:405
 msgid "Exit"
 msgstr "Выход"
 
-#: ../../vdms_main/main_frame.py:463
 msgid "Import files\tCtrl+O"
 msgstr "Импортировать файлы\tCtrl+O"
 
-#: ../../vdms_main/main_frame.py:466
 msgid "Open destination folder of encodings\tCtrl+D"
 msgstr "Открыть папку назначения кодировок\tCtrl+D"
 
-#: ../../vdms_main/main_frame.py:469
 msgid "Load queue file"
 msgstr "Загрузить файл очереди(.json)"
 
-#: ../../vdms_main/main_frame.py:470
 msgid "Load a previously exported queue file"
 msgstr "Загрузите ранее экспортированный файл очереди(.json)"
 
-#: ../../vdms_main/main_frame.py:473
 msgid "Open trash"
 msgstr "Открыть корзину"
 
-#: ../../vdms_main/main_frame.py:474
 msgid "Open the Videomass trash folder"
 msgstr "Откройте корзину Videomass"
 
-#: ../../vdms_main/main_frame.py:476
 msgid "Empty trash"
 msgstr "Очистить корзину"
 
-#: ../../vdms_main/main_frame.py:477
 msgid "Delete all files in the Videomass trash folder"
 msgstr "Удалить все файлы в корзине Videomass"
 
-#: ../../vdms_main/main_frame.py:480
 msgid "Exit\tCtrl+Q"
 msgstr "Выход\tCtrl+Q"
 
-#: ../../vdms_main/main_frame.py:481
 msgid "Completely exit the application"
 msgstr "Полностью выйти из приложения"
 
-#: ../../vdms_main/main_frame.py:482
 msgid "File"
 msgstr "Файл"
 
-#: ../../vdms_main/main_frame.py:486 ../../vdms_panels/filedrop.py:340
-#: ../../vdms_panels/filedrop.py:381
 msgid "Rename selected file\tCtrl+R"
 msgstr "Переименовать выбранный файл\tCtrl+R"
 
-#: ../../vdms_main/main_frame.py:487
 msgid "Rename the destination of the selected file"
 msgstr "Переименуйте место назначения выбранного файла"
 
-#: ../../vdms_main/main_frame.py:490 ../../vdms_panels/filedrop.py:341
-#: ../../vdms_panels/filedrop.py:384
 msgid "Batch rename files\tCtrl+B"
 msgstr "Пакетное переименование файлов\tCtrl+B"
 
-#: ../../vdms_main/main_frame.py:491
 msgid "Numerically renames the destination of all items in the list"
 msgstr "Численно переименовывает пункт назначения всех элементов в списке."
 
-#: ../../vdms_main/main_frame.py:496 ../../vdms_panels/filedrop.py:343
-#: ../../vdms_panels/filedrop.py:388
 msgid "Remove selected entry\tDEL"
 msgstr "Удалить выбранный файл\tDEL"
 
-#: ../../vdms_main/main_frame.py:497
 msgid "Remove the selected file from the list"
 msgstr "Удалить выбранный файл из списка"
 
-#: ../../vdms_main/main_frame.py:500 ../../vdms_panels/filedrop.py:344
-#: ../../vdms_panels/filedrop.py:391
 msgid "Clear list\tShift+DEL"
 msgstr "Очистить список\tShift+DEL"
 
-#: ../../vdms_main/main_frame.py:501
 msgid "Clear the file list"
 msgstr "Очистить список файлов"
 
-#: ../../vdms_main/main_frame.py:506
 msgid "Preferences\tCtrl+P"
 msgstr "Настройки\tCtrl+P"
 
-#: ../../vdms_main/main_frame.py:507
 msgid "Application preferences"
 msgstr "Настройки приложения"
 
-#: ../../vdms_main/main_frame.py:512
 msgid "Find FFmpeg topics"
 msgstr "Найти темы FFmpeg"
 
-#: ../../vdms_main/main_frame.py:513
 msgid "A useful tool to search for FFmpeg help topics and options"
 msgstr "Полезный инструмент для поиска тем и параметров справки FFmpeg"
 
-#: ../../vdms_main/main_frame.py:518
 msgid "Check for preset updates"
 msgstr "Проверьте наличие обновления пресетов"
 
-#: ../../vdms_main/main_frame.py:519
 #, python-brace-format
 msgid "Check for new presets updates from {0}"
 msgstr "Проверьте наличие новых обновлений пресетов на {0}"
 
-#: ../../vdms_main/main_frame.py:521
 msgid "Get latest presets"
 msgstr "Получить последние пресеты"
 
-#: ../../vdms_main/main_frame.py:522
 #, python-brace-format
 msgid "Get the latest presets from {0}"
 msgstr "Получить последние пресеты по адресу {0}"
 
-#: ../../vdms_main/main_frame.py:525
 msgid "Work notes\tCtrl+N"
 msgstr "Рабочие заметки\tCtrl+N"
 
-#: ../../vdms_main/main_frame.py:526
 msgid "Read and write useful notes and reminders."
 msgstr "Читайте и пишите полезные заметки и напоминания."
 
-#: ../../vdms_main/main_frame.py:528
 msgid "Tools"
 msgstr "Инструменты"
 
-#: ../../vdms_main/main_frame.py:535
 msgid "Show FFmpeg's built-in configuration capabilities"
 msgstr "Показать встроенные возможности настройки FFmpeg"
 
-#: ../../vdms_main/main_frame.py:539
 msgid "Muxers and demuxers available on your version of FFmpeg"
 msgstr "Мультиплексоры и демультиплексоры доступны в вашей версии FFmpeg"
 
-#: ../../vdms_main/main_frame.py:543
 msgid "Encoders available on your version of FFmpeg"
 msgstr "Кодировщики, доступные в вашей версии FFmpeg"
 
-#: ../../vdms_main/main_frame.py:546
 msgid "Decoders available on your version of FFmpeg"
 msgstr "Декодеры, доступные в вашей версии FFmpeg"
 
-#: ../../vdms_main/main_frame.py:550
 msgid "Enable timestamps on playback"
 msgstr "Включить шкалу времени при воспроизведении"
 
-#: ../../vdms_main/main_frame.py:551
 msgid "Displays timestamp when playing media with FFplay"
 msgstr "Отображает шкалу времени при воспроизведении мультимедиа с помощью FFplay"
 
-#: ../../vdms_main/main_frame.py:554
 msgid "Auto-exit after playback"
 msgstr "Автоматический выход после воспроизведения"
 
-#: ../../vdms_main/main_frame.py:555
 msgid "If checked, the FFplay window will auto-close when playback is complete"
 msgstr ""
 "Если флажок установлен, окно FFplay будет автоматически закрываться \n"
 "после завершения воспроизведения"
 
-#: ../../vdms_main/main_frame.py:559
 msgid "Customize the timestamp style"
 msgstr "Настройте стиль метки времени"
 
-#: ../../vdms_main/main_frame.py:562
 msgid "While playing..."
 msgstr "Навигация во время проигрывания..."
 
-#: ../../vdms_main/main_frame.py:563
 msgid "Show useful shortcut keys when playing or previewing using FFplay"
 msgstr ""
 "Покажите полезные сочетания клавиш при воспроизведении \n"
 "или предварительном просмотре с помощью FFplay"
 
-#: ../../vdms_main/main_frame.py:567
 msgid "Show timeline editor\tCtrl+T"
 msgstr "Показать редактор timeline\tCtrl+T"
 
-#: ../../vdms_main/main_frame.py:568
 msgid "Set duration or trim slices of time to remove unwanted parts from your files"
 msgstr ""
 "Установите продолжительность или обрежьте отрезки времени, чтобы удалить \n"
 "ненужные части из ваших файлов"
 
-#: ../../vdms_main/main_frame.py:572
 msgid "View"
 msgstr "Посмотр"
 
-#: ../../vdms_main/main_frame.py:579
 msgid "Home panel\tCtrl+Shift+H"
 msgstr "Начальная панель\tCtrl+Shift+H"
 
-#: ../../vdms_main/main_frame.py:580
 msgid "Go to the «Home» panel"
 msgstr "Перейти на «Начальная панель»"
 
-#: ../../vdms_main/main_frame.py:583
 msgid "Presets Manager\tCtrl+Shift+P"
 msgstr "Менеджер Пресетов\tCtrl+Shift+P"
 
-#: ../../vdms_main/main_frame.py:584
 msgid "Go to the «Presets Manager» panel"
 msgstr "Перейдите на панель «Менеджер пресетов»"
 
-#: ../../vdms_main/main_frame.py:586
 msgid "A/V Conversions\tCtrl+Shift+V"
 msgstr "A/V Конвертация\tCtrl+Shift+V"
 
-#: ../../vdms_main/main_frame.py:587
 msgid "Go to the «A/V Conversions» panel"
 msgstr "Перейдите на панель «A/V-конверсии»"
 
-#: ../../vdms_main/main_frame.py:589
 msgid "Concatenate Demuxer\tCtrl+Shift+D"
 msgstr "Concatenate Demuxer\tCtrl+Shift+D"
 
-#: ../../vdms_main/main_frame.py:590
 msgid "Go to the «Concatenate Demuxer» panel"
 msgstr "Перейдите на панель «Объединить медиафайлы»"
 
-#: ../../vdms_main/main_frame.py:593
 msgid "Still Image Maker\tCtrl+Shift+I"
 msgstr "Still Image Maker\tCtrl+Shift+I"
 
-#: ../../vdms_main/main_frame.py:594
 msgid "Go to the «Still Image Maker» panel"
 msgstr "Перейдите на панель 'Still Image Maker'"
 
-#: ../../vdms_main/main_frame.py:596
 msgid "From Movie to Pictures\tCtrl+Shift+S"
 msgstr "Картинки из фильма\tCtrl+Shift+S"
 
-#: ../../vdms_main/main_frame.py:597
 msgid "Go to the «From Movie to Pictures» panel"
 msgstr "Переходим на панель «Картинки из фильма»"
 
-#: ../../vdms_main/main_frame.py:600
 msgid "Output monitor\tCtrl+Shift+O"
 msgstr "Выходной монитор\tCtrl+Shift+O"
 
-#: ../../vdms_main/main_frame.py:601
 msgid "Keeps track of the output for debugging errors"
 msgstr "Отслеживает вывод для отладки ошибок"
 
-#: ../../vdms_main/main_frame.py:603
 msgid "Go"
 msgstr "Переход"
 
-#: ../../vdms_main/main_frame.py:607
 msgid "User guide"
 msgstr "Руководство пользователя"
 
-#: ../../vdms_main/main_frame.py:611
 msgid "System version"
 msgstr "Версия системы"
 
-#: ../../vdms_main/main_frame.py:612
 msgid "Get version about your operating system, version of Python and wxPython."
 msgstr "Получить версию вашей операционной системы, версию Python и wxPython."
 
-#: ../../vdms_main/main_frame.py:616
 msgid "Show log files\tCtrl+L"
 msgstr "Показать файлы log-журналов\tCtrl+L"
 
-#: ../../vdms_main/main_frame.py:617
 msgid "Viewing log messages"
 msgstr "Просмотр сообщений log-журнала"
 
-#: ../../vdms_main/main_frame.py:620
 msgid "Issue tracker"
 msgstr "Сообщить о проблеме"
 
-#: ../../vdms_main/main_frame.py:624
 msgid "Contribute to the project"
 msgstr "Внести свой вклад в проект"
 
-#: ../../vdms_main/main_frame.py:627
 msgid "Sponsor this project"
 msgstr "Спонсируйте этот проект"
 
-#: ../../vdms_main/main_frame.py:628
 msgid "Become a developer supporter"
 msgstr "Станьте сторонником разработчиков"
 
-#: ../../vdms_main/main_frame.py:629
 msgid "Donate"
 msgstr "Пожертвовать"
 
-#: ../../vdms_main/main_frame.py:630
 msgid "Donate to the app developer"
 msgstr "Пожертвуйте разработчику приложения"
 
-#: ../../vdms_main/main_frame.py:634
 msgid "Other projects by the developer"
 msgstr "Другие проекты разработчика"
 
-#: ../../vdms_main/main_frame.py:650
 msgid "About Videomass"
 msgstr "Информация об Videomass"
 
-#: ../../vdms_main/main_frame.py:651
 msgid "Check for newer version"
 msgstr "Проверить последнюю версию"
 
-#: ../../vdms_main/main_frame.py:652
 msgid "Check for the latest Videomass version"
 msgstr "Проверьте наличие последней версии Videomass"
 
-#: ../../vdms_main/main_frame.py:654
 msgid "Help"
 msgstr "Помощь"
 
-#: ../../vdms_main/main_frame.py:729
 msgid "Import files"
 msgstr "Импортировать файлы"
 
-#: ../../vdms_main/main_frame.py:752
 msgid "No default folder has been set for the destination of the encodings. The current setting is \"Same destination paths as source files\"."
 msgstr "Для назначения кодировок не установлена ​​папка по умолчанию. Текущая настройка — «Те же пути назначения, что и исходные файлы»."
 
-#: ../../vdms_main/main_frame.py:784 ../../vdms_main/main_frame.py:809
 #, python-brace-format
 msgid ""
 "'{}':\n"
@@ -2163,11 +1598,9 @@ msgstr ""
 "'{}':\n"
 "Данный файл или каталог отсутствует"
 
-#: ../../vdms_main/main_frame.py:797
 msgid "Are you sure to empty trash folder?"
 msgstr "Вы уверены, что очистили папку \"Корзина\"?"
 
-#: ../../vdms_main/main_frame.py:805
 #, python-brace-format
 msgid ""
 "'{}':\n"
@@ -2176,17 +1609,14 @@ msgstr ""
 "'{}':\n"
 "Нет файлов для удаления."
 
-#: ../../vdms_main/main_frame.py:862
 #, python-brace-format
 msgid "Installed release v{0}. A new presets release is available {1}"
 msgstr "Installed release v{0}. A new presets release is available {1}"
 
-#: ../../vdms_main/main_frame.py:866
 #, python-brace-format
 msgid "Installed release v{0}. No new updates found."
 msgstr "Установленная версия {0}. Новых обновлений не обнаружено."
 
-#: ../../vdms_main/main_frame.py:896
 msgid ""
 "Wait....\n"
 "The archive is being downloaded"
@@ -2194,16 +1624,13 @@ msgstr ""
 "Подождите...\n"
 "Архив скачивается"
 
-#: ../../vdms_main/main_frame.py:908
 #, python-brace-format
 msgid "Successfully downloaded to \"{0}\""
 msgstr "Успешно загружено в \"{0}\""
 
-#: ../../vdms_main/main_frame.py:1120
 msgid "Some changes require restarting the application."
 msgstr "Некоторые изменения требуют перезапуска приложения."
 
-#: ../../vdms_main/main_frame.py:1126
 #, python-brace-format
 msgid ""
 "{0}\n"
@@ -2214,116 +1641,85 @@ msgstr ""
 "\n"
 "Хотите перезапустить приложение сейчас?"
 
-#: ../../vdms_main/main_frame.py:1128
 msgid "Restart Videomass?"
 msgstr "Перезапустить Видеомасс?"
 
-#: ../../vdms_main/main_frame.py:1207
 #, python-brace-format
 msgid "A new release is available - v.{0}\n"
 msgstr "Доступна новая версия - v.{0}\n"
 
-#: ../../vdms_main/main_frame.py:1210
 msgid "You are using a development version that has not yet been released!\n"
 msgstr "Вы используете версию для разработки, которая еще не выпущена!\n"
 
-#: ../../vdms_main/main_frame.py:1213
 msgid "Congratulation! You are already using the latest version.\n"
 msgstr "Поздравляю! Вы уже используете последнюю версию.\n"
 
-#: ../../vdms_main/main_frame.py:1301
 msgid "Previous panel"
 msgstr "Предыдущая панель"
 
-#: ../../vdms_main/main_frame.py:1302
 msgid "Back"
 msgstr "Назад"
 
-#: ../../vdms_main/main_frame.py:1305
 msgid "Next panel"
 msgstr "Следующая панель"
 
-#: ../../vdms_main/main_frame.py:1306
 msgid "Next"
 msgstr "Вперед"
 
-#: ../../vdms_main/main_frame.py:1309
 msgid "Home panel"
 msgstr "Начальная панель"
 
-#: ../../vdms_main/main_frame.py:1310
 msgid "Home"
 msgstr "Начальная панель"
 
-#: ../../vdms_main/main_frame.py:1313
 msgid "Play the selected imput file"
 msgstr "Воспроизвести выбранный входной файл"
 
-#: ../../vdms_main/main_frame.py:1314
 msgid "Play"
 msgstr "Воспроизведение"
 
-#: ../../vdms_main/main_frame.py:1317
 msgid "Get informative data about imported media streams"
 msgstr "Получайте информативные данные об импортированных медиапотоках"
 
-#: ../../vdms_main/main_frame.py:1321
 msgid "Start batch processing"
 msgstr "Начать пакетную обработку"
 
-#: ../../vdms_main/main_frame.py:1325
 msgid "Stops current process"
 msgstr "Останавливает текущий процесс"
 
-#: ../../vdms_main/main_frame.py:1329
 msgid "Add an item to Queue"
 msgstr "Добавить элемент в очередь"
 
-#: ../../vdms_main/main_frame.py:1330
 msgid "Add to Queue"
 msgstr "Добавить в очередь"
 
-#: ../../vdms_main/main_frame.py:1333
 msgid "Show queue"
 msgstr "Показать очередь"
 
-#: ../../vdms_main/main_frame.py:1408 ../../vdms_panels/presets_manager.py:569
 msgid "Videomass"
 msgstr "Videomass"
 
-#: ../../vdms_main/main_frame.py:1442
 msgid "Videomass - File List"
 msgstr "Videomass - Список файлов"
 
-#: ../../vdms_main/main_frame.py:1459
 msgid "Videomass - AV Conversions"
 msgstr "Videomass - AV-конвертация"
 
-#: ../../vdms_main/main_frame.py:1488
 msgid "Videomass - Presets Manager"
 msgstr "Videomass - Менеджер Пресетов"
 
-#: ../../vdms_main/main_frame.py:1518
 msgid "Videomass - Concatenate Demuxer"
 msgstr "Videomass - Concatenate Demuxer"
 
-#: ../../vdms_main/main_frame.py:1547
 msgid "Videomass - From Movie to Pictures"
 msgstr "Videomass - Картинки из фильма"
 
-#: ../../vdms_main/main_frame.py:1576
 msgid "Videomass - Still Image Maker"
 msgstr "Videomass - Still Image Maker"
 
-#: ../../vdms_main/main_frame.py:1660 ../../vdms_panels/av_conversions.py:577
-#: ../../vdms_panels/filedrop.py:500 ../../vdms_panels/filedrop.py:616
-#: ../../vdms_panels/sequence_to_video.py:322
-#: ../../vdms_panels/video_to_sequence.py:369
-#: ../../vdms_panels/video_to_sequence.py:501
 msgid "Have to select an item in the file list first"
 msgstr "Сначала необходимо выбрать элемент в списке файлов"
 
-#: ../../vdms_main/main_frame.py:1682
 msgid ""
 "An item with the same destination file already exists.\n"
 "\n"
@@ -2333,86 +1729,65 @@ msgstr ""
 "\n"
 "Хотите заменить его, добавив новый элемент в очередь?"
 
-#: ../../vdms_main/main_frame.py:1703
 msgid "Videomass - FFmpeg Message Monitoring"
 msgstr "Videomass - Мониторинг сообщений FFmpeg"
 
 # русское сокращение последнего слова
-#: ../../vdms_main/main_frame.py:1828
 #, python-brace-format
 msgid "The system will turn off in {0} seconds"
 msgstr "Система выключится через {0} сек."
 
-#: ../../vdms_main/main_frame.py:1829
 msgid "Videomass - Shutdown!"
 msgstr "Videomass - Выключение!"
 
-#: ../../vdms_main/main_frame.py:1836
 msgid "Error while shutting down. Please see file log for details."
 msgstr "Ошибка при выключении. Подробности смотрите в журнале файлов."
 
 # русское сокращение последнего слова
-#: ../../vdms_main/main_frame.py:1848
 #, python-brace-format
 msgid "Exiting the application in {0} seconds"
 msgstr "Выход из приложения через {0} сек."
 
-#: ../../vdms_main/main_frame.py:1849
 msgid "Videomass - Exiting!"
 msgstr "Videomass - Выход!"
 
-#: ../../vdms_miniframes/timeline.py:46
 msgid "Start point adjustment"
 msgstr "Регулировка точки \"Начало\""
 
-#: ../../vdms_miniframes/timeline.py:48
 msgid "End point adjustment"
 msgstr "Регулировка точки \"Конец\""
 
-#: ../../vdms_miniframes/timeline.py:105
 msgid "Hours"
 msgstr "Часы"
 
-#: ../../vdms_miniframes/timeline.py:106
 msgid "Minutes"
 msgstr "Минуты"
 
-#: ../../vdms_miniframes/timeline.py:107
 msgid "Seconds"
 msgstr "Секунды"
 
-#: ../../vdms_miniframes/timeline.py:108
 msgid "Milliseconds"
 msgstr "Миллисекунды"
 
-#: ../../vdms_miniframes/timeline.py:189 ../../vdms_miniframes/timeline.py:312
 msgid "No source duration:"
 msgstr "Нет длительности источника:"
 
-#: ../../vdms_miniframes/timeline.py:208 ../../vdms_miniframes/timeline.py:298
-#: ../../vdms_miniframes/timeline.py:333 ../../vdms_miniframes/timeline.py:338
-#: ../../vdms_miniframes/timeline.py:441
 #, python-brace-format
 msgid "{0} {1}  |  Segment Duration: {2}"
 msgstr "{0} {1}  |  Продолжительность сегмента: {2}"
 
-#: ../../vdms_miniframes/timeline.py:260 ../../vdms_miniframes/timeline.py:277
 msgid "End adjustment"
 msgstr "Регулировка \"Конец\""
 
-#: ../../vdms_miniframes/timeline.py:261 ../../vdms_miniframes/timeline.py:279
 msgid "Start adjustment"
 msgstr "Регулировка \"Начало\""
 
-#: ../../vdms_miniframes/timeline.py:320
 msgid "Source duration:"
 msgstr "Длительность источника:"
 
-#: ../../vdms_miniframes/timeline.py:387
 msgid "WARNING: Invalid selection, out of range."
 msgstr "WARNING: Неверный выбор, вне допустимого диапазона."
 
-#: ../../vdms_miniframes/timeline.py:461
 msgid ""
 "Start by dragging the bottom left handle,\n"
 "or right-click for options."
@@ -2420,15 +1795,12 @@ msgstr ""
 "Начните с перетаскивания нижнего левого маркера \n"
 "или щелкните правой кнопкой мыши для выбора параметров."
 
-#: ../../vdms_miniframes/timeline.py:497
 msgid "Start"
 msgstr "Начало"
 
-#: ../../vdms_miniframes/timeline.py:498
 msgid "End"
 msgstr "Конец"
 
-#: ../../vdms_miniframes/timeline.py:548
 msgid ""
 "The timeline editor is a tool that allows you to trim slices of time on selected imported media (see File List panel).\n"
 "\n"
@@ -2450,39 +1822,30 @@ msgstr ""
 "\n"
 "Значения длительности «Начало» и «Конец» всегда относятся к начальному положению timeline: 00:00:00.000. Дополнительную информацию, такую ​​как продолжительность сегмента и предупреждения, можно найти в сообщениях строки состояния."
 
-#: ../../vdms_miniframes/timeline.py:565
 msgid "Timeline Editor Usage"
 msgstr "Использование редактора Timeline"
 
-#: ../../vdms_panels/av_conversions.py:153
 msgid "Media:"
 msgstr "Медиа:"
 
-#: ../../vdms_panels/av_conversions.py:169
 msgid "Container:"
 msgstr "Контейнер:"
 
-#: ../../vdms_panels/av_conversions.py:180
 msgid "Save profile"
 msgstr "Сохранить профиль"
 
-#: ../../vdms_panels/av_conversions.py:183
 msgid "Target"
 msgstr "Target"
 
-#: ../../vdms_panels/av_conversions.py:316
 msgid "Miscellaneous"
 msgstr "Разное"
 
-#: ../../vdms_panels/av_conversions.py:323
 msgid "Save as a new profile of the Presets Manager."
 msgstr "Сохранить как новый профиль в Менеджере Пресетов."
 
-#: ../../vdms_panels/av_conversions.py:325
 msgid "Available video encoders. \"Copy\" means that the video stream will not be re-encoded and will allow you (depending on the encoder) to change the container, audio codec and a few other parameters."
 msgstr "Доступные видеокодеры. «Copy» означает, что видеопоток не будет перекодироваться и позволит вам (в зависимости от кодировщика) изменить контейнер, аудиокодек и некоторые другие параметры."
 
-#: ../../vdms_panels/av_conversions.py:330
 msgid ""
 "Container format. It is usually represented by the file extension (output format).\n"
 "\n"
@@ -2496,7 +1859,6 @@ msgstr ""
 "\n"
 "Если для цели мультимедиа установлено значение «Аудио», вы можете извлекать из видео только аудиопотоки или просто конвертировать исходные аудиофайлы."
 
-#: ../../vdms_panels/av_conversions.py:338
 msgid ""
 "Set output files target: \"Video\" to save output files as video files; \"Audio\" to save files using an audio encoder and format.\n"
 "\n"
@@ -2508,45 +1870,33 @@ msgstr ""
 
 # изменено 21-2-2021
 # оставлено 19-3-2021
-#: ../../vdms_panels/av_conversions.py:346
 msgid "Preview video filters"
 msgstr "Предварительный просмотр с учётом фильтров FFplay"
 
-#: ../../vdms_panels/av_conversions.py:347
 msgid "Disable active filters"
 msgstr "Отключить активные фильтры"
 
-#: ../../vdms_panels/av_conversions.py:348
-#: ../../vdms_panels/sequence_to_video.py:156
-#: ../../vdms_panels/video_to_sequence.py:113
 msgid "Resize"
 msgstr "Изменить размер"
 
-#: ../../vdms_panels/av_conversions.py:349
 msgid "Crop"
 msgstr "Обрезать"
 
-#: ../../vdms_panels/av_conversions.py:350
 msgid "Transpose"
 msgstr "Поворот"
 
-#: ../../vdms_panels/av_conversions.py:352
 msgid "Denoise"
 msgstr "Шумоподавление"
 
-#: ../../vdms_panels/av_conversions.py:353
 msgid "Stabilize"
 msgstr "Stabilize"
 
-#: ../../vdms_panels/av_conversions.py:354
 msgid "Equalize"
 msgstr "Цветокоррекция"
 
-#: ../../vdms_panels/av_conversions.py:517
 msgid "Unable to preview Video Stabilizer filter"
 msgstr "Невозможно просмотреть Stabilizer видеофильтр"
 
-#: ../../vdms_panels/av_conversions.py:602
 msgid ""
 "Unsupported file:\n"
 "Missing decoder or library? Check FFmpeg configuration."
@@ -2554,22 +1904,15 @@ msgstr ""
 "Неподдерживаемый файл:\n"
 "Отсутствует декодер или библиотека? Проверьте конфигурацию FFmpeg."
 
-#: ../../vdms_panels/av_conversions.py:611
-#: ../../vdms_panels/sequence_to_video.py:351
-#: ../../vdms_panels/video_to_sequence.py:398
 msgid "The file is not a frame or a video file"
 msgstr "Файл не является кадром или видеофайлом"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:434
-#: ../../vdms_panels/av_conversions.py:861
 msgid "Undetected volume values! Click the \"Volume detect\" button to analyze audio volume data."
 msgstr "Не обнаружены значения громкости! Нажмите кнопку «Обнаружение громкости», чтобы проанализировать данные о громкости звука."
 
-#: ../../vdms_panels/av_conversions.py:1186
 msgid "Off"
 msgstr "Выключено"
 
-#: ../../vdms_panels/av_conversions.py:1203
 msgid ""
 "Batch processing items\n"
 "Destination\n"
@@ -2595,109 +1938,81 @@ msgstr ""
 "Начало сегмента\n"
 "Продолжительность клипа"
 
-#: ../../vdms_panels/av_conversions.py:1246
-#: ../../vdms_panels/presets_manager.py:814
 #, python-brace-format
 msgid "Write profile on «{0}»"
 msgstr "Написать профиль в «{0}»"
 
-#: ../../vdms_panels/av_conversions.py:1266
-#: ../../vdms_panels/presets_manager.py:513
 msgid "Enter name for new preset"
 msgstr "Введите имя для нового пресета"
 
-#: ../../vdms_panels/av_conversions.py:1276
-#: ../../vdms_panels/presets_manager.py:524
 msgid "Invalid file name, make sure to provide a valid name including the «.json» extension"
 msgstr "Недопустимое имя файла. Обязательно укажите допустимое имя, включая расширение «.json»"
 
-#: ../../vdms_panels/av_conversions.py:1284
 #, python-brace-format
 msgid "Cannot save current data in file «{}»."
 msgstr "Невозможно сохранить текущие данные в файл «{}»."
 
-#: ../../vdms_panels/av_conversions.py:1289
 msgid "Open Videomass preset"
 msgstr "Открыть пресет Videomass"
 
-#: ../../vdms_panels/av_conversions.py:1307
 msgid "Videomass - Save new profile"
 msgstr "Videomass - Сохранить новый профиль"
 
-#: ../../vdms_panels/av_conversions.py:1308
 msgid "Where do you want to save this profile?"
 msgstr "Где вы хотите сохранить этот профиль?"
 
-#: ../../vdms_panels/av_conversions.py:1309
 msgid "Save the profile to a new preset"
 msgstr "Сохраните профиль в новом пресете"
 
-#: ../../vdms_panels/av_conversions.py:1310
 msgid "Save the profile to an existing preset"
 msgstr "Сохраните профиль в существующем пресете"
 
-#: ../../vdms_panels/choose_topic.py:69
 msgid "Welcome to Videomass"
 msgstr "Добро пожаловать в Videomass"
 
-#: ../../vdms_panels/choose_topic.py:71
 #, python-brace-format
 msgid "Version {}"
 msgstr "Версия {}"
 
-#: ../../vdms_panels/choose_topic.py:82
 msgid "Presets Manager"
 msgstr "Менеджер Пресетов"
 
-#: ../../vdms_panels/choose_topic.py:85
 msgid "AV-Conversions"
 msgstr "AV-конвертация"
 
-#: ../../vdms_panels/choose_topic.py:88
 msgid "Concatenate media files"
 msgstr "Объединить медиафайлы"
 
-#: ../../vdms_panels/choose_topic.py:91
 msgid "Still Image Maker"
 msgstr "Still Image Maker"
 
-#: ../../vdms_panels/choose_topic.py:94
 msgid "From Movie to Pictures"
 msgstr "Картинки из фильма"
 
-#: ../../vdms_panels/choose_topic.py:123
 msgid "Create, edit and use quickly your favorite FFmpeg presets and profiles with full formats support and codecs."
 msgstr "Cоздавайте, редактируйте или используйте свои любимые пресеты и профили прямо сейчас с полной поддержкой форматов и кодеков FFmpeg."
 
-#: ../../vdms_panels/choose_topic.py:127
 msgid "A set of useful tools for audio and video conversions. Save your profiles and reuse them with Presets Manager."
 msgstr "Набор полезных инструментов для преобразования аудио и видео. Сохраните свои профили и повторно используйте их с помощью Менеджера Пресетов."
 
-#: ../../vdms_panels/choose_topic.py:131
 msgid "Concatenate multiple media files based on import order without re-encoding"
 msgstr "Объединение нескольких медиафайлов в соответствии с порядком импорта без перекодирования"
 
-#: ../../vdms_panels/choose_topic.py:134
 msgid "Create video from a sequence of images, based on import order, with the ability to add an audio file."
 msgstr "Создавайте видео из последовательности изображений, основываясь на порядке импорта, с возможностью добавления аудиофайла."
 
-#: ../../vdms_panels/choose_topic.py:137
 msgid "Extract images (frames) from your movies in JPG, PNG, BMP, GIF formats."
 msgstr "Извлекайте изображения (кадры) из ваших фильмов в форматы JPG, PNG, BMP, GIF."
 
-#: ../../vdms_panels/concatenate.py:47
 msgid "At least two files are required to perform concatenation."
 msgstr "Для объединения требуются как минимум два файла."
 
-#: ../../vdms_panels/concatenate.py:63
 msgid "Invalid data found"
 msgstr "Обнаружены неверные данные"
 
-#: ../../vdms_panels/concatenate.py:68
 msgid "The files do not have the same \"codec_types\", same \"sample_rate\" or same \"width\" or \"height\". Unable to proceed."
 msgstr "Файлы не имеют одинаковых «codec_types», «sample_rate» или одинаковых «ширины» или «высоты». Невозможно продолжить."
 
-#: ../../vdms_panels/concatenate.py:84
 msgid ""
 "\n"
 "- The concatenation function is performed only with Audio files or only with Video files.\n"
@@ -2728,17 +2043,12 @@ msgstr ""
 "- Аудиофайлы должны иметь одинаковые форматы, одинаковые кодеки \n"
 "  с одинаковой частотой дискретизации."
 
-#: ../../vdms_panels/concatenate.py:125
 msgid "Videomass Documentation:"
 msgstr "Документация Videomass:"
 
-#: ../../vdms_panels/concatenate.py:136
-#: ../../vdms_panels/sequence_to_video.py:212
-#: ../../vdms_panels/video_to_sequence.py:181
 msgid "Official FFmpeg documentation:"
 msgstr "Официальная документация FFmpeg:"
 
-#: ../../vdms_panels/concatenate.py:253
 msgid ""
 "Items to concatenate\n"
 "File destination\n"
@@ -2752,254 +2062,192 @@ msgstr ""
 "Тип вывода мультимедиа\n"
 "Продолжительность"
 
-#: ../../vdms_panels/filedrop.py:45
 msgid "File has illegal characters like:"
 msgstr "Файл содержит недопустимые символы, такие как:"
 
-#: ../../vdms_panels/filedrop.py:46
 msgid "Invalid character found in path name: (\")"
 msgstr "В имени пути обнаружен недопустимый символ: (\")"
 
-#: ../../vdms_panels/filedrop.py:47
 msgid "Directories are not allowed, just add files, please."
 msgstr "Каталоги не разрешены, добавьте просто файлы."
 
-#: ../../vdms_panels/filedrop.py:48
 msgid "File without format extension: please give an appropriate extension to the file name, example '.mkv', '.avi', '.mp3', etc."
 msgstr "Файл без расширения формата: укажите соответствующее расширение имени файла, например «.mkv», «.avi», «.mp3» и т.д."
 
-#: ../../vdms_panels/filedrop.py:84
 #, python-brace-format
 msgid "Name has illegal characters like: {0}"
 msgstr "Имя содержит недопустимые символы, такие как: {0}"
 
-#: ../../vdms_panels/filedrop.py:85
 msgid "Name already in use:"
 msgstr "Имя уже используется:"
 
-#: ../../vdms_panels/filedrop.py:185
 msgid "Duplicate file, it has already been added to the list."
 msgstr "Дублирующий файл, он уже добавлен в список."
 
-#: ../../vdms_panels/filedrop.py:197
 msgid "Rejected files"
 msgstr "Отклоненные файлы"
 
 # Изменил 14-5-2021
-#: ../../vdms_panels/filedrop.py:269
 msgid "Source file"
 msgstr "Исходный файл"
 
-#: ../../vdms_panels/filedrop.py:270
 msgid "Duration"
 msgstr "Длина"
 
-#: ../../vdms_panels/filedrop.py:271
 msgid "Media type"
 msgstr "Тип медиа"
 
-#: ../../vdms_panels/filedrop.py:272
 msgid "Size"
 msgstr "Размер"
 
-#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:405
 msgid "Drag one or more files below"
 msgstr "Перетащите один или несколько файлов ниже"
 
-#: ../../vdms_panels/filedrop.py:282
 msgid "Save to:"
 msgstr "Сохранить в:"
 
-#: ../../vdms_panels/filedrop.py:306
 msgid "Set a new destination folder for encodings"
 msgstr "Установите новую папку назначения для кодировок"
 
-#: ../../vdms_panels/filedrop.py:308
 msgid "Encodings destination folder"
 msgstr "Папка назначения кодировок"
 
-#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:394
 msgid "Play file"
 msgstr "Воспроизвести файл"
 
-#: ../../vdms_panels/filedrop.py:408
 msgid "Drag two or more Audio/Video files below"
 msgstr "Перетащите два (или более) аудио/видео файла в поле ниже"
 
-#: ../../vdms_panels/filedrop.py:412
 msgid "Drag one or more Image files below"
 msgstr "Перетащите один или несколько файлов изображений ниже"
 
-#: ../../vdms_panels/filedrop.py:415
 msgid "Drag one or more Video files below"
 msgstr "Перетащите один или несколько видеофайлов ниже"
 
-#: ../../vdms_panels/filedrop.py:623
 msgid "Rename the file destination"
 msgstr "Переименуйте место назначения файла"
 
-#: ../../vdms_panels/filedrop.py:624
 msgid "Rename the selected file to:"
 msgstr "Переименуйте выбранный файл в:"
 
-#: ../../vdms_panels/filedrop.py:638 ../../vdms_panels/filedrop.py:648
-#: ../../vdms_panels/filedrop.py:679
 msgid "Add Files"
 msgstr "Добавить файлы"
 
-#: ../../vdms_panels/filedrop.py:655
 msgid "Rename in batch"
 msgstr "Переименование в пакетном режиме"
 
 # Здесь изменил фразу исходника для правильного использования в русском языке
-#: ../../vdms_panels/filedrop.py:656
 #, python-brace-format
 msgid "Rename the {0} items to:"
 msgstr "Файлов для переименования: {0}"
 
-#: ../../vdms_panels/filedrop.py:658
 msgid "New Name #"
 msgstr "Новое имя #"
 
-#: ../../vdms_panels/long_processing_task.py:114
 msgid "Sorry, all task failed !"
 msgstr "Извините, задача не выполнена !"
 
-#: ../../vdms_panels/long_processing_task.py:115
 msgid "The process was stopped due to a fatal error."
 msgstr "Процесс был остановлен из-за фатальной ошибки."
 
-#: ../../vdms_panels/long_processing_task.py:116
 msgid "Interrupted Process !"
 msgstr "Процесс прерван !"
 
-#: ../../vdms_panels/long_processing_task.py:117
 msgid "Successfully completed !"
 msgstr "Успешно завершено !"
 
-#: ../../vdms_panels/long_processing_task.py:118
 msgid "Not everything was successful."
 msgstr "Завершено, но не все прошло хорошо."
 
-#: ../../vdms_panels/long_processing_task.py:148
 msgid "Encoding Status"
 msgstr "Статус кодирования"
 
-#: ../../vdms_panels/long_processing_task.py:152
 msgid "Current Log"
 msgstr "Current Log"
 
-#: ../../vdms_panels/long_processing_task.py:354
 msgid "Fatal Error !"
 msgstr "Фатальная ошибка !"
 
-#: ../../vdms_panels/long_processing_task.py:363
 msgid "Get your files at the destination you specified"
 msgstr "Получите ваши файлы по указанному вами адресу"
 
-#: ../../vdms_panels/long_processing_task.py:377
 msgid "For more details please read the Current Log."
 msgstr ""
 "Для получения более подробной информации, \n"
 "пожалуйста, прочтите текущий журнал."
 
-#: ../../vdms_panels/long_processing_task.py:380
 msgid "...Finished"
 msgstr "...Завершено"
 
-#: ../../vdms_panels/long_processing_task.py:399
 msgid "Please wait... interruption in progress"
 msgstr "Пожалуйста, подождите... происходит прерывание"
 
-#: ../../vdms_panels/long_processing_task.py:402
 msgid "...Interrupted"
 msgstr "...Прервано"
 
-#: ../../vdms_panels/presets_manager.py:166
 msgid "Presets"
 msgstr "Пресеты"
 
-#: ../../vdms_panels/presets_manager.py:180
 msgid "Write"
 msgstr "Записать"
 
-#: ../../vdms_panels/presets_manager.py:184
 msgid "Delete"
 msgstr "Удалить"
 
-#: ../../vdms_panels/presets_manager.py:194
 msgid "Duplicate"
 msgstr "Дублировать"
 
-#: ../../vdms_panels/presets_manager.py:199
 msgid "Profiles"
 msgstr "Профили"
 
-#: ../../vdms_panels/presets_manager.py:206
 msgid "One-Pass Encoding"
 msgstr "Однопроходное кодирование"
 
-#: ../../vdms_panels/presets_manager.py:218
 msgid "Two-Pass Encoding"
 msgstr "Двухпроходное кодирование"
 
-#: ../../vdms_panels/presets_manager.py:232
 msgid "Choose a preset and view its profiles"
 msgstr "Выберите пресет и просмотрите его профили"
 
-#: ../../vdms_panels/presets_manager.py:233
 msgid "Write a new profile and save it in the selected preset"
 msgstr "Напишите новый профиль и сохраните его в выбранном пресете"
 
-#: ../../vdms_panels/presets_manager.py:235
 msgid "Delete the selected profile"
 msgstr "Удалить выбранный профиль"
 
-#: ../../vdms_panels/presets_manager.py:236
 msgid "Edit the selected profile"
 msgstr "Редактировать выбранный профиль"
 
-#: ../../vdms_panels/presets_manager.py:237
 msgid "Duplicate the selected profile"
 msgstr "Дублировать выбранный профиль"
 
-#: ../../vdms_panels/presets_manager.py:238
 msgid "Create new preset"
 msgstr "Создать новый пресет"
 
-#: ../../vdms_panels/presets_manager.py:240
 msgid "Remove selected preset"
 msgstr "Удалить выбранный пресет"
 
-#: ../../vdms_panels/presets_manager.py:242
 msgid "Backup selected preset"
 msgstr "Резервное копирование выбранного пресета"
 
-#: ../../vdms_panels/presets_manager.py:244
 msgid "Backup the presets folder"
 msgstr "Сделайте резервную копию папки пресетов"
 
-#: ../../vdms_panels/presets_manager.py:246
 msgid "Restore a preset"
 msgstr "Восстановить пресет"
 
-#: ../../vdms_panels/presets_manager.py:248
 msgid "Restore a presets folder"
 msgstr "Восстановить папку пресетов"
 
-#: ../../vdms_panels/presets_manager.py:250
 msgid "Resets the selected preset to default values"
 msgstr "Сбрасывает выбранный пресет к значениям по умолчанию"
 
-#: ../../vdms_panels/presets_manager.py:252
 msgid "Reset all presets to default values"
 msgstr "Сброс всех пресетов к значениям по умолчанию"
 
-#: ../../vdms_panels/presets_manager.py:254
 msgid "Refresh the presets list"
 msgstr "Обновить список пресетов"
 
-#: ../../vdms_panels/presets_manager.py:338
 #, python-brace-format
 msgid ""
 "Outdated presets version found: v{1}\n"
@@ -3023,28 +2271,22 @@ msgstr ""
 "\n"
 "Вы хотите выполнить это обновление сейчас?"
 
-#: ../../vdms_panels/presets_manager.py:403
 msgid "Name"
 msgstr "Имя"
 
-#: ../../vdms_panels/presets_manager.py:405
 msgid "Output Format"
 msgstr "Выходной формат"
 
-#: ../../vdms_panels/presets_manager.py:406
 msgid "Supported Format List"
 msgstr "Список поддерживаемых форматов"
 
-#: ../../vdms_panels/presets_manager.py:531
 #, python-brace-format
 msgid "Cannot save current data in file '{}'."
 msgstr "Невозможно сохранить текущие данные в файл '{}'."
 
-#: ../../vdms_panels/presets_manager.py:535
 msgid "You just successfully created a new preset!"
 msgstr "Вы только что успешно создали новый пресет!"
 
-#: ../../vdms_panels/presets_manager.py:547
 #, python-brace-format
 msgid ""
 "Are you sure you want to remove \"{}\" preset?\n"
@@ -3055,7 +2297,6 @@ msgstr ""
 "\n"
 "Он будет перемещен в подпапку «Удалённые» внутри папки пресетов."
 
-#: ../../vdms_panels/presets_manager.py:558
 #, python-brace-format
 msgid ""
 "{}\n"
@@ -3066,30 +2307,22 @@ msgstr ""
 "\n"
 "Извините, удаление не получилось, продолжение невозможно."
 
-#: ../../vdms_panels/presets_manager.py:568
 #, python-brace-format
 msgid "The preset \"{0}\" was successfully removed"
 msgstr "Пресет \"{0}\" был успешно удален"
 
-#: ../../vdms_panels/presets_manager.py:583
-#: ../../vdms_panels/presets_manager.py:612
 msgid "Open a destination folder"
 msgstr "Открыть папку назначения"
 
-#: ../../vdms_panels/presets_manager.py:588
 msgid "A file with this name already exists, do you want to overwrite it?"
 msgstr "Файл с таким именем уже существует. Вы хотите его перезаписать?"
 
-#: ../../vdms_panels/presets_manager.py:602
-#: ../../vdms_panels/presets_manager.py:622
 msgid "Backup completed successfully"
 msgstr "Резервное копирование успешно завершено"
 
-#: ../../vdms_panels/presets_manager.py:631
 msgid "Open the preset you want to restore"
 msgstr "Откройте пресет, который хотите восстановить"
 
-#: ../../vdms_panels/presets_manager.py:645
 msgid ""
 "This preset already exists and is about to be updated. Don't worry, it will keep all your saved profiles.\n"
 "\n"
@@ -3099,11 +2332,9 @@ msgstr ""
 "\n"
 "Вы хотите продолжить?"
 
-#: ../../vdms_panels/presets_manager.py:663
 msgid "Restore successful"
 msgstr "Восстановление успешно завершено"
 
-#: ../../vdms_panels/presets_manager.py:681
 msgid ""
 "This will update the presets database. Don't worry, it will keep all your saved profiles.\n"
 "\n"
@@ -3113,19 +2344,15 @@ msgstr ""
 "\n"
 "Вы хотите продолжить?"
 
-#: ../../vdms_panels/presets_manager.py:689
 msgid "Open the presets folder to restore"
 msgstr "Откройте папку пресетов для восстановления"
 
-#: ../../vdms_panels/presets_manager.py:725
 msgid "The presets database has been successfully updated"
 msgstr "База данных пресетов успешно обновлена"
 
-#: ../../vdms_panels/presets_manager.py:740
 msgid "The selected preset is not part of Videomass's default presets."
 msgstr "Выбранный пресет не является частью пресетов Videomass по умолчанию."
 
-#: ../../vdms_panels/presets_manager.py:745
 msgid ""
 "Be careful! The selected preset will be overwritten with the default one. Your profiles may be deleted!\n"
 "\n"
@@ -3135,12 +2362,9 @@ msgstr ""
 "\n"
 "Вы хотите продолжить?"
 
-#: ../../vdms_panels/presets_manager.py:760
-#: ../../vdms_panels/presets_manager.py:794
 msgid "Successful recovery"
 msgstr "Успешное восстановление"
 
-#: ../../vdms_panels/presets_manager.py:769
 msgid ""
 "Be careful! This action will restore all presets to default ones. Your profiles may be deleted!\n"
 "\n"
@@ -3156,20 +2380,16 @@ msgstr ""
 "\n"
 "Вы хотите продолжать?"
 
-#: ../../vdms_panels/presets_manager.py:833
 #, python-brace-format
 msgid "Edit profile on «{0}»"
 msgstr "Редактировать профиль в «{0}»"
 
-#: ../../vdms_panels/presets_manager.py:872
 msgid "Are you sure you want to delete the selected profile? It will no longer be possible to recover it."
 msgstr "Вы уверены, что хотите удалить выбранный профиль? Восстановить его уже не удастся."
 
-#: ../../vdms_panels/presets_manager.py:891
 msgid "First select a profile in the list"
 msgstr "Вы должны выбрать профиль в списке"
 
-#: ../../vdms_panels/presets_manager.py:899
 msgid ""
 "The selected profile command has been changed manually.\n"
 "Do you want to apply it during the conversion process?"
@@ -3177,11 +2397,9 @@ msgstr ""
 "Управление выбранным профилем изменено вручную.\n"
 "Вы хотите применить его в процессе конвертации?"
 
-#: ../../vdms_panels/presets_manager.py:909
 msgid "Don't show this dialog again"
 msgstr "Больше не показывать этот диалог"
 
-#: ../../vdms_panels/presets_manager.py:1054
 msgid ""
 "Batch processing items\n"
 "Destination\n"
@@ -3201,11 +2419,9 @@ msgstr ""
 "Начало сегмента\n"
 "Продолжительность клипа"
 
-#: ../../vdms_panels/sequence_to_video.py:54
 msgid "Images need to be resized, please use Resize function."
 msgstr "Размер изображений необходимо изменить, воспользуйтесь функцией изменения размера."
 
-#: ../../vdms_panels/sequence_to_video.py:73
 msgid ""
 "\n"
 "1. Import one or more image files such as JPG, PNG and BMP formats, then select one.\n"
@@ -3238,11 +2454,9 @@ msgstr ""
 "Созданное видео будет иметь имя выбранного файла на панели «Список файлов», которое\\n\n"
 "будут сохранены в папке с именем «Still_Images» с прогрессивной цифрой по указанному вами пути."
 
-#: ../../vdms_panels/sequence_to_video.py:129
 msgid "Enable a single still image"
 msgstr "Включить одно неподвижное изображение"
 
-#: ../../vdms_panels/sequence_to_video.py:162
 msgid ""
 "Force original aspect ratio using\n"
 "padding rather than stretching"
@@ -3250,28 +2464,21 @@ msgstr ""
 "Принудительно использовать исходное соотношение \n"
 " сторон, используя отступы, а не растяжение"
 
-#: ../../vdms_panels/sequence_to_video.py:170
 msgid "Include audio file"
 msgstr "Включить аудиофайл"
 
-#: ../../vdms_panels/sequence_to_video.py:173
 msgid "Play the video until audio track finishes"
 msgstr "Воспроизведение видео до окончания звуковой дорожки(трека)"
 
-#: ../../vdms_panels/sequence_to_video.py:180
-#: ../../vdms_panels/sequence_to_video.py:439
 msgid "Open audio file"
 msgstr "Открыть аудиофайл"
 
-#: ../../vdms_panels/sequence_to_video.py:199
 msgid "Additional arguments"
 msgstr "Дополнительные аргументы"
 
-#: ../../vdms_panels/sequence_to_video.py:454
 msgid "Open Audio File"
 msgstr "Открыть аудиофайл"
 
-#: ../../vdms_panels/sequence_to_video.py:466
 #, python-brace-format
 msgid ""
 "Invalid file: '{}'\n"
@@ -3282,7 +2489,6 @@ msgstr ""
 "\n"
 "{}"
 
-#: ../../vdms_panels/sequence_to_video.py:471
 #, python-brace-format
 msgid ""
 "Invalid file: '{}'\n"
@@ -3293,21 +2499,14 @@ msgstr ""
 "\n"
 "Похоже, это не аудиофайл."
 
-#: ../../vdms_panels/sequence_to_video.py:560
-#: ../../vdms_panels/sequence_to_video.py:587
-#: ../../vdms_panels/video_to_sequence.py:511
 #, python-brace-format
 msgid "Invalid file: '{}'"
 msgstr "Недопустимый файл: '{}'"
 
-#: ../../vdms_panels/sequence_to_video.py:570
-#: ../../vdms_panels/sequence_to_video.py:595
 #, python-brace-format
 msgid "Unsupported format '{}'"
 msgstr "Неподдерживаемый формат '{}'"
 
-#: ../../vdms_panels/sequence_to_video.py:576
-#: ../../vdms_panels/sequence_to_video.py:600
 #, python-brace-format
 msgid ""
 "File does not exist:\n"
@@ -3318,15 +2517,9 @@ msgstr ""
 "\n"
 "\"{}\"\n"
 
-#: ../../vdms_panels/sequence_to_video.py:577
 msgid "ERROR"
 msgstr "ОШИБКА"
 
-#: ../../vdms_panels/sequence_to_video.py:707
-msgid "Shortest"
-msgstr "Коротко"
-
-#: ../../vdms_panels/sequence_to_video.py:715
 msgid ""
 "Items to concatenate\n"
 "Output filename\n"
@@ -3354,7 +2547,6 @@ msgstr ""
 "Продолжительность неподвижного изображения\n"
 "Общая продолжительность видео"
 
-#: ../../vdms_panels/video_to_sequence.py:50
 msgid ""
 "\n"
 "1. Import one or more video files, then select one.\n"
@@ -3387,51 +2579,39 @@ msgstr ""
 "с именем 'Movie_to_Pictures'\n"
 "с прогрессивной цифрой по указанному вами пути."
 
-#: ../../vdms_panels/video_to_sequence.py:86
 msgid "Create thumbnails"
 msgstr "Создание эскизов"
 
-#: ../../vdms_panels/video_to_sequence.py:87
 msgid "Create tiled mosaics"
 msgstr "Создание мозаики из плиток"
 
-#: ../../vdms_panels/video_to_sequence.py:88
 msgid "Create animated GIF"
 msgstr "Создать анимированный GIF"
 
-#: ../../vdms_panels/video_to_sequence.py:90
 msgid "Options"
 msgstr "Параметры"
 
-#: ../../vdms_panels/video_to_sequence.py:119
 msgid "Output format:"
 msgstr "Выходной формат:"
 
-#: ../../vdms_panels/video_to_sequence.py:131
 msgid "Rows:"
 msgstr "Ряды:"
 
-#: ../../vdms_panels/video_to_sequence.py:141
 msgid "Columns:"
 msgstr "Столбцы:"
 
-#: ../../vdms_panels/video_to_sequence.py:205
 msgid "Other unofficial resources:"
 msgstr "Другие неофициальные ресурсы:"
 
-#: ../../vdms_panels/video_to_sequence.py:229
 msgid "Set FPS control from 0.1 to 30.0 fps. The higher this value, the more images will be extracted."
 msgstr "Установите контроль FPS от 0,1 до 30,0 кадров в секунду. Чем выше это значение, тем больше изображений будет извлечено."
 
-#: ../../vdms_panels/video_to_sequence.py:232
 msgid "Spaces around the mosaic tiles. From 0 to 32 pixels"
 msgstr "Пространства вокруг мозаичных плиток. От 0 до 32 пикселей"
 
-#: ../../vdms_panels/video_to_sequence.py:234
 msgid "Spaces around the mosaic borders. From 0 to 32 pixels"
 msgstr "Пространства вокруг границ мозаики. От 0 до 32 пикселей"
 
-#: ../../vdms_panels/video_to_sequence.py:626
 msgid ""
 "Selected File\n"
 "Output Format\n"
@@ -3459,51 +2639,39 @@ msgstr ""
 "Начало сегмента\n"
 "Продолжительность"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:118
 msgid "Audio encoder settings, mapping and filters"
 msgstr "Настройки аудиокодера, сопоставление и фильтры"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:128
 msgid "Audio Encoder"
 msgstr "Аудио кодировщик"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:137
 msgid "Settings"
 msgstr "Настройки"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:148
 msgid "Index Selection:"
 msgstr "Выбор индекса:"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:157
 msgid "Map:"
 msgstr "Map:"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:180
 msgid "Normalization"
 msgstr "Нормализация"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:191
 msgid "Volume detect"
 msgstr "Обнаружение громкости"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:195
 msgid "Volume Statistics"
 msgstr "Статистика громкости"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:199
 msgid "Target level:"
 msgstr "Целевой уровень:"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:264
 msgid "Gets maximum volume and average volume data in dBFS, then calculates the offset amount for audio normalization."
 msgstr "Получает данные о максимальной и средней громкости в dBFS, затем вычисляет величину смещения для нормализации звука."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:267
 msgid "Limiter for the maximum peak level or the mean level (when switch to RMS) in dBFS. From -99.0 to +0.0; default for PEAK level is -1.0; default for RMS is -20.0"
 msgstr "Ограничитель максимального пикового уровня или среднего уровня (при переключении на RMS) в dBFS. От -99,0 до +0,0; по умолчанию для уровня PEAK -1,0; по умолчанию для RMS -20.0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:271
 msgid ""
 "Normally on a video with correctly indexed streams and having one or more audio streams, the first audio stream should be indexed at \"1\", the second at \"2\" and so on (the video stream on the other hand is always indexed at \"0\"). In this case it is recommended to select the desired stream by setting a specific index, e.g \"1\" for for the first available audio stream.\n"
 "\n"
@@ -3513,7 +2681,6 @@ msgstr ""
 "\n"
 "Установите для этого элемента управления значение «Авто», если исходный файл представляет собой просто звуковую дорожку."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:280
 msgid ""
 "\"Auto\" keeps all audio streams and processes only the one selected by the \"Index Selection\" control.\n"
 "\n"
@@ -3528,27 +2695,21 @@ msgstr ""
 "\n"
 "«Индекс Only» обрабатывает только аудиопоток, выбранный с помощью элемента управления «Выбор индекса», и удаляет все остальные из видео"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:288
 msgid "Integrated Loudness Target in LUFS. From -70.0 to -5.0, default is -16.0"
 msgstr "Интегрированная цель громкости в LUFS. От -70,0 до -5,0, по умолчанию - -16,0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:291
 msgid "Maximum True Peak in dBTP. From -1.5 to +0.0, default is -2.0"
 msgstr "Максимальный True Peak в dBTP. От -1,5 до +0,0, по умолчанию — -2,0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:294
 msgid "Loudness Range Target in LUFS. From +1.0 to +20.0, default is +11.0"
 msgstr "Целевой диапазон громкости в LUFS. От +1,0 до +20,0, по умолчанию +11,0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:297
 msgid "Play the audio stream selected in the \"Index Selection\" control. Using this function you can test the result of audio normalization."
 msgstr "Воспроизведите аудиопоток, выбранный в элементе управления «Выбор индекса». Используя эту функцию, вы можете проверить результат нормализации звука."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:503
 msgid "Selected index does not exist or does not contain any audio streams"
 msgstr "Выбранный индекс не существует или не содержит никаких аудиопотоков"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:508
 #, python-brace-format
 msgid ""
 "ERROR: Missing audio stream:\n"
@@ -3557,15 +2718,12 @@ msgstr ""
 "ОШИБКА: Отсутствует аудиопоток:\n"
 "\"{}\""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:726
 msgid "PEAK level normalization, which will produce a maximum peak level equal to the set target level."
 msgstr "Нормализация уровня PEAK, которая обеспечивает максимальный пиковый уровень, равный установленному целевому уровню."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:729
 msgid "RMS-based normalization, which according to mean volume calculates the amount of gain to reach same average power signal."
 msgstr "Нормализация на основе среднеквадратичного значения(RMS), которая в соответствии со средним объемом вычисляет величину усиления, необходимую для достижения сигнала той же средней мощности."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:733
 msgid ""
 "Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements the EBU R128 algorithm.\n"
 "Ideal for live normalization. It produces worse results than the High-quality two-pass Loudnorm normalization, but is faster."
@@ -3573,7 +2731,6 @@ msgstr ""
 "Нормализация громкости. Нормализует воспринимаемую громкость с помощью фильтра «loudnorm», реализующего алгоритм EBU R128.\n"
 "Идеально подходит для живой нормализации. Он дает худшие результаты, чем высококачественная двухпроходная нормализация Loudnorm, но работает быстрее."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:740
 msgid ""
 "High-quality two-pass Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements\n"
 "the EBU R128 algorithm. Ideal for postprocessing."
@@ -3582,23 +2739,18 @@ msgstr ""
 "громкость с помощью фильтра «loudnorm», реализующего алгоритм EBU R128.\n"
 "Идеально подходит для постобработки."
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:789
 msgid "You need to import at least one file"
 msgstr "Вам необходимо импортировать хотя бы один файл"
 
-#: ../../vdms_panels/miscellaneous/miscell.py:63
 msgid "Subtitle Mapping:"
 msgstr "Отображение субтитров:"
 
-#: ../../vdms_panels/miscellaneous/miscell.py:77
 msgid "Copy Chapters"
 msgstr "Копировать Главы"
 
-#: ../../vdms_panels/miscellaneous/miscell.py:79
 msgid "Copy Metadata"
 msgstr "Копировать Метаданные"
 
-#: ../../vdms_panels/miscellaneous/miscell.py:85
 msgid ""
 "Select \"All\" to include any source file subtitles in the output video.\n"
 "\n"
@@ -3612,147 +2764,63 @@ msgstr ""
 "\n"
 "Эта опция автоматически игнорируется для выходных аудиофайлов."
 
-#: ../../vdms_panels/miscellaneous/miscell.py:90
 msgid "Copy the chapter markers as is from source file. This option is automatically ignored for output audio files."
 msgstr "Скопируйте маркеры глав как есть из исходного файла. Эта опция автоматически игнорируется для выходных аудиофайлов."
 
-#: ../../vdms_panels/miscellaneous/miscell.py:93
 msgid "Copy all incoming metadata from source file, such as audio/video tags, titles, unique marks, and so on."
 msgstr "Скопируйте все входящие метаданные из исходного файла, такие как теги аудио/видео, заголовки, уникальные метки и т. д."
 
-#: ../../vdms_panels/miscellaneous/miscell.py:108
 msgid "Additional options"
 msgstr "Дополнительные опции"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:89
-#: ../../vdms_panels/video_encoders/av1_svt.py:120
-#: ../../vdms_panels/video_encoders/avc_x264.py:90
-#: ../../vdms_panels/video_encoders/hevc_x265.py:98
-#: ../../vdms_panels/video_encoders/mpeg4.py:71
-#: ../../vdms_panels/video_encoders/vp9_webm.py:131
 msgid "Reload"
 msgstr "Перезагрузить"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:101
-#: ../../vdms_panels/video_encoders/av1_svt.py:129
-#: ../../vdms_panels/video_encoders/avc_x264.py:101
-#: ../../vdms_panels/video_encoders/hevc_x265.py:109
-#: ../../vdms_panels/video_encoders/mpeg4.py:82
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:97
-#: ../../vdms_panels/video_encoders/vp9_webm.py:141
 msgid "Optimize for Web"
 msgstr "Оптимизация для Web"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:247
-#: ../../vdms_panels/video_encoders/av1_svt.py:313
-#: ../../vdms_panels/video_encoders/avc_x264.py:242
-#: ../../vdms_panels/video_encoders/hevc_x265.py:250
-#: ../../vdms_panels/video_encoders/mpeg4.py:198
-#: ../../vdms_panels/video_encoders/vp9_webm.py:288
 msgid "Reloads the selected video encoder settings. Changes will be discarded."
 msgstr "Перезагружает выбранные настройки видеокодера. Изменения будут отменены."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:250
-#: ../../vdms_panels/video_encoders/avc_x264.py:273
-#: ../../vdms_panels/video_encoders/hevc_x265.py:277
-#: ../../vdms_panels/video_encoders/vp9_webm.py:291
 msgid "Constant rate factor. Lower values correspond to higher quality and greater file size. Set to -1 to disable this control."
 msgstr "Коэффициент постоянной скорости. Более низкие значения соответствуют более высокому качеству и большему размеру файла. Установите значение -1, чтобы отключить этот элемент управления."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:254
-#: ../../vdms_panels/video_encoders/av1_svt.py:357
-#: ../../vdms_panels/video_encoders/vp9_webm.py:295
 msgid "Number of tile rows to use, default changes per resolution"
 msgstr "Количество используемых строк плитки, изменения по умолчанию для каждого разрешения"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:256
-#: ../../vdms_panels/video_encoders/av1_svt.py:359
-#: ../../vdms_panels/video_encoders/vp9_webm.py:297
 msgid "Number of tile columns to use, default changes per resolution"
 msgstr "Количество используемых столбцов плиток, изменения по умолчанию для каждого разрешения"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:259
-#: ../../vdms_panels/video_encoders/av1_svt.py:368
-#: ../../vdms_panels/video_encoders/avc_x264.py:253
-#: ../../vdms_panels/video_encoders/hevc_x265.py:261
-#: ../../vdms_panels/video_encoders/mpeg4.py:201
-#: ../../vdms_panels/video_encoders/vp9_webm.py:300
 msgid "Set the Group Of Picture (GOP). Set to -1 to disable this control."
 msgstr "Установите группу изображений (GOP). Установите значение -1, чтобы отключить этот элемент управления."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:262
-#: ../../vdms_panels/video_encoders/av1_svt.py:371
-#: ../../vdms_panels/video_encoders/avc_x264.py:256
-#: ../../vdms_panels/video_encoders/hevc_x265.py:264
-#: ../../vdms_panels/video_encoders/mpeg4.py:204
-#: ../../vdms_panels/video_encoders/vp9_webm.py:303
 msgid "It can reduce the file size, but takes longer."
 msgstr "Это может уменьшить размер файла, но занимает больше времени."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:264
-#: ../../vdms_panels/video_encoders/av1_svt.py:373
-#: ../../vdms_panels/video_encoders/avc_x264.py:258
-#: ../../vdms_panels/video_encoders/hevc_x265.py:266
-#: ../../vdms_panels/video_encoders/mpeg4.py:206
-#: ../../vdms_panels/video_encoders/vp9_webm.py:305
 msgid "Set minimum bitrate tolerance. Most useful in setting up a CBR encode. It is of little use otherwise. Set to -1 to disable this control."
 msgstr "Установите минимальный допустимый битрейт. Наиболее полезен при настройке кодирования CBR. В противном случае от него мало пользы. Установите значение -1, чтобы отключить этот элемент управления."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:268
-#: ../../vdms_panels/video_encoders/av1_svt.py:377
-#: ../../vdms_panels/video_encoders/avc_x264.py:262
-#: ../../vdms_panels/video_encoders/hevc_x265.py:270
-#: ../../vdms_panels/video_encoders/mpeg4.py:210
-#: ../../vdms_panels/video_encoders/vp9_webm.py:309
 msgid "Specifies a maximum tolerance. Requires bufsize to be set. Set to -1 to disable this control."
 msgstr "Определяет максимальный допуск. Требуется установить bufsize. Установите значение -1, чтобы отключить этот элемент управления."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:271
-#: ../../vdms_panels/video_encoders/av1_svt.py:380
-#: ../../vdms_panels/video_encoders/avc_x264.py:265
-#: ../../vdms_panels/video_encoders/hevc_x265.py:273
-#: ../../vdms_panels/video_encoders/mpeg4.py:213
-#: ../../vdms_panels/video_encoders/vp9_webm.py:312
 msgid "Set ratecontrol buffer size, which determines the variability of the output bitrate. Set to -1 to disable this control."
 msgstr "Установите размер буфера управления скоростью, который определяет изменчивость выходного битрейта. Установите значение -1, чтобы отключить этот элемент управления."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:275
-#: ../../vdms_panels/video_encoders/av1_svt.py:384
-#: ../../vdms_panels/video_encoders/avc_x264.py:277
-#: ../../vdms_panels/video_encoders/hevc_x265.py:281
-#: ../../vdms_panels/video_encoders/mpeg4.py:231
-#: ../../vdms_panels/video_encoders/vp9_webm.py:316
 msgid "Specifies the target (average) bit rate for the encoder to use. Higher value = higher quality. Set -1 to disable this control."
 msgstr "Указывает целевую (среднюю) скорость передачи данных, которую будет использовать кодер. Более высокая ценность = более высокое качество. Установите -1, чтобы отключить этот элемент управления."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:279
-#: ../../vdms_panels/video_encoders/av1_svt.py:388
-#: ../../vdms_panels/video_encoders/avc_x264.py:281
-#: ../../vdms_panels/video_encoders/hevc_x265.py:285
-#: ../../vdms_panels/video_encoders/mpeg4.py:235
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:131
-#: ../../vdms_panels/video_encoders/vp9_webm.py:320
 msgid "Video width and video height ratio."
 msgstr "Соотношение ширины и высоты видео."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:281
-#: ../../vdms_panels/video_encoders/av1_svt.py:390
-#: ../../vdms_panels/video_encoders/avc_x264.py:283
-#: ../../vdms_panels/video_encoders/hevc_x265.py:287
-#: ../../vdms_panels/video_encoders/mpeg4.py:237
-#: ../../vdms_panels/video_encoders/vp9_webm.py:322
 msgid "Frame rate (frames per second). Frames repeat a given number of times per second. In some countries this is 30 for NTSC, other countries (like Italy) use 25 for PAL"
 msgstr "Частота кадров (кадров в секунду). Кадры повторяются заданное количество раз в секунду. В некоторых странах это 30 для NTSC, другие страны (например, Италия) используют 25 для PAL"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:285
 msgid "Quality/Speed ratio modifier. CPU Used sets how efficient the compression will be. Lower values mean slower encoding with better quality, and vice-versa. Valid values are from 0 to 8 inclusive."
 msgstr "Модификатор соотношения качество/скорость. Параметр «Использование ЦП» определяет, насколько эффективным будет сжатие. Более низкие значения означают более медленное кодирование с лучшим качеством и наоборот. Допустимые значения от 0 до 8 включительно."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:290
 msgid "Quality and compression efficiency vs speed trade-off. \"good\" is the default and recommended for most applications; \"realtime\" is recommended for live/fast encoding (live streaming, video conferencing, etc); \"allintra\" for All Intra encoding."
 msgstr "Качество и эффективность сжатия в сравнении со скоростью. «good» — значение по умолчанию и рекомендуется для большинства приложений; «realtime» рекомендуется для живого/быстрого кодирования (потоковое вещание, видеоконференции и т. д.); «allintra» для кодирования All Intra."
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:297
 msgid ""
 "Row Multi-Threading enables row-based multi-threading which maximizes CPU usage.\n"
 "\n"
@@ -3766,7 +2834,6 @@ msgstr ""
 "\n"
 "Включение многопоточности строк происходит быстрее только в том случае, если количество потоков процессора превышает количество закодированных плиток."
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:316
 msgid ""
 "presets 1-3 represent extremely high efficiency, for use when encode time is not important and quality/size of the resulting video file is critical.\n"
 "\n"
@@ -3784,7 +2851,6 @@ msgstr ""
 "\n"
 "Пресет 13 еще быстрее, но не предназначена для непосредственного использования человеком — ее можно использовать, например, в качестве показателя качества каждой сцены в приложениях VOD. Следует использовать наименьшую допустимую настройку."
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:327
 msgid ""
 "Constant rate factor. This parameter governs the quality/size trade-off.\n"
 "\n"
@@ -3802,7 +2868,6 @@ msgstr ""
 "\n"
 "Установите значение -1, чтобы отключить этот элемент управления."
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:334
 msgid ""
 "The \"Film Grain\" parameter allows SVT-AV1 to detect and delete film grain from the source video, and replace it with synthetic grain of the same character, resulting in significant bitrate savings.\n"
 "\n"
@@ -3824,7 +2889,6 @@ msgstr ""
 "\n"
 "Если исходное видео не имеет естественного зерна, для этого параметра можно установить значение -1, чтобы отключить его или, по крайней мере, 0."
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:346
 msgid ""
 "If enabled, the \"Film Grain Denoiser\" option can mitigate the detail removal caused by high \"Film Grain\" values required to preserve the look of very grainy films\n"
 "\n"
@@ -3834,55 +2898,36 @@ msgstr ""
 "\n"
 "По умолчанию кадры с шумоподавлением передаются для кодирования в качестве окончательных изображений. Включение этой функции приведет к использованию вместо них исходных кадров. "
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:353
 msgid "Enables encoder optimization to produce faster (less CPU intensive) bit streams to decode, similar to the fastdecode tuning in x264 and x265."
 msgstr "Включает оптимизацию кодировщика для создания более быстрых (менее ресурсоемких) битовых потоков для декодирования, аналогично настройке fastdecode в x264 и x265."
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:362
-#: ../../vdms_panels/video_encoders/avc_x264.py:247
-#: ../../vdms_panels/video_encoders/hevc_x265.py:255
 msgid "Set profile restrictions"
 msgstr "Установить ограничения профиля"
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:364
-#: ../../vdms_panels/video_encoders/avc_x264.py:249
-#: ../../vdms_panels/video_encoders/hevc_x265.py:257
 msgid "Specify level for a selected profile"
 msgstr "Укажите уровень для выбранного профиля"
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:366
-#: ../../vdms_panels/video_encoders/avc_x264.py:251
-#: ../../vdms_panels/video_encoders/hevc_x265.py:259
 msgid "Tune the encoding params"
 msgstr "Настройте параметры кодирования"
 
-#: ../../vdms_panels/video_encoders/avc_x264.py:245
-#: ../../vdms_panels/video_encoders/hevc_x265.py:253
 msgid "Set the encoding preset (default \"medium\")"
 msgstr "Установите пресет кодирования (по умолчанию \"medium\")"
 
-#: ../../vdms_panels/video_encoders/avc_x264.py:269
 msgid "specifies the target (average) bit rate for the encoder to use. Higher value = higher quality. Set -1 to disable this control."
 msgstr "определяет целевую (в среднем) скорость передачи данных для кодировщика. Высокая значение = высокое качество. Установите значение -1, чтобы отключить эту проверку."
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:217
 msgid "Variable Bit Rate. From 0-30, with 1 being highest quality/largest filesize and 30 being the lowest quality/smallest filesize. Set to -1 to disable this control."
 msgstr "Переменный битрейт. От 0 до 30, где 1 — самое высокое качество/самый большой размер файла, а 30 — самое низкое качество/наименьший размер файла. Установите значение -1, чтобы отключить этот элемент управления."
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:222
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:133
 msgid "Frames repeat a given number of times per second. In some countries this is 30 for NTSC, other countries (like Italy) use 25 for PAL"
 msgstr "Кадры повторяются заданное количество раз в секунду. В некоторых странах это 30 для NTSC, другие страны (например, Италия) используют 25 для PAL"
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:226
 msgid "The default FourCC stored in an MPEG-4-coded file will be FMP4. If you want a different FourCC, set this option to xvid to force the FourCC xvid to be stored as the video FourCC rather than the default."
 msgstr "По умолчанию FourCC, хранящийся в файле с кодировкой MPEG-4, будет FMP4. Если вам нужен другой FourCC, установите для этого параметра значение xvid, чтобы xvid FourCC сохранялся как видео FourCC, а не как видео по умолчанию."
 
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:162
 msgid "Copy Video Codec"
 msgstr "Копировать Видеокодек"
 
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:163
 msgid ""
 "This will just copy the video track as is, without any video re-encoding.\n"
 "You will only be able to change output format, select other audio encoders and\n"
@@ -3892,11 +2937,9 @@ msgstr ""
 "Вы сможете только изменить выходной формат, выбрать другие аудиокодеры \n"
 "и несколько других опций."
 
-#: ../../vdms_panels/video_encoders/video_no_enc.py:74
 msgid "Video export disabled"
 msgstr "Экспорт видео отключен"
 
-#: ../../vdms_panels/video_encoders/video_no_enc.py:75
 msgid ""
 "The Media target you just selected will only allow you to export files as audio tracks.\n"
 "You can then process audio source files only or extract indexed audio streams on\n"
@@ -3907,7 +2950,6 @@ msgstr ""
 "Затем вы можете обрабатывать только исходные аудиофайлы или извлекать \n"
 "индексированные аудиопотоки из видеофайлов."
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:326
 msgid ""
 "Speed sets how efficient the compression will be.\n"
 "\n"
@@ -3929,7 +2971,6 @@ msgstr ""
 "\n"
 "Если для параметра «Качество» установлено значение «В реальном времени», доступные значения для «Скорость» составляют от 0 до 8."
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:335
 msgid ""
 "Time to spend encoding.\n"
 "\n"
@@ -3947,24 +2988,23 @@ msgstr ""
 "\n"
 "\"realtime\" рекомендуется для живого/быстрого кодирования."
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:341
-msgid "If enabled, adds support for row based multithreading which greatly enhances the number of threads the encoder can utilise. This improves encoding speed significantly on systems that are otherwise underutilised when encoding VP9. Since the amount of additional threads depends on the number of \"tiles\", which itself depends on the video resolution, encoding higher resolution videos will see a larger performance improvement."
-msgstr "Если этот параметр включен, добавляется поддержка многопоточности на основе строк, что значительно увеличивает количество потоков, которые может использовать кодер. Это значительно повышает скорость кодирования в системах, которые в противном случае недостаточно используются при кодировании VP9. Поскольку количество дополнительных потоков зависит от количества «плиток», которое в свою очередь зависит от разрешения видео, кодирование видео с более высоким разрешением приведет к большему повышению производительности."
+msgid ""
+"If enabled, adds support for row based multithreading which greatly enhances the number of threads the encoder can utilise. This improves encoding speed significantly on systems that are otherwise underutilised when encoding VP9. Since the amount of additional threads depends on the number of \"tiles\", which itself depends on the video resolution, encoding higher resolution videos will see a "
+"larger performance improvement."
+msgstr ""
+"Если этот параметр включен, добавляется поддержка многопоточности на основе строк, что значительно увеличивает количество потоков, которые может использовать кодер. Это значительно повышает скорость кодирования в системах, которые в противном случае недостаточно используются при кодировании VP9. Поскольку количество дополнительных потоков зависит от количества «плиток», которое в свою очередь "
+"зависит от разрешения видео, кодирование видео с более высоким разрешением приведет к большему повышению производительности."
 
-#: ../../vdms_utils/presets_manager_utils.py:46
 #, python-brace-format
 msgid "Supports ({0}) formats only, not ({1})"
 msgstr "Поддерживаются только форматы ({0}), но не ({1})"
 
-#: ../../vdms_utils/presets_manager_utils.py:49
 msgid "File formats not supported by the selected profile"
 msgstr "Форматы файлов, не поддерживаемые выбранным профилем"
 
-#: ../../vdms_utils/presets_manager_utils.py:52
 msgid "Warning"
 msgstr "Предупреждение"
 
-#: ../../vdms_utils/presets_manager_utils.py:90
 msgid ""
 "No presets found.\n"
 "\n"
@@ -3974,11 +3014,9 @@ msgstr ""
 "\n"
 "Возможное решение: откройте панель Менеджер Пресетов, перейдите в столбец пресеты и попробуйте нажать кнопку «Восстановить всё ...»"
 
-#: ../../vdms_utils/queue_utils.py:54
 msgid "Import queue file"
 msgstr "Импортировать файл очереди(.json)"
 
-#: ../../vdms_utils/queue_utils.py:89
 #, python-brace-format
 msgid ""
 "ERROR: invalid data found loading queue file.\n"
@@ -3991,11 +3029,9 @@ msgstr ""
 "\n"
 "Значение ключа 'назначения' не может содержать несколько вхождений."
 
-#: ../../vdms_utils/queue_utils.py:118
 msgid "Videomass - Add Items to Queue"
 msgstr "Videomass - Добавить элементы в очередь"
 
-#: ../../vdms_utils/queue_utils.py:119
 msgid ""
 "Multiple items with identical names and destination paths cannot coexist.\n"
 "Please choose one of the following actions:"
@@ -4003,15 +3039,12 @@ msgstr ""
 "Несколько элементов с одинаковыми именами и путями назначения не могут сосуществовать.\n"
 "Пожалуйста, выберите одно из следующих действий:"
 
-#: ../../vdms_utils/queue_utils.py:123
 msgid "Replace occurrences with items from the imported queue."
 msgstr "Замените вхождения элементами из импортированной очереди."
 
-#: ../../vdms_utils/queue_utils.py:124
 msgid "Add only the currently missing items to the queue."
 msgstr "Добавлять в очередь только недостающие элементы."
 
-#: ../../vdms_utils/queue_utils.py:125
 msgid "Remove the current queue and replace it with the imported one."
 msgstr "Удалите текущую очередь и замените ее импортированной."
 
@@ -4023,3 +3056,7 @@ msgstr "Удалите текущую очередь и замените ее и
 
 #~ msgid "Subtitle Mapping"
 #~ msgstr "Сопоставление субтитров"
+
+#~ msgid "Shortest"
+#~ msgstr "Коротко"
+

--- a/videomass/data/locale/ru_RU/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/ru_RU/LC_MESSAGES/videomass.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Videomass 6.1.13\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-30 11:02+0200\n"
+"POT-Creation-Date: 2025-07-30 15:28+0200\n"
 "PO-Revision-Date: 2025-07-27 12:27+0300\n"
 "Last-Translator: ChourS <ChourS2008@yandex.ru>\n"
 "Language: ru_RU\n"
@@ -3047,16 +3047,4 @@ msgstr "Добавлять в очередь только недостающие
 
 msgid "Remove the current queue and replace it with the imported one."
 msgstr "Удалите текущую очередь и замените ее импортированной."
-
-#~ msgid "Some text boxes are still incomplete"
-#~ msgstr "Некоторые текстовые поля все еще не заполнены"
-
-#~ msgid "FFplay"
-#~ msgstr "FFplay"
-
-#~ msgid "Subtitle Mapping"
-#~ msgstr "Сопоставление субтитров"
-
-#~ msgid "Shortest"
-#~ msgstr "Коротко"
 

--- a/videomass/data/locale/videomass.pot
+++ b/videomass/data/locale/videomass.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Videomass VERSION\n"
+"Project-Id-Version: Videomass 6.1.13\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-30 11:02+0200\n"
+"POT-Creation-Date: 2025-07-30 15:28+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/videomass/data/locale/videomass.pot
+++ b/videomass/data/locale/videomass.pot
@@ -1,15 +1,14 @@
-# Translations template for Videomassing.
+# Translations template for Videomass.
 # Copyright (C) 2025 ORGANIZATION
-# This file is distributed under the same license as the Videomassing
-# project.
+# This file is distributed under the same license as the Videomass project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Videomassing 6.1.13\n"
+"Project-Id-Version: Videomass VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-29 17:47+0200\n"
+"POT-Creation-Date: 2025-07-30 11:02+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +17,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
-#: ../../gui_app.py:196
 #, python-brace-format
 msgid ""
 "Unexpected error while deleting file contents:\n"
@@ -26,304 +24,203 @@ msgid ""
 "{0}"
 msgstr ""
 
-#: ../../vdms_dialogs/about_dialog.py:52
 msgid "Cross-platform graphical user interface for FFmpeg\n"
 msgstr ""
 
-#: ../../vdms_dialogs/audioproperties.py:224
-msgid ""
-"Videomass supports mono and stereo audio channels. If you are not sure "
-"set to \"Auto\" and source values will be copied."
+msgid "Videomass supports mono and stereo audio channels. If you are not sure set to \"Auto\" and source values will be copied."
 msgstr ""
 
-#: ../../vdms_dialogs/audioproperties.py:228
-msgid ""
-"The audio Rate (or sample-rate) is the sound sampling frequency and is "
-"measured in Hertz. The higher the frequency, the more true it will be to "
-"the sound source and the more the file will increase in size. For audio "
-"CD playback, set a sampling frequency of 44100 kHz. If you are not sure, "
-"set to \"Auto\" and source values will be copied."
+msgid "The audio Rate (or sample-rate) is the sound sampling frequency and is measured in Hertz. The higher the frequency, the more true it will be to the sound source and the more the file will increase in size. For audio CD playback, set a sampling frequency of 44100 kHz. If you are not sure, set to \"Auto\" and source values will be copied."
 msgstr ""
 
-#: ../../vdms_dialogs/audioproperties.py:237
-msgid ""
-"The audio bitrate affects the file compression and thus the quality of "
-"listening. The higher the value, the higher the quality."
+msgid "The audio bitrate affects the file compression and thus the quality of listening. The higher the value, the higher the quality."
 msgstr ""
 
-#: ../../vdms_dialogs/audioproperties.py:241
-msgid ""
-"Bit depth is the number of bits of information in each sample, and it "
-"directly corresponds to the resolution of each sample. Bit depth is only "
-"meaningful in reference to a PCM digital signal. Non-PCM formats, such as"
-" lossy compression formats, do not have associated bit depths."
+msgid "Bit depth is the number of bits of information in each sample, and it directly corresponds to the resolution of each sample. Bit depth is only meaningful in reference to a PCM digital signal. Non-PCM formats, such as lossy compression formats, do not have associated bit depths."
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:74 ../../vdms_dialogs/queuedlg.py:120
 msgid "When finished, once the operations have been completed successfully:"
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:80 ../../vdms_dialogs/queuedlg.py:126
 msgid "Trash the source files"
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:84 ../../vdms_dialogs/queuedlg.py:130
 msgid "Clear the File List"
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:91 ../../vdms_dialogs/queuedlg.py:142
-#: ../../vdms_main/main_frame.py:1322
 msgid "Run"
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:97
 msgid "Videomass - Batch Mode"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:47
 msgid "FFmpeg encoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:48
 msgid "supported encoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:50
 msgid "FFmpeg decoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:51
 msgid "supported decoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:77
-#: ../../vdms_panels/av_conversions.py:293
 msgid "Video"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:87
-#: ../../vdms_panels/av_conversions.py:305
 msgid "Audio"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:97
 msgid "Subtitle"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:114
-#: ../../vdms_dialogs/ffmpeg_codecs.py:123
-#: ../../vdms_dialogs/ffmpeg_codecs.py:132
-#: ../../vdms_dialogs/ffmpeg_formats.py:112
-#: ../../vdms_dialogs/ffmpeg_formats.py:115
-#: ../../vdms_dialogs/ffmpeg_formats.py:118
 msgid "description"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:72
 msgid "Informations"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:83
 msgid "Flags settings"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:93
 msgid "Flags enabled"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:103
 msgid "Flags disabled"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:116
 msgid "FFmpeg configuration"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:124
 msgid "flags"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:125 ../../vdms_dialogs/ffmpeg_conf.py:129
-#: ../../vdms_dialogs/ffmpeg_conf.py:133
 msgid "options"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:128 ../../vdms_dialogs/ffmpeg_conf.py:132
 msgid "status"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:167
 msgid "FFprobe   ...not found !"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:175
 msgid "FFplay   ...not found !"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:205
-#: ../../vdms_panels/sequence_to_video.py:706
-#: ../../vdms_panels/video_to_sequence.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:216
-#: ../../vdms_panels/sequence_to_video.py:706
-#: ../../vdms_panels/video_to_sequence.py:610
 msgid "Disabled"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:71
 msgid "Demuxing only"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:82
 msgid "Muxing only"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:93
 msgid "Demuxing/Muxing support"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:104
 msgid "FFmpeg file formats"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:111
-#: ../../vdms_dialogs/ffmpeg_formats.py:114
-#: ../../vdms_dialogs/ffmpeg_formats.py:117
 msgid "supported formats"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:46
 msgid ""
-"Contextual help based on the argument entered in the additional text "
-"field.\n"
+"Contextual help based on the argument entered in the additional text field.\n"
 "Each argument consists of the type and a type-specific name.\n"
 "\n"
 "For the list of encoders click the \"Encoders\" button.\n"
 "For the list of decoders click on the \"Decoders\" button.\n"
 "For the muxers and demuxers click on the \"Muxers and Demuxers\" button.\n"
-"For the filters, select \"Show available filters\" in the drop down menu."
-"\n"
-"For the bsf, select \"Show available bitstream filters\" in the drop down"
-" menu.\n"
-"For the protocols, select \"Show available protocols\" in the drop down "
-"menu.\n"
+"For the filters, select \"Show available filters\" in the drop down menu.\n"
+"For the bsf, select \"Show available bitstream filters\" in the drop down menu.\n"
+"For the protocols, select \"Show available protocols\" in the drop down menu.\n"
 "\n"
 "Some examples:"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:68 ../../vdms_dialogs/ffmpeg_help.py:301
-#: ../../vdms_dialogs/ffmpeg_help.py:315
 msgid "Help topic"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:69
 msgid "List basic options"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:70
 msgid "List more options"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:71
 msgid "List all options (very long)"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:72
 msgid "Show available devices"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:73
 msgid "Show available bit stream filters"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:74
 msgid "Show available protocols"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:75
 msgid "Show available filters"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:76
 msgid "Show available pixel formats"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:77
 msgid "Show available audio sample formats"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:78
 msgid "Show available color names"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:79
 msgid "List sources of the input device"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:80
 msgid "List sinks of the output device"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:81
 msgid "Show available HW acceleration methods"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:82
 msgid "Show license"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:117 ../../vdms_dialogs/filter_scale.py:76
-#: ../../vdms_dialogs/shownormlist.py:98 ../../vdms_dialogs/shownormlist.py:107
-#: ../../vdms_dialogs/shownormlist.py:116 ../../vdms_miniframes/timeline.py:263
-#: ../../vdms_miniframes/timeline.py:283 ../../vdms_panels/concatenate.py:117
-#: ../../vdms_panels/sequence_to_video.py:117
-#: ../../vdms_panels/video_to_sequence.py:81
 msgid "Read me"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:123 ../../vdms_main/main_frame.py:534
 msgid "Show configuration"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:127 ../../vdms_main/main_frame.py:542
 msgid "Encoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:131 ../../vdms_main/main_frame.py:545
 msgid "Decoders"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:135 ../../vdms_main/main_frame.py:538
 msgid "Muxers and Demuxers"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:165
 msgid "help topic list"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:184
 msgid "Type the argument here and confirm with the enter key on your keyboard"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:192
 msgid "The search function allows you to find entries in the current topic"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:195
 msgid "Ignore case"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:196
 msgid "Ignore case distinctions: characters with different case will match."
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:206
 msgid "FFmpeg help topics"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:254
 msgid ""
 "This is a multifunctional search tool useful for local help searches\n"
 "on multiple FFmpeg topics and options. The search control, to\n"
@@ -336,1028 +233,647 @@ msgid ""
 "with those features."
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:320 ../../vdms_dialogs/ffmpeg_help.py:345
-#: ../../vdms_dialogs/ffmpeg_help.py:371
 msgid ""
 "\n"
 "  ..Nothing available"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:391
 msgid ""
 "\n"
 "  ..Not found"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:91
 msgid "Before"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:97
 msgid "After"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:103
-#: ../../vdms_dialogs/filter_crop.py:239
 msgid "Search for a specific frame"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:117
-#: ../../vdms_dialogs/filter_crop.py:253
 msgid "Load"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:120
 msgid "Color EQ"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:126
 msgid "Contrast:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:134
-#: ../../vdms_dialogs/filter_colorcorrection.py:148
 msgid "-100 to +100, default value 0"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:139
 msgid "Brightness:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:158
 msgid "Saturation:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:166
 msgid "0 to 300, default value 100"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:170
 msgid "Gamma:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:179
 msgid "0 to 100, default value 10"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:187
-#: ../../vdms_dialogs/filter_crop.py:306
-#: ../../vdms_dialogs/filter_deinterlace.py:209
-#: ../../vdms_dialogs/filter_denoisers.py:110
-#: ../../vdms_dialogs/filter_scale.py:210 ../../vdms_dialogs/filter_stab.py:316
-#: ../../vdms_dialogs/filter_transpose.py:105
-#: ../../vdms_miniframes/timeline.py:262 ../../vdms_miniframes/timeline.py:281
 msgid "Reset"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:207
 msgid "Color Correction EQ Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:343
-#: ../../vdms_dialogs/filter_colorcorrection.py:383
-#: ../../vdms_dialogs/filter_colorcorrection.py:390
-#: ../../vdms_dialogs/filter_crop.py:417 ../../vdms_dialogs/filter_scale.py:287
-#: ../../vdms_dialogs/filter_scale.py:394 ../../vdms_dialogs/filter_stab.py:473
-#: ../../vdms_dialogs/filter_stab.py:483 ../../vdms_dialogs/filter_stab.py:494
-#: ../../vdms_dialogs/filter_transpose.py:182
-#: ../../vdms_dialogs/mediainfo.py:245 ../../vdms_dialogs/mediainfo.py:265
-#: ../../vdms_dialogs/mediainfo.py:285 ../../vdms_dialogs/mediainfo.py:305
-#: ../../vdms_dialogs/setting_profiles.py:281
-#: ../../vdms_dialogs/setting_profiles.py:289 ../../vdms_io/checkup.py:45
-#: ../../vdms_io/checkup.py:93 ../../vdms_io/io_tools.py:144
-#: ../../vdms_main/main_frame.py:904 ../../vdms_main/main_frame.py:939
-#: ../../vdms_main/main_frame.py:961 ../../vdms_main/main_frame.py:979
-#: ../../vdms_main/main_frame.py:999
-#: ../../vdms_panels/audio_encoders/acodecs.py:510
-#: ../../vdms_panels/audio_encoders/acodecs.py:800
-#: ../../vdms_panels/concatenate.py:186
-#: ../../vdms_panels/long_processing_task.py:60
-#: ../../vdms_panels/presets_manager.py:426
-#: ../../vdms_panels/presets_manager.py:490
-#: ../../vdms_panels/presets_manager.py:560
-#: ../../vdms_panels/presets_manager.py:599
-#: ../../vdms_panels/presets_manager.py:619
-#: ../../vdms_panels/presets_manager.py:657
-#: ../../vdms_panels/presets_manager.py:701
-#: ../../vdms_panels/presets_manager.py:714
-#: ../../vdms_panels/presets_manager.py:721
-#: ../../vdms_panels/presets_manager.py:756
-#: ../../vdms_panels/presets_manager.py:785
-#: ../../vdms_panels/presets_manager.py:791
-#: ../../vdms_panels/sequence_to_video.py:467
-#: ../../vdms_panels/sequence_to_video.py:473
-#: ../../vdms_panels/sequence_to_video.py:561
-#: ../../vdms_panels/sequence_to_video.py:571
-#: ../../vdms_panels/sequence_to_video.py:588
-#: ../../vdms_panels/sequence_to_video.py:596
-#: ../../vdms_panels/sequence_to_video.py:602
-#: ../../vdms_panels/sequence_to_video.py:643
-#: ../../vdms_panels/sequence_to_video.py:689
-#: ../../vdms_panels/video_to_sequence.py:512
-#: ../../vdms_panels/video_to_sequence.py:583
-#: ../../vdms_threads/ffplay_file.py:43
-#: ../../vdms_utils/presets_manager_utils.py:86
-#: ../../vdms_utils/presets_manager_utils.py:95
-#: ../../vdms_utils/queue_utils.py:68 ../../vdms_utils/queue_utils.py:82
-#: ../../vdms_utils/queue_utils.py:95
 msgid "Videomass - Error!"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:228 ../../vdms_dialogs/filter_scale.py:109
 #, python-brace-format
 msgid "Source size: {0} x {1} pixels"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:236
 msgid "Crop color"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:256
 msgid "Cropping area selection "
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:261 ../../vdms_dialogs/filter_scale.py:121
 msgid "Height"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:281
 msgid "Center"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:292 ../../vdms_dialogs/filter_scale.py:121
 msgid "Width"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:334
 msgid "Crop Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:335
 msgid "Choose the color to draw the cropping area"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:337
 msgid "Crop to width"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:338
 msgid "Move vertically (set to -1 to center the vertical axis)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:340
 msgid "Move horizontally (set to -1 to center the horizontal axis)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_crop.py:342
 msgid "Crop to height"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:56
 msgid "Advanced Options"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:57
-#: ../../vdms_panels/av_conversions.py:351
 msgid "Deinterlace"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:59
 msgid "Interlace"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:63
 msgid "Deinterlaces with w3fdif filter"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:77
 msgid "Deinterlaces with yadif filter"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:101
 msgid "Interlaces with interlace filter"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:118
 msgid "Deinterlacing and Interlacing"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:144
 msgid "Deinterlace the input video with `w3fdif` filter"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:146
 msgid "Set the interlacing filter coefficients."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:148
-#: ../../vdms_dialogs/filter_deinterlace.py:158
 msgid "Specify which frames to deinterlace."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:150
-msgid ""
-"Deinterlace the input video with `yadif` filter. Using FFmpeg, this is "
-"the best and fastest choice"
+msgid "Deinterlace the input video with `yadif` filter. Using FFmpeg, this is the best and fastest choice"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:153
 msgid ""
 "mode\n"
 "The interlacing mode to adopt."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:155
 msgid ""
 "parity\n"
 "The picture field parity assumed for the input interlaced video."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:160
 msgid "Simple interlacing filter from progressive contents."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:162
 msgid ""
 "scan:\n"
-"determines whether the interlaced frame is taken from the even (tff - "
-"default) or odd (bff) lines of the progressive frame."
+"determines whether the interlaced frame is taken from the even (tff - default) or odd (bff) lines of the progressive frame."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_deinterlace.py:166
 msgid ""
 "lowpass:\n"
-"Enable (default) or disable the vertical lowpass filter to avoid twitter "
-"interlacing and reduce moire patterns.\n"
+"Enable (default) or disable the vertical lowpass filter to avoid twitter interlacing and reduce moire patterns.\n"
 "Default is no setting."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:56
 msgid "Denoiser Filters"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:60
 msgid "Enable nlmeans denoiser"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:73
 msgid "nlmeans options"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:82
 msgid "Enable hqdn3d denoiser"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:91
 msgid "hqdn3d options"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:116
 msgid "Denoiser Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:117
 msgid ""
 "nlmeans:\n"
-"Denoise frames using Non-Local Means algorithm is capable of restoring "
-"video sequences, even with strong noise. It is ideal for enhancing the "
-"quality of old VHS tapes."
+"Denoise frames using Non-Local Means algorithm is capable of restoring video sequences, even with strong noise. It is ideal for enhancing the quality of old VHS tapes."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_denoisers.py:122
 msgid ""
 "hqdn3d:\n"
-"This is a high precision/quality 3d denoise filter. It aims to reduce "
-"image noise, producing smooth images and making still images really "
-"still. It should enhance compressibility."
+"This is a high precision/quality 3d denoise filter. It aims to reduce image noise, producing smooth images and making still images really still. It should enhance compressibility."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:81
 msgid "View result"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:85
 msgid "New size in pixels"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:89
 msgid "Width:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:99
 msgid "Height:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:115
 msgid "Constrain proportions (keep aspect ratio)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:120
 msgid "Which dimension to adjust?"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:129
 msgid "Aspect Ratio"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:132
 msgid "Setdar filter (display aspect ratio) example 16/9, 4/3 "
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:137
-#: ../../vdms_dialogs/filter_scale.py:171
 msgid "Numerator"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:162
-#: ../../vdms_dialogs/filter_scale.py:196
 msgid "Denominator"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:166
 msgid "Setsar filter (sample aspect ratio) example 1/1"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:217
 msgid "Resize Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:218
 msgid "Scale filter, set to 0 to disable"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:221
 msgid "Display Aspect Ratio. Set to 0 to disable"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:224
 msgid ""
 "Sample (aka Pixel) Aspect Ratio.\n"
 "Set to 0 to disable"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_scale.py:366
 msgid ""
-"If you want to keep the aspect ratio, select \"Constrain proportions\" "
-"below and\n"
-"specify only one dimension, either width or height, and set the other "
-"dimension\n"
+"If you want to keep the aspect ratio, select \"Constrain proportions\" below and\n"
+"specify only one dimension, either width or height, and set the other dimension\n"
 "to -1 or -2 (some codecs require -2, so you should do some testing first)."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:81
 msgid "Enable stabilizer"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:83
 msgid "Create a side-by-side comparison video"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:88
 msgid "Create a snapshot"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:106
-#: ../../vdms_panels/audio_encoders/acodecs.py:167
 msgid "Preview"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:109
 msgid "Duration seconds:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:118
 msgid "Video Detect"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:176
 msgid "[TRIPOD] Enable tripod mode if checked"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:183
 msgid "Video transform"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:202
 msgid "[OPTALGO] optimization algorithm"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:224
 msgid "[CROP] Specify how to deal with borders at movement compensation"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:231
 msgid "[INVERT] Invert transforms if checked"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:234
-msgid ""
-"[RELATIVE] Consider transforms as relative to previous frame if checked, "
-"absolute if unchecked"
+msgid "[RELATIVE] Consider transforms as relative to previous frame if checked, absolute if unchecked"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:279
 msgid "Specify type of interpolation"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:287
-msgid ""
-"[TRIPOD2] virtual tripod mode, equivalent to "
-"relative=unchecked:smoothing=0"
+msgid "[TRIPOD2] virtual tripod mode, equivalent to relative=unchecked:smoothing=0"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:294
 msgid "Unsharp filter:"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:323
 msgid "Seek to a position on the video."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:325
 msgid "Make a snapshot of the video with the settings made."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:327
-msgid ""
-"Set the snapshot duration from 3 to 15 seconds from the seek position, "
-"default is 5 seconds."
+msgid "Set the snapshot duration from 3 to 15 seconds from the seek position, default is 5 seconds."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:331
-msgid ""
-"Set how shaky the video is and how quick the camera is. A value of 1 "
-"means little shakiness, a value of 10 means strong shakiness. Default "
-"value is 5."
+msgid "Set how shaky the video is and how quick the camera is. A value of 1 means little shakiness, a value of 10 means strong shakiness. Default value is 5."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:335
-msgid ""
-"Set the accuracy of the detection process. A value of 1 means low "
-"accuracy, a value of 15 means high accuracy. Default value is 15."
+msgid "Set the accuracy of the detection process. A value of 1 means low accuracy, a value of 15 means high accuracy. Default value is 15."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:339
-msgid ""
-"Set stepsize of the search process. The region around minimum is scanned "
-"with 1 pixel resolution. Default value is 6."
+msgid "Set stepsize of the search process. The region around minimum is scanned with 1 pixel resolution. Default value is 6."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:343
-msgid ""
-"Set minimum contrast. Below this value a local measurement field is "
-"discarded. The range is 0-1. Default value is 0.25."
+msgid "Set minimum contrast. Below this value a local measurement field is discarded. The range is 0-1. Default value is 0.25."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:346
-msgid ""
-"Set reference frame number for tripod mode. If enabled, the motion of the"
-" frames is compared to a reference frame in the filtered stream, "
-"identified by the specified number. The idea is to compensate all "
-"movements in a more-or-less static scene and keep the camera view "
-"absolutely still. The frames are counted starting from 1."
+msgid "Set reference frame number for tripod mode. If enabled, the motion of the frames is compared to a reference frame in the filtered stream, identified by the specified number. The idea is to compensate all movements in a more-or-less static scene and keep the camera view absolutely still. The frames are counted starting from 1."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:355
 msgid ""
-"Set the number of frames (value*2 + 1) used for lowpass filtering the "
-"camera movements. Default value is 15. For example a number of 10 means "
-"that 21 frames are used (10 in the past and 10 in the future) to smoothen"
-" the motion in the video. A larger value leads to a smoother video, but "
-"limits the acceleration of the camera (pan/tilt movements). 0 is a "
-"special case where a static camera is simulated."
+"Set the number of frames (value*2 + 1) used for lowpass filtering the camera movements. Default value is 15. For example a number of 10 means that 21 frames are used (10 in the past and 10 in the future) to smoothen the motion in the video. A larger value leads to a smoother video, but limits the acceleration of the camera (pan/tilt movements). 0 is a special case where a static camera is "
+"simulated."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:363
-msgid ""
-"Set the camera path optimization algorithm. Values are: `gauss`: gaussian"
-" kernel low-pass filter on camera motion (default), and `avg`: averaging "
-"on transformations"
+msgid "Set the camera path optimization algorithm. Values are: `gauss`: gaussian kernel low-pass filter on camera motion (default), and `avg`: averaging on transformations"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:367
-msgid ""
-"Set maximal angle in radians (degree*PI/180) to rotate frames. Default "
-"value is -1, meaning no limit."
+msgid "Set maximal angle in radians (degree*PI/180) to rotate frames. Default value is -1, meaning no limit."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:370
-msgid ""
-"Specify how to deal with borders that may be visible due to movement "
-"compensation. Values are: `keep` keep image information from previous "
-"frame (default), `black` fill the border black"
+msgid "Specify how to deal with borders that may be visible due to movement compensation. Values are: `keep` keep image information from previous frame (default), `black` fill the border black"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:375
 msgid "Invert transforms if checked. Default is unchecked."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:377
-msgid ""
-"Consider transforms as relative to previous frame if checked, absolute if"
-" unchecked. Default is checked."
+msgid "Consider transforms as relative to previous frame if checked, absolute if unchecked. Default is checked."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:380
-msgid ""
-"Set percentage to zoom. A positive value will result in a zoom-in effect,"
-" a negative value in a zoom-out effect. Default value is 0 (no zoom)."
+msgid "Set percentage to zoom. A positive value will result in a zoom-in effect, a negative value in a zoom-out effect. Default value is 0 (no zoom)."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:384
-msgid ""
-"Set optimal zooming to avoid borders. Accepted values are: `0` disabled, "
-"`1` optimal static zoom value is determined (only very strong movements "
-"will lead to visible borders) (default), `2` optimal adaptive zoom value "
-"is determined (no borders will be visible), see zoomspeed. Note that the "
-"value given at zoom is added to the one calculated here."
+msgid "Set optimal zooming to avoid borders. Accepted values are: `0` disabled, `1` optimal static zoom value is determined (only very strong movements will lead to visible borders) (default), `2` optimal adaptive zoom value is determined (no borders will be visible), see zoomspeed. Note that the value given at zoom is added to the one calculated here."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:391
-msgid ""
-"Set percent to zoom maximally each frame (enabled when optzoom is set to "
-"2). Range is from 0 to 5, default value is 0.25."
+msgid "Set percent to zoom maximally each frame (enabled when optzoom is set to 2). Range is from 0 to 5, default value is 0.25."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:395
-msgid ""
-"Specify type of interpolation. Available values are: `no` no "
-"interpolation, `linear` linear only horizontal, `bilinear` linear in both"
-" directions (default), `bicubic` cubic in both directions (slow)"
+msgid "Specify type of interpolation. Available values are: `no` no interpolation, `linear` linear only horizontal, `bilinear` linear in both directions (default), `bicubic` cubic in both directions (slow)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:400
-msgid ""
-"Enable virtual tripod mode if checked, which is equivalent to "
-"relative=0:smoothing=0. Default is unchecked. Use also tripod option of "
-"vidstabdetect."
+msgid "Enable virtual tripod mode if checked, which is equivalent to relative=0:smoothing=0. Default is unchecked. Use also tripod option of vidstabdetect."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:405
-msgid ""
-"Sharpen or blur the input video. Note the use of the unsharp filter which"
-" is always recommended."
+msgid "Sharpen or blur the input video. Note the use of the unsharp filter which is always recommended."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:409
 msgid "Video Stabilizer Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:541 ../../vdms_io/io_tools.py:73
 msgid "Videomass - Loading..."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:542
 msgid ""
 "Please wait,\n"
 "This process will take a few seconds."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:80
-#: ../../vdms_dialogs/filter_transpose.py:293
 msgid "Default position"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:86
 msgid "Rotation setting"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:94
 msgid "90° (left)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:96
 msgid "90° (right)"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:100
 msgid "180°"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:115
 msgid "Transpose Tool"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:229
 msgid "Rotate 90 degrees right"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:251
 msgid "Rotate 180 degrees"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_transpose.py:272
 msgid "Rotate 90 degrees left"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:82
 msgid "Format"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:96
 msgid "Video Stream"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:109
 msgid "Audio Streams"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:122
 msgid "Subtitle Streams"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:126
 msgid "Copy to clipboard"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:137
 msgid "FILE SELECTION"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:139 ../../vdms_dialogs/mediainfo.py:142
-#: ../../vdms_dialogs/mediainfo.py:145 ../../vdms_dialogs/mediainfo.py:148
-#: ../../vdms_main/main_frame.py:1318
 msgid "Properties"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:140 ../../vdms_dialogs/mediainfo.py:143
-#: ../../vdms_dialogs/mediainfo.py:146 ../../vdms_dialogs/mediainfo.py:149
 msgid "Values"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:152
 msgid "Streams Properties"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:244
 msgid "Unable to open the clipboard on Format tab"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:263
 msgid "Unable to open the clipboard on Video Streams tab"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:283
 msgid "Unable to open the clipboard on Audio Streams tab"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:303
 msgid "Unable to open the clipboard on Subtitle Streams tab"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:90
 msgid "Where do you prefer to save your transcodes?"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:101 ../../vdms_dialogs/preferences.py:128
-#: ../../vdms_dialogs/preferences.py:149 ../../vdms_dialogs/preferences.py:161
-#: ../../vdms_dialogs/preferences.py:173 ../../vdms_panels/filedrop.py:284
 msgid "Change"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:103
-#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:602
-#: ../../vdms_panels/presets_manager.py:1050
 msgid "Same destination paths as source files"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:108
 msgid "Assign optional suffix to destination file names:"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:114
 msgid "File removal preferences"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:118
 msgid "Trash the source files after successful encoding"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:131
 msgid "File Preferences"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:138
 msgid "Location of executables"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:140
 msgid ""
-"FFmpeg can be built by enabling/disabling its options and this depends on"
-" your needs.\n"
-"For some use cases it is possible to provide a custom build of FFmpeg "
-"where you can specify\n"
+"FFmpeg can be built by enabling/disabling its options and this depends on your needs.\n"
+"For some use cases it is possible to provide a custom build of FFmpeg where you can specify\n"
 "it in this preferences tab."
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:147
 msgid "Enable a custom location to run FFmpeg"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:159
 msgid "Enable a custom location to run FFprobe"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:171
 msgid "Enable a custom location to run FFplay"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:183
 msgid "FFmpeg"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:189
 msgid "Look and Feel (requires application restart)"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:194
 msgid "Icon themes"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:208
 msgid "At the top of window (default)"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:209
 msgid "At the bottom of window"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:210
 msgid "At the right of window"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:211
 msgid "At the left of window"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:213
 msgid "Place the toolbar"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:222
 msgid "Toolbar's icons size:"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:236
 msgid "Application Language (requires application restart)"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:248
 msgid "Look and Language"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:254
 msgid "Upon exiting the application"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:259
 msgid "Always ask me to confirm"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:261
 msgid "Clean the log files"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:264
 msgid "Remove cached files"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:268
 msgid "On operations completion"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:271
-msgid ""
-"These settings will remain active until the application is closed, If "
-"necessary, remember to reactivate them."
+msgid "These settings will remain active until the application is closed, If necessary, remember to reactivate them."
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:276
 msgid "Exit the application"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:279
 msgid "Shutdown the system"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:283
 msgid "SUDO password:"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:292
 msgid "Exit and Shutdown"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:298
 msgid "Specify the character encoding format"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:301
 msgid ""
-"Although UTF-8 is the default and most widely used standard encoding "
-"format, it is not the only encoding format available.\n"
-"Some file metadata may still contain non-UTF-8 character encodings "
-"resulting in the error \"'utf-8' codec can't decode bytes...\".\n"
-"If you know the encoding format the file was written in, you can try "
-"specifying it here, e.g. ISO 8859-1, ISO 8859-16, etc."
+"Although UTF-8 is the default and most widely used standard encoding format, it is not the only encoding format available.\n"
+"Some file metadata may still contain non-UTF-8 character encodings resulting in the error \"'utf-8' codec can't decode bytes...\".\n"
+"If you know the encoding format the file was written in, you can try specifying it here, e.g. ISO 8859-1, ISO 8859-16, etc."
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:311
 msgid "Character encoding:"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:320
 msgid "Default application directories"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:324
 msgid "Configuration directory"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:337
 msgid "Cache directory"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:349
 msgid "Log directory"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:363
 msgid "Advanced"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:369
 msgid ""
-"The following settings affect output messages and the log messages during"
-" transcoding processes.\n"
-"Be careful, by changing these settings some functions of the application "
-"may not work correctly,\n"
+"The following settings affect output messages and the log messages during transcoding processes.\n"
+"Be careful, by changing these settings some functions of the application may not work correctly,\n"
 "change only if you know what you are doing.\n"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:376
 msgid "Set logging level flags used by FFmpeg"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:383
 msgid "Set logging level flags used by FFplay"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:391
 msgid "FFmpeg logging levels"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:437
 msgid "By assigning an additional suffix you could avoid overwriting files"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:440
-msgid ""
-"Type sudo password here, only for Unix-like operating systems, not for MS"
-" Windows"
+msgid "Type sudo password here, only for Unix-like operating systems, not for MS Windows"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:443
 msgid "Preferences"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:596 ../../vdms_dialogs/preferences.py:676
-#: ../../vdms_main/main_frame.py:879 ../../vdms_main/main_frame.py:1060
 msgid "Choose Destination"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:627
-msgid ""
-"Enter only alphanumeric characters. You can also use the hyphen (\"-\") "
-"and the underscore (\"_\"). Spaces are not allowed."
+msgid "Enter only alphanumeric characters. You can also use the hyphen (\"-\") and the underscore (\"_\"). Spaces are not allowed."
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:642
-#: ../../vdms_dialogs/setting_profiles.py:257
-#: ../../vdms_dialogs/setting_profiles.py:264
-#: ../../vdms_dialogs/setting_profiles.py:286
-#: ../../vdms_dialogs/setting_profiles.py:309 ../../vdms_main/main_frame.py:399
-#: ../../vdms_main/main_frame.py:421 ../../vdms_panels/av_conversions.py:605
-#: ../../vdms_panels/av_conversions.py:612
-#: ../../vdms_panels/sequence_to_video.py:352
-#: ../../vdms_panels/video_to_sequence.py:399
 msgid "Videomass - Warning!"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:731 ../../vdms_dialogs/preferences.py:771
-#: ../../vdms_dialogs/preferences.py:811 ../../vdms_dialogs/wizard_dlg.py:365
-#: ../../vdms_dialogs/wizard_dlg.py:384 ../../vdms_dialogs/wizard_dlg.py:403
 #, python-brace-format
 msgid "{} location"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:36
-#: ../../vdms_dialogs/setting_profiles.py:38
-msgid ""
-"One-Pass, Do not start with `ffmpeg -i filename`; do not end with "
-"`output-filename`"
+msgid "One-Pass, Do not start with `ffmpeg -i filename`; do not end with `output-filename`"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:40
-#: ../../vdms_dialogs/setting_profiles.py:42
-msgid ""
-"Two-Pass (optional), Do not start with `ffmpeg -i filename`; do not end "
-"with `output-filename`"
+msgid "Two-Pass (optional), Do not start with `ffmpeg -i filename`; do not end with `output-filename`"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:59
 msgid "Videomass - Edit the selected item in the queue"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:71
-#: ../../vdms_dialogs/setting_profiles.py:92
 msgid "Pre-input arguments for One-Pass (optional)"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:82
-#: ../../vdms_dialogs/setting_profiles.py:151
-#: ../../vdms_panels/presets_manager.py:255
 msgid "FFmpeg arguments for one-pass encoding"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:88
-#: ../../vdms_dialogs/setting_profiles.py:158
-#: ../../vdms_panels/presets_manager.py:259
-msgid ""
-"Any optional arguments to add before input file on the one-pass encoding,"
-" e.g required names of some hardware accelerations like -hwaccel to use "
-"with CUDA."
+msgid "Any optional arguments to add before input file on the one-pass encoding, e.g required names of some hardware accelerations like -hwaccel to use with CUDA."
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:102
-#: ../../vdms_dialogs/setting_profiles.py:98
 msgid "Pre-input arguments for Two-Pass (optional)"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:113
-#: ../../vdms_dialogs/setting_profiles.py:152
-#: ../../vdms_panels/presets_manager.py:257
 msgid "FFmpeg arguments for two-pass encoding"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:120
-#: ../../vdms_dialogs/setting_profiles.py:162
-#: ../../vdms_panels/presets_manager.py:263
-msgid ""
-"Any optional arguments to add before input file on the two-pass encoding,"
-" e.g required names of some hardware accelerations like -hwaccel to use "
-"with CUDA."
+msgid "Any optional arguments to add before input file on the two-pass encoding, e.g required names of some hardware accelerations like -hwaccel to use with CUDA."
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:65 ../../vdms_main/main_frame.py:508
-#: ../../vdms_panels/presets_manager.py:189
-#: ../../vdms_panels/video_to_sequence.py:171
 msgid "Edit"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:68
 msgid "Remove"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:71
 msgid "Remove all"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:74
 msgid ""
 "Export\n"
 "queue file"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:77
 msgid ""
 "Import\n"
 "queue file"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:85 ../../vdms_panels/filedrop.py:273
 msgid "Destination file name"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:137
 msgid "Remove all items in the queue"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:151
 msgid "Videomass - Queue"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:228
 msgid "Export queue file"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:296 ../../vdms_panels/av_conversions.py:1192
-#: ../../vdms_panels/presets_manager.py:1044
-#: ../../vdms_panels/video_to_sequence.py:600
 msgid "Same as source"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:301
 msgid ""
 "Source\n"
 "File destination\n"
@@ -1368,188 +884,129 @@ msgid ""
 "Clip duration"
 msgstr ""
 
-#: ../../vdms_dialogs/renamer.py:76
 msgid "# will be replaced by ascending numbers starting with:"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:87
 msgid "Font Size"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:111
 msgid "Font Color"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:121
 msgid "Shadow Color"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:132
 msgid "Show text box"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:136
 msgid "Box Color"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:156
-msgid ""
-"The timestamp size does not auto-adjust to the video size, you have to "
-"set the size here"
+msgid "The timestamp size does not auto-adjust to the video size, you have to set the size here"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:160 ../../vdms_main/main_frame.py:559
 msgid "Timestamp settings"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:46
 msgid "Supported Formats list (optional). Do not include the `.`"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:47
 msgid "Output Format. Empty to copy format and codec. Do not include the `.`"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:70
 msgid "Profile Name"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:74
-#: ../../vdms_panels/presets_manager.py:404
 msgid "Description"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:149
 msgid "A short profile name"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:150
 msgid "A long description of the profile"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:153
 msgid "One or more comma-separated format names compatible with this profile"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:155
 msgid "Output format extension. Leave empty to copy codec and format"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:256
 msgid "Incomplete profile assignments"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:263
 msgid "Formats must be comma-separated"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:279
-#: ../../vdms_utils/queue_utils.py:80
 #, python-brace-format
 msgid ""
 "ERROR: Keys mismatched for requested data.\n"
 "Invalid file: «{0}»"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:285
-#: ../../vdms_dialogs/setting_profiles.py:308
 msgid "Profile already stored with same name"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:293
 msgid "Profile stored successfully!"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:311
 msgid "Profile change successful!"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:80
 msgid "Log file list"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:82 ../../vdms_dialogs/showlogs.py:116
 msgid "Log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:105
 msgid "Refresh log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:107
 msgid "Clear log messages"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:160
 msgid "Select a log file"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:167
 msgid "Are you sure you want to clear the selected log file?"
 msgstr ""
 
-#: ../../vdms_dialogs/showlogs.py:168 ../../vdms_dialogs/wizard_dlg.py:251
-#: ../../vdms_io/checkup.py:68 ../../vdms_main/main_frame.py:205
-#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1685
-#: ../../vdms_panels/presets_manager.py:349
-#: ../../vdms_panels/presets_manager.py:550
-#: ../../vdms_panels/presets_manager.py:590
-#: ../../vdms_panels/presets_manager.py:649
-#: ../../vdms_panels/presets_manager.py:684
-#: ../../vdms_panels/presets_manager.py:749
-#: ../../vdms_panels/presets_manager.py:775
-#: ../../vdms_panels/presets_manager.py:874
-#: ../../vdms_panels/presets_manager.py:904
 msgid "Please confirm"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:83
 msgid "File name"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:84
 msgid "Max volume dBFS"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:85
 msgid "Mean volume dBFS"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:86
 msgid "Offset dBFS"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:87
 msgid "Result dBFS"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:92
 msgid "Post-normalization references:"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:102
 msgid "=  Clipped peaks"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:111
 msgid "=  No changes"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:121
 msgid "=  Below max peak"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:166
-#: ../../vdms_panels/audio_encoders/acodecs.py:841
 msgid "RMS-based volume statistics"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:191
-#: ../../vdms_panels/audio_encoders/acodecs.py:839
 msgid "PEAK-based volume statistics"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:216
 msgid ""
 "...It means the resulting audio will be clipped,\n"
 "because its volume is higher than the maximum 0 db\n"
@@ -1557,34 +1014,28 @@ msgid ""
 "sound distorted."
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:242
 msgid ""
 "...It means the resulting audio will not change,\n"
 "because it's equal to the source."
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:266
 msgid ""
 "...It means an audio signal will be produced with\n"
 "a lower volume than the source."
 msgstr ""
 
-#: ../../vdms_dialogs/videomass_check_version.py:63
 msgid "Get Latest Version"
 msgstr ""
 
-#: ../../vdms_dialogs/videomass_check_version.py:67
 msgid "Checking for newer version"
 msgstr ""
 
-#: ../../vdms_dialogs/videomass_check_version.py:95
 msgid ""
 "\n"
 "\n"
 "New releases fix bugs and offer new features."
 msgstr ""
 
-#: ../../vdms_dialogs/videomass_check_version.py:96
 #, python-brace-format
 msgid ""
 "\n"
@@ -1593,7 +1044,6 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../../vdms_dialogs/while_playing.py:37
 msgid ""
 "q, ESC\n"
 "f\n"
@@ -1616,119 +1066,89 @@ msgid ""
 "left mouse double-click"
 msgstr ""
 
-#: ../../vdms_dialogs/while_playing.py:92
 msgid "Shortcut keys while playing with FFplay"
 msgstr ""
 
-#: ../../vdms_dialogs/widget_utils.py:120 ../../vdms_main/main_frame.py:1326
 msgid "Stop"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:63
 msgid "Please take a moment to set up the application"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:64
 msgid "Click the \"Next\" button to get started"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:79
 msgid "Welcome to the Videomass Wizard!"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:123
 msgid "Videomass is an application based on FFmpeg\n"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:125
 msgid "If FFmpeg is not on your computer, this application will be unusable"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:128
 msgid ""
 "If you have already installed FFmpeg on your operating system,\n"
 "click the \"Auto-detection\" button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:131
 msgid ""
 "If you want to use a version of FFmpeg located on your filesystem\n"
 "but not installed on your operating system,\n"
 "click the \"Locate\" button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:162
 msgid "Auto-detection"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:164
 msgid "Locate"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:214
 msgid "Click the \"Next\" button"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:235
 #, python-brace-format
-msgid ""
-"'{}' is not installed on your computer. Install it or indicate another "
-"location by clicking the 'Locate' button."
+msgid "'{}' is not installed on your computer. Install it or indicate another location by clicking the 'Locate' button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:249
 msgid ""
 "Videomass already seems to include FFmpeg.\n"
 "\n"
 "Do you want to use that?"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:275
 msgid "Locating FFmpeg executables\n"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:277
 msgid ""
 "\"ffmpeg\", \"ffprobe\" and \"ffplay\" are required. Complete all\n"
 "the text boxes below by clicking on the respective buttons."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:437
 msgid "Wizard completed successfully!\n"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:438
-msgid ""
-"Remember that you can always change these settings later, through the "
-"Preferences dialog."
+msgid "Remember that you can always change these settings later, through the Preferences dialog."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:440
 msgid "Thank You!"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:441
 msgid "To exit click the \"Finish\" button"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:527
 msgid "< Previous"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:530 ../../vdms_dialogs/wizard_dlg.py:613
 msgid "Next >"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:535
 msgid "Videomass Wizard"
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:563 ../../vdms_dialogs/wizard_dlg.py:586
-#: ../../vdms_dialogs/wizard_dlg.py:591
 msgid "Finish"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:44 ../../vdms_io/checkup.py:92
 #, python-brace-format
 msgid ""
 "Output folder does not exist:\n"
@@ -1736,438 +1156,326 @@ msgid ""
 "\"{}\"\n"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:65
 msgid "Files already exist, do you want to overwrite them?"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:67
 msgid "Already exist"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:81
 msgid "Not found"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:82 ../../vdms_panels/filedrop.py:196
 msgid "Error list"
 msgstr ""
 
-#: ../../vdms_io/checkup.py:83
 msgid "File(s) not found"
 msgstr ""
 
-#: ../../vdms_io/io_tools.py:56
 #, python-format
 msgid "File does not exist or is invalid:  %s"
 msgstr ""
 
-#: ../../vdms_io/io_tools.py:74
 msgid ""
 "Wait....\n"
 "Audio peak analysis."
 msgstr ""
 
-#: ../../vdms_io/io_tools.py:179
 msgid "Videomass - Downloading..."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1409
-#: ../../vdms_main/main_frame.py:1441
 msgid "Ready"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:203
 msgid ""
 "Not all items in the queue were completed.\n"
 "\n"
 "Would you like to keep them in the queue?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:224
 #, python-brace-format
 msgid "Queue ({0})"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:229 ../../vdms_main/main_frame.py:1334
 msgid "Queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:396 ../../vdms_main/main_frame.py:418
-msgid ""
-"There are still active windows with running processes, make sure you "
-"finish your work before exit."
+msgid "There are still active windows with running processes, make sure you finish your work before exit."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:403
 msgid "Are you sure you want to exit the application?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:405
 msgid "Exit"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:463
 msgid "Import files\tCtrl+O"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:466
 msgid "Open destination folder of encodings\tCtrl+D"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:469
 msgid "Load queue file"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:470
 msgid "Load a previously exported queue file"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:473
 msgid "Open trash"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:474
 msgid "Open the Videomass trash folder"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:476
 msgid "Empty trash"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:477
 msgid "Delete all files in the Videomass trash folder"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:480
 msgid "Exit\tCtrl+Q"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:481
 msgid "Completely exit the application"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:482
 msgid "File"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:486 ../../vdms_panels/filedrop.py:340
-#: ../../vdms_panels/filedrop.py:381
 msgid "Rename selected file\tCtrl+R"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:487
 msgid "Rename the destination of the selected file"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:490 ../../vdms_panels/filedrop.py:341
-#: ../../vdms_panels/filedrop.py:384
 msgid "Batch rename files\tCtrl+B"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:491
 msgid "Numerically renames the destination of all items in the list"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:496 ../../vdms_panels/filedrop.py:343
-#: ../../vdms_panels/filedrop.py:388
 msgid "Remove selected entry\tDEL"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:497
 msgid "Remove the selected file from the list"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:500 ../../vdms_panels/filedrop.py:344
-#: ../../vdms_panels/filedrop.py:391
 msgid "Clear list\tShift+DEL"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:501
 msgid "Clear the file list"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:506
 msgid "Preferences\tCtrl+P"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:507
 msgid "Application preferences"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:512
 msgid "Find FFmpeg topics"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:513
 msgid "A useful tool to search for FFmpeg help topics and options"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:518
 msgid "Check for preset updates"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:519
 #, python-brace-format
 msgid "Check for new presets updates from {0}"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:521
 msgid "Get latest presets"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:522
 #, python-brace-format
 msgid "Get the latest presets from {0}"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:525
 msgid "Work notes\tCtrl+N"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:526
 msgid "Read and write useful notes and reminders."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:528
 msgid "Tools"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:535
 msgid "Show FFmpeg's built-in configuration capabilities"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:539
 msgid "Muxers and demuxers available on your version of FFmpeg"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:543
 msgid "Encoders available on your version of FFmpeg"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:546
 msgid "Decoders available on your version of FFmpeg"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:550
 msgid "Enable timestamps on playback"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:551
 msgid "Displays timestamp when playing media with FFplay"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:554
 msgid "Auto-exit after playback"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:555
 msgid "If checked, the FFplay window will auto-close when playback is complete"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:559
 msgid "Customize the timestamp style"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:562
 msgid "While playing..."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:563
 msgid "Show useful shortcut keys when playing or previewing using FFplay"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:567
 msgid "Show timeline editor\tCtrl+T"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:568
-msgid ""
-"Set duration or trim slices of time to remove unwanted parts from your "
-"files"
+msgid "Set duration or trim slices of time to remove unwanted parts from your files"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:572
 msgid "View"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:579
 msgid "Home panel\tCtrl+Shift+H"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:580
 msgid "Go to the «Home» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:583
 msgid "Presets Manager\tCtrl+Shift+P"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:584
 msgid "Go to the «Presets Manager» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:586
 msgid "A/V Conversions\tCtrl+Shift+V"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:587
 msgid "Go to the «A/V Conversions» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:589
 msgid "Concatenate Demuxer\tCtrl+Shift+D"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:590
 msgid "Go to the «Concatenate Demuxer» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:593
 msgid "Still Image Maker\tCtrl+Shift+I"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:594
 msgid "Go to the «Still Image Maker» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:596
 msgid "From Movie to Pictures\tCtrl+Shift+S"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:597
 msgid "Go to the «From Movie to Pictures» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:600
 msgid "Output monitor\tCtrl+Shift+O"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:601
 msgid "Keeps track of the output for debugging errors"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:603
 msgid "Go"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:607
 msgid "User guide"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:611
 msgid "System version"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:612
 msgid "Get version about your operating system, version of Python and wxPython."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:616
 msgid "Show log files\tCtrl+L"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:617
 msgid "Viewing log messages"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:620
 msgid "Issue tracker"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:624
 msgid "Contribute to the project"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:627
 msgid "Sponsor this project"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:628
 msgid "Become a developer supporter"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:629
 msgid "Donate"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:630
 msgid "Donate to the app developer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:634
 msgid "Other projects by the developer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:650
 msgid "About Videomass"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:651
 msgid "Check for newer version"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:652
 msgid "Check for the latest Videomass version"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:654
 msgid "Help"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:729
 msgid "Import files"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:752
-msgid ""
-"No default folder has been set for the destination of the encodings. The "
-"current setting is \"Same destination paths as source files\"."
+msgid "No default folder has been set for the destination of the encodings. The current setting is \"Same destination paths as source files\"."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:784 ../../vdms_main/main_frame.py:809
 #, python-brace-format
 msgid ""
 "'{}':\n"
 "No such file or directory"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:797
 msgid "Are you sure to empty trash folder?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:805
 #, python-brace-format
 msgid ""
 "'{}':\n"
 "There are no files to delete."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:862
 #, python-brace-format
 msgid "Installed release v{0}. A new presets release is available {1}"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:866
 #, python-brace-format
 msgid "Installed release v{0}. No new updates found."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:896
 msgid ""
 "Wait....\n"
 "The archive is being downloaded"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:908
 #, python-brace-format
 msgid "Successfully downloaded to \"{0}\""
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1120
 msgid "Some changes require restarting the application."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1126
 #, python-brace-format
 msgid ""
 "{0}\n"
@@ -2175,355 +1483,250 @@ msgid ""
 "Do you want to restart the application now?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1128
 msgid "Restart Videomass?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1207
 #, python-brace-format
 msgid "A new release is available - v.{0}\n"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1210
 msgid "You are using a development version that has not yet been released!\n"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1213
 msgid "Congratulation! You are already using the latest version.\n"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1301
 msgid "Previous panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1302
 msgid "Back"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1305
 msgid "Next panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1306
 msgid "Next"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1309
 msgid "Home panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1310
 msgid "Home"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1313
 msgid "Play the selected imput file"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1314
 msgid "Play"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1317
 msgid "Get informative data about imported media streams"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1321
 msgid "Start batch processing"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1325
 msgid "Stops current process"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1329
 msgid "Add an item to Queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1330
 msgid "Add to Queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1333
 msgid "Show queue"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1408 ../../vdms_panels/presets_manager.py:569
 msgid "Videomass"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1442
 msgid "Videomass - File List"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1459
 msgid "Videomass - AV Conversions"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1488
 msgid "Videomass - Presets Manager"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1518
 msgid "Videomass - Concatenate Demuxer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1547
 msgid "Videomass - From Movie to Pictures"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1576
 msgid "Videomass - Still Image Maker"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1660 ../../vdms_panels/av_conversions.py:577
-#: ../../vdms_panels/filedrop.py:500 ../../vdms_panels/filedrop.py:616
-#: ../../vdms_panels/sequence_to_video.py:322
-#: ../../vdms_panels/video_to_sequence.py:369
-#: ../../vdms_panels/video_to_sequence.py:501
 msgid "Have to select an item in the file list first"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1682
 msgid ""
 "An item with the same destination file already exists.\n"
 "\n"
 "Do you want to replace it by adding the new item to the queue?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1703
 msgid "Videomass - FFmpeg Message Monitoring"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1828
 #, python-brace-format
 msgid "The system will turn off in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1829
 msgid "Videomass - Shutdown!"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1836
 msgid "Error while shutting down. Please see file log for details."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1848
 #, python-brace-format
 msgid "Exiting the application in {0} seconds"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1849
 msgid "Videomass - Exiting!"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:46
 msgid "Start point adjustment"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:48
 msgid "End point adjustment"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:105
 msgid "Hours"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:106
 msgid "Minutes"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:107
 msgid "Seconds"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:108
 msgid "Milliseconds"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:189 ../../vdms_miniframes/timeline.py:312
 msgid "No source duration:"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:208 ../../vdms_miniframes/timeline.py:298
-#: ../../vdms_miniframes/timeline.py:333 ../../vdms_miniframes/timeline.py:338
-#: ../../vdms_miniframes/timeline.py:441
 #, python-brace-format
 msgid "{0} {1}  |  Segment Duration: {2}"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:260 ../../vdms_miniframes/timeline.py:277
 msgid "End adjustment"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:261 ../../vdms_miniframes/timeline.py:279
 msgid "Start adjustment"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:320
 msgid "Source duration:"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:387
 msgid "WARNING: Invalid selection, out of range."
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:461
 msgid ""
 "Start by dragging the bottom left handle,\n"
 "or right-click for options."
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:497
 msgid "Start"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:498
 msgid "End"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:548
 msgid ""
-"The timeline editor is a tool that allows you to trim slices of time on "
-"selected imported media (see File List panel).\n"
+"The timeline editor is a tool that allows you to trim slices of time on selected imported media (see File List panel).\n"
 "\n"
-"The \"time format\" used to report durations is expressed in hours, "
-"minutes, seconds and milliseconds (HH:MM:SS.ms).\n"
+"The \"time format\" used to report durations is expressed in hours, minutes, seconds and milliseconds (HH:MM:SS.ms).\n"
 "\n"
-"Note that importing new files, making new selection, deselection, "
-"deleting items, sorting items (ie by LEFT clicking on the column "
-"headers), will reset any previous settings to default values.\n"
+"Note that importing new files, making new selection, deselection, deleting items, sorting items (ie by LEFT clicking on the column headers), will reset any previous settings to default values.\n"
 "\n"
-"If the File List panel is empty or no source files are selected, the "
-"overall duration values will be set to 23:59:59.999, rather than the "
-"duration of a selected source file (see status bar messages).\n"
+"If the File List panel is empty or no source files are selected, the overall duration values will be set to 23:59:59.999, rather than the duration of a selected source file (see status bar messages).\n"
 "\n"
-"The \"Start\"/\"End\" duration values always refer to the initial "
-"position of the timeline: 00:00:00.000. For other informations as the "
-"segment duration and warnings, please refer to the status bar messages."
+"The \"Start\"/\"End\" duration values always refer to the initial position of the timeline: 00:00:00.000. For other informations as the segment duration and warnings, please refer to the status bar messages."
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:565
 msgid "Timeline Editor Usage"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:153
 msgid "Media:"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:169
 msgid "Container:"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:180
 msgid "Save profile"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:183
 msgid "Target"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:316
 msgid "Miscellaneous"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:323
 msgid "Save as a new profile of the Presets Manager."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:325
-msgid ""
-"Available video encoders. \"Copy\" means that the video stream will not "
-"be re-encoded and will allow you (depending on the encoder) to change the"
-" container, audio codec and a few other parameters."
+msgid "Available video encoders. \"Copy\" means that the video stream will not be re-encoded and will allow you (depending on the encoder) to change the container, audio codec and a few other parameters."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:330
 msgid ""
-"Container format. It is usually represented by the file extension (output"
-" format).\n"
+"Container format. It is usually represented by the file extension (output format).\n"
 "\n"
-"If the Media target is set to \"Video\" and the Video Encoder to "
-"\"Copy\", optionally you can set this control to \"Copy\" the same "
-"container as source file.\n"
+"If the Media target is set to \"Video\" and the Video Encoder to \"Copy\", optionally you can set this control to \"Copy\" the same container as source file.\n"
 "\n"
-"If the media target is set to \"Audio\", you can extract only the audio "
-"streams from videos, or simply convert audio source files."
+"If the media target is set to \"Audio\", you can extract only the audio streams from videos, or simply convert audio source files."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:338
 msgid ""
-"Set output files target: \"Video\" to save output files as video files; "
-"\"Audio\" to save files using an audio encoder and format.\n"
+"Set output files target: \"Video\" to save output files as video files; \"Audio\" to save files using an audio encoder and format.\n"
 "\n"
-"Note that by using \"Audio\" as the target, you will still be able to "
-"work on the video source files but you will only be able to extract the "
-"audio streams, convert them and apply audio filters such as "
-"normalization."
+"Note that by using \"Audio\" as the target, you will still be able to work on the video source files but you will only be able to extract the audio streams, convert them and apply audio filters such as normalization."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:346
 msgid "Preview video filters"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:347
 msgid "Disable active filters"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:348
-#: ../../vdms_panels/sequence_to_video.py:156
-#: ../../vdms_panels/video_to_sequence.py:113
 msgid "Resize"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:349
 msgid "Crop"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:350
 msgid "Transpose"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:352
 msgid "Denoise"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:353
 msgid "Stabilize"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:354
 msgid "Equalize"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:517
 msgid "Unable to preview Video Stabilizer filter"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:602
 msgid ""
 "Unsupported file:\n"
 "Missing decoder or library? Check FFmpeg configuration."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:611
-#: ../../vdms_panels/sequence_to_video.py:351
-#: ../../vdms_panels/video_to_sequence.py:398
 msgid "The file is not a frame or a video file"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:434
-#: ../../vdms_panels/av_conversions.py:861
-msgid ""
-"Undetected volume values! Click the \"Volume detect\" button to analyze "
-"audio volume data."
+msgid "Undetected volume values! Click the \"Volume detect\" button to analyze audio volume data."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1186
 msgid "Off"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1203
 msgid ""
 "Batch processing items\n"
 "Destination\n"
@@ -2538,150 +1741,102 @@ msgid ""
 "Clip duration"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1246
-#: ../../vdms_panels/presets_manager.py:814
 #, python-brace-format
 msgid "Write profile on «{0}»"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1266
-#: ../../vdms_panels/presets_manager.py:513
 msgid "Enter name for new preset"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1276
-#: ../../vdms_panels/presets_manager.py:524
-msgid ""
-"Invalid file name, make sure to provide a valid name including the "
-"«.json» extension"
+msgid "Invalid file name, make sure to provide a valid name including the «.json» extension"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1284
 #, python-brace-format
 msgid "Cannot save current data in file «{}»."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1289
 msgid "Open Videomass preset"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1307
 msgid "Videomass - Save new profile"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1308
 msgid "Where do you want to save this profile?"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1309
 msgid "Save the profile to a new preset"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1310
 msgid "Save the profile to an existing preset"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:69
 msgid "Welcome to Videomass"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:71
 #, python-brace-format
 msgid "Version {}"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:82
 msgid "Presets Manager"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:85
 msgid "AV-Conversions"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:88
 msgid "Concatenate media files"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:91
 msgid "Still Image Maker"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:94
 msgid "From Movie to Pictures"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:123
-msgid ""
-"Create, edit and use quickly your favorite FFmpeg presets and profiles "
-"with full formats support and codecs."
+msgid "Create, edit and use quickly your favorite FFmpeg presets and profiles with full formats support and codecs."
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:127
-msgid ""
-"A set of useful tools for audio and video conversions. Save your profiles"
-" and reuse them with Presets Manager."
+msgid "A set of useful tools for audio and video conversions. Save your profiles and reuse them with Presets Manager."
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:131
 msgid "Concatenate multiple media files based on import order without re-encoding"
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:134
-msgid ""
-"Create video from a sequence of images, based on import order, with the "
-"ability to add an audio file."
+msgid "Create video from a sequence of images, based on import order, with the ability to add an audio file."
 msgstr ""
 
-#: ../../vdms_panels/choose_topic.py:137
 msgid "Extract images (frames) from your movies in JPG, PNG, BMP, GIF formats."
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:47
 msgid "At least two files are required to perform concatenation."
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:63
 msgid "Invalid data found"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:68
-msgid ""
-"The files do not have the same \"codec_types\", same \"sample_rate\" or "
-"same \"width\" or \"height\". Unable to proceed."
+msgid "The files do not have the same \"codec_types\", same \"sample_rate\" or same \"width\" or \"height\". Unable to proceed."
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:84
 msgid ""
 "\n"
-"- The concatenation function is performed only with Audio files or only "
-"with Video files.\n"
+"- The concatenation function is performed only with Audio files or only with Video files.\n"
 "\n"
-"- The order of concatenation depends on the order in which the files were"
-" added.\n"
+"- The order of concatenation depends on the order in which the files were added.\n"
 "\n"
-"- The output file name will have the same name as the first file added "
-"(also depends on the\n"
-"  settings made in the preferences dialog or the renaming functions "
-"used).\n"
+"- The output file name will have the same name as the first file added (also depends on the\n"
+"  settings made in the preferences dialog or the renaming functions used).\n"
 "\n"
 "- Video files must have exactly same streams, same codecs and same\n"
 "  width/height, but can be wrapped in different container formats.\n"
 "\n"
-"- Audio files must have exactly the same formats, same codecs with equal "
-"sample rate."
+"- Audio files must have exactly the same formats, same codecs with equal sample rate."
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:125
 msgid "Videomass Documentation:"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:136
-#: ../../vdms_panels/sequence_to_video.py:212
-#: ../../vdms_panels/video_to_sequence.py:181
 msgid "Official FFmpeg documentation:"
 msgstr ""
 
-#: ../../vdms_panels/concatenate.py:253
 msgid ""
 "Items to concatenate\n"
 "File destination\n"
@@ -2690,289 +1845,217 @@ msgid ""
 "Duration"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:45
 msgid "File has illegal characters like:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:46
 msgid "Invalid character found in path name: (\")"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:47
 msgid "Directories are not allowed, just add files, please."
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:48
-msgid ""
-"File without format extension: please give an appropriate extension to "
-"the file name, example '.mkv', '.avi', '.mp3', etc."
+msgid "File without format extension: please give an appropriate extension to the file name, example '.mkv', '.avi', '.mp3', etc."
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:84
 #, python-brace-format
 msgid "Name has illegal characters like: {0}"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:85
 msgid "Name already in use:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:185
 msgid "Duplicate file, it has already been added to the list."
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:197
 msgid "Rejected files"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:269
 msgid "Source file"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:270
 msgid "Duration"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:271
 msgid "Media type"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:272
 msgid "Size"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:405
 msgid "Drag one or more files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:282
 msgid "Save to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:306
 msgid "Set a new destination folder for encodings"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:308
 msgid "Encodings destination folder"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:394
 msgid "Play file"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:408
 msgid "Drag two or more Audio/Video files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:412
 msgid "Drag one or more Image files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:415
 msgid "Drag one or more Video files below"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:623
 msgid "Rename the file destination"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:624
 msgid "Rename the selected file to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:638 ../../vdms_panels/filedrop.py:648
-#: ../../vdms_panels/filedrop.py:679
 msgid "Add Files"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:655
 msgid "Rename in batch"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:656
 #, python-brace-format
 msgid "Rename the {0} items to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:658
 msgid "New Name #"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:114
 msgid "Sorry, all task failed !"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:115
 msgid "The process was stopped due to a fatal error."
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:116
 msgid "Interrupted Process !"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:117
 msgid "Successfully completed !"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:118
 msgid "Not everything was successful."
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:148
 msgid "Encoding Status"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:152
 msgid "Current Log"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:354
 msgid "Fatal Error !"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:363
 msgid "Get your files at the destination you specified"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:377
 msgid "For more details please read the Current Log."
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:380
 msgid "...Finished"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:399
 msgid "Please wait... interruption in progress"
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:402
 msgid "...Interrupted"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:166
 msgid "Presets"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:180
 msgid "Write"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:184
 msgid "Delete"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:194
 msgid "Duplicate"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:199
 msgid "Profiles"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:206
 msgid "One-Pass Encoding"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:218
 msgid "Two-Pass Encoding"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:232
 msgid "Choose a preset and view its profiles"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:233
 msgid "Write a new profile and save it in the selected preset"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:235
 msgid "Delete the selected profile"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:236
 msgid "Edit the selected profile"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:237
 msgid "Duplicate the selected profile"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:238
 msgid "Create new preset"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:240
 msgid "Remove selected preset"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:242
 msgid "Backup selected preset"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:244
 msgid "Backup the presets folder"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:246
 msgid "Restore a preset"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:248
 msgid "Restore a presets folder"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:250
 msgid "Resets the selected preset to default values"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:252
 msgid "Reset all presets to default values"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:254
 msgid "Refresh the presets list"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:338
 #, python-brace-format
 msgid ""
 "Outdated presets version found: v{1}\n"
 "A new version is available: v{0}\n"
 "\n"
-"This update provides new presets included on the latest versions of "
-"Videomass.\n"
+"This update provides new presets included on the latest versions of Videomass.\n"
 "\n"
-"To avoid data loss and allow for possible recovery, the outdated presets "
-"folder will be backed up in the program configuration directory:\n"
+"To avoid data loss and allow for possible recovery, the outdated presets folder will be backed up in the program configuration directory:\n"
 "«{2}»\n"
 "\n"
 "Do you want to perform this update now?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:403
 msgid "Name"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:405
 msgid "Output Format"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:406
 msgid "Supported Format List"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:531
 #, python-brace-format
 msgid "Cannot save current data in file '{}'."
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:535
 msgid "You just successfully created a new preset!"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:547
 #, python-brace-format
 msgid ""
 "Are you sure you want to remove \"{}\" preset?\n"
@@ -2980,7 +2063,6 @@ msgid ""
 " It will be moved to the \"Removals\" subfolder inside the presets folder."
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:558
 #, python-brace-format
 msgid ""
 "{}\n"
@@ -2988,111 +2070,81 @@ msgid ""
 "Sorry, removal failed, cannot continue.."
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:568
 #, python-brace-format
 msgid "The preset \"{0}\" was successfully removed"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:583
-#: ../../vdms_panels/presets_manager.py:612
 msgid "Open a destination folder"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:588
 msgid "A file with this name already exists, do you want to overwrite it?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:602
-#: ../../vdms_panels/presets_manager.py:622
 msgid "Backup completed successfully"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:631
 msgid "Open the preset you want to restore"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:645
 msgid ""
-"This preset already exists and is about to be updated. Don't worry, it "
-"will keep all your saved profiles.\n"
+"This preset already exists and is about to be updated. Don't worry, it will keep all your saved profiles.\n"
 "\n"
 "Do you want to continue?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:663
 msgid "Restore successful"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:681
 msgid ""
-"This will update the presets database. Don't worry, it will keep all your"
-" saved profiles.\n"
+"This will update the presets database. Don't worry, it will keep all your saved profiles.\n"
 "\n"
 "Do you want to continue?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:689
 msgid "Open the presets folder to restore"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:725
 msgid "The presets database has been successfully updated"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:740
 msgid "The selected preset is not part of Videomass's default presets."
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:745
 msgid ""
-"Be careful! The selected preset will be overwritten with the default one."
-" Your profiles may be deleted!\n"
+"Be careful! The selected preset will be overwritten with the default one. Your profiles may be deleted!\n"
 "\n"
 "Do you want to continue?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:760
-#: ../../vdms_panels/presets_manager.py:794
 msgid "Successful recovery"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:769
 msgid ""
-"Be careful! This action will restore all presets to default ones. Your "
-"profiles may be deleted!\n"
+"Be careful! This action will restore all presets to default ones. Your profiles may be deleted!\n"
 "\n"
-"In any case, to avoid data loss, the presets folder will be backed up in "
-"the program's configuration directory.\n"
+"In any case, to avoid data loss, the presets folder will be backed up in the program's configuration directory.\n"
 "\n"
 "Do you want to continue?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:833
 #, python-brace-format
 msgid "Edit profile on «{0}»"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:872
-msgid ""
-"Are you sure you want to delete the selected profile? It will no longer "
-"be possible to recover it."
+msgid "Are you sure you want to delete the selected profile? It will no longer be possible to recover it."
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:891
 msgid "First select a profile in the list"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:899
 msgid ""
 "The selected profile command has been changed manually.\n"
 "Do you want to apply it during the conversion process?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:909
 msgid "Don't show this dialog again"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:1054
 msgid ""
 "Batch processing items\n"
 "Destination\n"
@@ -3104,66 +2156,49 @@ msgid ""
 "Clip duration"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:54
 msgid "Images need to be resized, please use Resize function."
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:73
 msgid ""
 "\n"
-"1. Import one or more image files such as JPG, PNG and BMP formats, then "
-"select one.\n"
+"1. Import one or more image files such as JPG, PNG and BMP formats, then select one.\n"
 "\n"
-"2. Use the Resize tool for images which have different sizes such as "
-"width and\n"
+"2. Use the Resize tool for images which have different sizes such as width and\n"
 "height. It is optional in other cases.\n"
 "\n"
-"3. Use the Timeline editor (CTRL+T) to set the time interval between "
-"images by adjusting\n"
-"the \"End\" duration value and leaving the \"Start\" value at "
-"00:00:00.000.\n"
+"3. Use the Timeline editor (CTRL+T) to set the time interval between images by adjusting\n"
+"the \"End\" duration value and leaving the \"Start\" value at 00:00:00.000.\n"
 "\n"
 "4. Run the conversion.\n"
 "\n"
 "\n"
-"The produced video will have the name of the selected file in the 'File "
-"List' panel, which\n"
-"will be saved in a folder named 'Still_Images' with a progressive digit, "
-"in the path you specify."
+"The produced video will have the name of the selected file in the 'File List' panel, which\n"
+"will be saved in a folder named 'Still_Images' with a progressive digit, in the path you specify."
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:129
 msgid "Enable a single still image"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:162
 msgid ""
 "Force original aspect ratio using\n"
 "padding rather than stretching"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:170
 msgid "Include audio file"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:173
 msgid "Play the video until audio track finishes"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:180
-#: ../../vdms_panels/sequence_to_video.py:439
 msgid "Open audio file"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:199
 msgid "Additional arguments"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:454
 msgid "Open Audio File"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:466
 #, python-brace-format
 msgid ""
 "Invalid file: '{}'\n"
@@ -3171,7 +2206,6 @@ msgid ""
 "{}"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:471
 #, python-brace-format
 msgid ""
 "Invalid file: '{}'\n"
@@ -3179,21 +2213,14 @@ msgid ""
 "It doesn't appear to be an audio file."
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:560
-#: ../../vdms_panels/sequence_to_video.py:587
-#: ../../vdms_panels/video_to_sequence.py:511
 #, python-brace-format
 msgid "Invalid file: '{}'"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:570
-#: ../../vdms_panels/sequence_to_video.py:595
 #, python-brace-format
 msgid "Unsupported format '{}'"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:576
-#: ../../vdms_panels/sequence_to_video.py:600
 #, python-brace-format
 msgid ""
 "File does not exist:\n"
@@ -3201,11 +2228,9 @@ msgid ""
 "\"{}\"\n"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:577
 msgid "ERROR"
 msgstr ""
 
-#: ../../vdms_panels/sequence_to_video.py:715
 msgid ""
 "Items to concatenate\n"
 "Output filename\n"
@@ -3221,13 +2246,11 @@ msgid ""
 "Overall video duration"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:50
 msgid ""
 "\n"
 "1. Import one or more video files, then select one.\n"
 "\n"
-"2. To select a slice of time use the Timeline editor (CTRL+T) by "
-"adjusting the\n"
+"2. To select a slice of time use the Timeline editor (CTRL+T) by adjusting the\n"
 "\"End\" and the \"Start\" duration values.\n"
 "\n"
 "3. Select an output format (jpg, png, bmp).\n"
@@ -3239,53 +2262,39 @@ msgid ""
 "with a progressive digit, in the path you specify."
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:86
 msgid "Create thumbnails"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:87
 msgid "Create tiled mosaics"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:88
 msgid "Create animated GIF"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:90
 msgid "Options"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:119
 msgid "Output format:"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:131
 msgid "Rows:"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:141
 msgid "Columns:"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:205
 msgid "Other unofficial resources:"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:229
-msgid ""
-"Set FPS control from 0.1 to 30.0 fps. The higher this value, the more "
-"images will be extracted."
+msgid "Set FPS control from 0.1 to 30.0 fps. The higher this value, the more images will be extracted."
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:232
 msgid "Spaces around the mosaic tiles. From 0 to 32 pixels"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:234
 msgid "Spaces around the mosaic borders. From 0 to 32 pixels"
 msgstr ""
 
-#: ../../vdms_panels/video_to_sequence.py:626
 msgid ""
 "Selected File\n"
 "Output Format\n"
@@ -3301,152 +2310,102 @@ msgid ""
 "Duration"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:118
 msgid "Audio encoder settings, mapping and filters"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:128
 msgid "Audio Encoder"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:137
 msgid "Settings"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:148
 msgid "Index Selection:"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:157
 msgid "Map:"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:180
 msgid "Normalization"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:191
 msgid "Volume detect"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:195
 msgid "Volume Statistics"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:199
 msgid "Target level:"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:264
-msgid ""
-"Gets maximum volume and average volume data in dBFS, then calculates the "
-"offset amount for audio normalization."
+msgid "Gets maximum volume and average volume data in dBFS, then calculates the offset amount for audio normalization."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:267
-msgid ""
-"Limiter for the maximum peak level or the mean level (when switch to RMS)"
-" in dBFS. From -99.0 to +0.0; default for PEAK level is -1.0; default for"
-" RMS is -20.0"
+msgid "Limiter for the maximum peak level or the mean level (when switch to RMS) in dBFS. From -99.0 to +0.0; default for PEAK level is -1.0; default for RMS is -20.0"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:271
 msgid ""
-"Normally on a video with correctly indexed streams and having one or more"
-" audio streams, the first audio stream should be indexed at \"1\", the "
-"second at \"2\" and so on (the video stream on the other hand is always "
-"indexed at \"0\"). In this case it is recommended to select the desired "
-"stream by setting a specific index, e.g \"1\" for for the first available"
-" audio stream.\n"
+"Normally on a video with correctly indexed streams and having one or more audio streams, the first audio stream should be indexed at \"1\", the second at \"2\" and so on (the video stream on the other hand is always indexed at \"0\"). In this case it is recommended to select the desired stream by setting a specific index, e.g \"1\" for for the first available audio stream.\n"
 "\n"
 "Set this control to \"Auto\" if the source file is simply an audio track."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:280
 msgid ""
-"\"Auto\" keeps all audio streams and processes only the one selected by "
-"the \"Index Selection\" control.\n"
+"\"Auto\" keeps all audio streams and processes only the one selected by the \"Index Selection\" control.\n"
 "\n"
-"\"All\" processes all audio streams in a video with the properties of the"
-" one selected by the \"Index Selection\" control.\n"
+"\"All\" processes all audio streams in a video with the properties of the one selected by the \"Index Selection\" control.\n"
 "\n"
-"\"Index Only\" processes only the audio stream selected by the \"Index "
-"Selection\" control and removes all others from the video"
+"\"Index Only\" processes only the audio stream selected by the \"Index Selection\" control and removes all others from the video"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:288
 msgid "Integrated Loudness Target in LUFS. From -70.0 to -5.0, default is -16.0"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:291
 msgid "Maximum True Peak in dBTP. From -1.5 to +0.0, default is -2.0"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:294
 msgid "Loudness Range Target in LUFS. From +1.0 to +20.0, default is +11.0"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:297
-msgid ""
-"Play the audio stream selected in the \"Index Selection\" control. Using "
-"this function you can test the result of audio normalization."
+msgid "Play the audio stream selected in the \"Index Selection\" control. Using this function you can test the result of audio normalization."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:503
 msgid "Selected index does not exist or does not contain any audio streams"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:508
 #, python-brace-format
 msgid ""
 "ERROR: Missing audio stream:\n"
 "\"{}\""
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:726
-msgid ""
-"PEAK level normalization, which will produce a maximum peak level equal "
-"to the set target level."
+msgid "PEAK level normalization, which will produce a maximum peak level equal to the set target level."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:729
-msgid ""
-"RMS-based normalization, which according to mean volume calculates the "
-"amount of gain to reach same average power signal."
+msgid "RMS-based normalization, which according to mean volume calculates the amount of gain to reach same average power signal."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:733
 msgid ""
-"Loudnorm normalization. Normalizes the perceived loudness using the "
-"\"loudnorm\" filter, which implements the EBU R128 algorithm.\n"
-"Ideal for live normalization. It produces worse results than the High-"
-"quality two-pass Loudnorm normalization, but is faster."
+"Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements the EBU R128 algorithm.\n"
+"Ideal for live normalization. It produces worse results than the High-quality two-pass Loudnorm normalization, but is faster."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:740
 msgid ""
-"High-quality two-pass Loudnorm normalization. Normalizes the perceived "
-"loudness using the \"loudnorm\" filter, which implements\n"
+"High-quality two-pass Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements\n"
 "the EBU R128 algorithm. Ideal for postprocessing."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:789
 msgid "You need to import at least one file"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:63
 msgid "Subtitle Mapping:"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:77
 msgid "Copy Chapters"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:79
 msgid "Copy Metadata"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:85
 msgid ""
 "Select \"All\" to include any source file subtitles in the output video.\n"
 "\n"
@@ -3455,389 +2414,200 @@ msgid ""
 "This option is automatically ignored for output audio files."
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:90
-msgid ""
-"Copy the chapter markers as is from source file. This option is "
-"automatically ignored for output audio files."
+msgid "Copy the chapter markers as is from source file. This option is automatically ignored for output audio files."
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:93
-msgid ""
-"Copy all incoming metadata from source file, such as audio/video tags, "
-"titles, unique marks, and so on."
+msgid "Copy all incoming metadata from source file, such as audio/video tags, titles, unique marks, and so on."
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:108
 msgid "Additional options"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:89
-#: ../../vdms_panels/video_encoders/av1_svt.py:120
-#: ../../vdms_panels/video_encoders/avc_x264.py:90
-#: ../../vdms_panels/video_encoders/hevc_x265.py:98
-#: ../../vdms_panels/video_encoders/mpeg4.py:71
-#: ../../vdms_panels/video_encoders/vp9_webm.py:131
 msgid "Reload"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:101
-#: ../../vdms_panels/video_encoders/av1_svt.py:129
-#: ../../vdms_panels/video_encoders/avc_x264.py:101
-#: ../../vdms_panels/video_encoders/hevc_x265.py:109
-#: ../../vdms_panels/video_encoders/mpeg4.py:82
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:97
-#: ../../vdms_panels/video_encoders/vp9_webm.py:141
 msgid "Optimize for Web"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:247
-#: ../../vdms_panels/video_encoders/av1_svt.py:313
-#: ../../vdms_panels/video_encoders/avc_x264.py:242
-#: ../../vdms_panels/video_encoders/hevc_x265.py:250
-#: ../../vdms_panels/video_encoders/mpeg4.py:198
-#: ../../vdms_panels/video_encoders/vp9_webm.py:288
 msgid "Reloads the selected video encoder settings. Changes will be discarded."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:250
-#: ../../vdms_panels/video_encoders/avc_x264.py:273
-#: ../../vdms_panels/video_encoders/hevc_x265.py:277
-#: ../../vdms_panels/video_encoders/vp9_webm.py:291
-msgid ""
-"Constant rate factor. Lower values correspond to higher quality and "
-"greater file size. Set to -1 to disable this control."
+msgid "Constant rate factor. Lower values correspond to higher quality and greater file size. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:254
-#: ../../vdms_panels/video_encoders/av1_svt.py:357
-#: ../../vdms_panels/video_encoders/vp9_webm.py:295
 msgid "Number of tile rows to use, default changes per resolution"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:256
-#: ../../vdms_panels/video_encoders/av1_svt.py:359
-#: ../../vdms_panels/video_encoders/vp9_webm.py:297
 msgid "Number of tile columns to use, default changes per resolution"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:259
-#: ../../vdms_panels/video_encoders/av1_svt.py:368
-#: ../../vdms_panels/video_encoders/avc_x264.py:253
-#: ../../vdms_panels/video_encoders/hevc_x265.py:261
-#: ../../vdms_panels/video_encoders/mpeg4.py:201
-#: ../../vdms_panels/video_encoders/vp9_webm.py:300
 msgid "Set the Group Of Picture (GOP). Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:262
-#: ../../vdms_panels/video_encoders/av1_svt.py:371
-#: ../../vdms_panels/video_encoders/avc_x264.py:256
-#: ../../vdms_panels/video_encoders/hevc_x265.py:264
-#: ../../vdms_panels/video_encoders/mpeg4.py:204
-#: ../../vdms_panels/video_encoders/vp9_webm.py:303
 msgid "It can reduce the file size, but takes longer."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:264
-#: ../../vdms_panels/video_encoders/av1_svt.py:373
-#: ../../vdms_panels/video_encoders/avc_x264.py:258
-#: ../../vdms_panels/video_encoders/hevc_x265.py:266
-#: ../../vdms_panels/video_encoders/mpeg4.py:206
-#: ../../vdms_panels/video_encoders/vp9_webm.py:305
-msgid ""
-"Set minimum bitrate tolerance. Most useful in setting up a CBR encode. It"
-" is of little use otherwise. Set to -1 to disable this control."
+msgid "Set minimum bitrate tolerance. Most useful in setting up a CBR encode. It is of little use otherwise. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:268
-#: ../../vdms_panels/video_encoders/av1_svt.py:377
-#: ../../vdms_panels/video_encoders/avc_x264.py:262
-#: ../../vdms_panels/video_encoders/hevc_x265.py:270
-#: ../../vdms_panels/video_encoders/mpeg4.py:210
-#: ../../vdms_panels/video_encoders/vp9_webm.py:309
-msgid ""
-"Specifies a maximum tolerance. Requires bufsize to be set. Set to -1 to "
-"disable this control."
+msgid "Specifies a maximum tolerance. Requires bufsize to be set. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:271
-#: ../../vdms_panels/video_encoders/av1_svt.py:380
-#: ../../vdms_panels/video_encoders/avc_x264.py:265
-#: ../../vdms_panels/video_encoders/hevc_x265.py:273
-#: ../../vdms_panels/video_encoders/mpeg4.py:213
-#: ../../vdms_panels/video_encoders/vp9_webm.py:312
-msgid ""
-"Set ratecontrol buffer size, which determines the variability of the "
-"output bitrate. Set to -1 to disable this control."
+msgid "Set ratecontrol buffer size, which determines the variability of the output bitrate. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:275
-#: ../../vdms_panels/video_encoders/av1_svt.py:384
-#: ../../vdms_panels/video_encoders/avc_x264.py:277
-#: ../../vdms_panels/video_encoders/hevc_x265.py:281
-#: ../../vdms_panels/video_encoders/mpeg4.py:231
-#: ../../vdms_panels/video_encoders/vp9_webm.py:316
-msgid ""
-"Specifies the target (average) bit rate for the encoder to use. Higher "
-"value = higher quality. Set -1 to disable this control."
+msgid "Specifies the target (average) bit rate for the encoder to use. Higher value = higher quality. Set -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:279
-#: ../../vdms_panels/video_encoders/av1_svt.py:388
-#: ../../vdms_panels/video_encoders/avc_x264.py:281
-#: ../../vdms_panels/video_encoders/hevc_x265.py:285
-#: ../../vdms_panels/video_encoders/mpeg4.py:235
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:131
-#: ../../vdms_panels/video_encoders/vp9_webm.py:320
 msgid "Video width and video height ratio."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:281
-#: ../../vdms_panels/video_encoders/av1_svt.py:390
-#: ../../vdms_panels/video_encoders/avc_x264.py:283
-#: ../../vdms_panels/video_encoders/hevc_x265.py:287
-#: ../../vdms_panels/video_encoders/mpeg4.py:237
-#: ../../vdms_panels/video_encoders/vp9_webm.py:322
-msgid ""
-"Frame rate (frames per second). Frames repeat a given number of times per"
-" second. In some countries this is 30 for NTSC, other countries (like "
-"Italy) use 25 for PAL"
+msgid "Frame rate (frames per second). Frames repeat a given number of times per second. In some countries this is 30 for NTSC, other countries (like Italy) use 25 for PAL"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:285
-msgid ""
-"Quality/Speed ratio modifier. CPU Used sets how efficient the compression"
-" will be. Lower values mean slower encoding with better quality, and "
-"vice-versa. Valid values are from 0 to 8 inclusive."
+msgid "Quality/Speed ratio modifier. CPU Used sets how efficient the compression will be. Lower values mean slower encoding with better quality, and vice-versa. Valid values are from 0 to 8 inclusive."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:290
-msgid ""
-"Quality and compression efficiency vs speed trade-off. \"good\" is the "
-"default and recommended for most applications; \"realtime\" is "
-"recommended for live/fast encoding (live streaming, video conferencing, "
-"etc); \"allintra\" for All Intra encoding."
+msgid "Quality and compression efficiency vs speed trade-off. \"good\" is the default and recommended for most applications; \"realtime\" is recommended for live/fast encoding (live streaming, video conferencing, etc); \"allintra\" for All Intra encoding."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:297
 msgid ""
-"Row Multi-Threading enables row-based multi-threading which maximizes CPU"
-" usage.\n"
+"Row Multi-Threading enables row-based multi-threading which maximizes CPU usage.\n"
 "\n"
-"To enable fast decoding performance, also set tiles (i.e. Tile Columns 4 "
-"and Tile Rows 1 or Tile Columns 2 and Tile Rows 2 for 4 tiles).\n"
+"To enable fast decoding performance, also set tiles (i.e. Tile Columns 4 and Tile Rows 1 or Tile Columns 2 and Tile Rows 2 for 4 tiles).\n"
 "\n"
-"Enabling Row Multi-Threading is only faster when the CPU has more threads"
-" than the number of encoded tiles."
+"Enabling Row Multi-Threading is only faster when the CPU has more threads than the number of encoded tiles."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:316
 msgid ""
-"presets 1-3 represent extremely high efficiency, for use when encode time"
-" is not important and quality/size of the resulting video file is "
-"critical.\n"
+"presets 1-3 represent extremely high efficiency, for use when encode time is not important and quality/size of the resulting video file is critical.\n"
 "\n"
-"Presets 4-6 are commonly used by home enthusiasts as they represent a "
-"balance of efficiency and reasonable compute time.\n"
+"Presets 4-6 are commonly used by home enthusiasts as they represent a balance of efficiency and reasonable compute time.\n"
 "\n"
 "Presets between 7 and 12 are used for fast and real-time encoding.\n"
 "\n"
-"Preset 13 is even faster but not intended for direct human consumption--"
-"it can be used, for example, as a per-scene quality metric in VOD "
-"applications. One should use the lowest preset that is tolerable."
+"Preset 13 is even faster but not intended for direct human consumption--it can be used, for example, as a per-scene quality metric in VOD applications. One should use the lowest preset that is tolerable."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:327
 msgid ""
 "Constant rate factor. This parameter governs the quality/size trade-off.\n"
 "\n"
-"Higher CRF values will result in a final output that takes less space, "
-"but begins to lose detail.\n"
+"Higher CRF values will result in a final output that takes less space, but begins to lose detail.\n"
 "\n"
-"Lower CRF values retain more detail at the cost of larger file sizes. A "
-"good starting point for 1080p video is 30.\n"
+"Lower CRF values retain more detail at the cost of larger file sizes. A good starting point for 1080p video is 30.\n"
 "\n"
 "Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:334
 msgid ""
-"The \"Film Grain\" parameter allows SVT-AV1 to detect and delete film "
-"grain from the source video, and replace it with synthetic grain of the "
-"same character, resulting in significant bitrate savings.\n"
+"The \"Film Grain\" parameter allows SVT-AV1 to detect and delete film grain from the source video, and replace it with synthetic grain of the same character, resulting in significant bitrate savings.\n"
 "\n"
-"A value of 8 is a reasonable starting point for live-action video with a "
-"normal amount of grain.\n"
+"A value of 8 is a reasonable starting point for live-action video with a normal amount of grain.\n"
 "\n"
-"Higher values in the range of 10-15 enable more aggressive use of this "
-"technique for video with lots of natural grain.\n"
+"Higher values in the range of 10-15 enable more aggressive use of this technique for video with lots of natural grain.\n"
 "\n"
-"For 2D animation, lower values in the range of 4-6 are often appropriate."
-" \n"
+"For 2D animation, lower values in the range of 4-6 are often appropriate. \n"
 "\n"
-"If the source video does not have natural grain, this parameter can be "
-"set to -1 to disable it or at least 0."
+"If the source video does not have natural grain, this parameter can be set to -1 to disable it or at least 0."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:346
 msgid ""
-"If enabled, the \"Film Grain Denoiser\" option can mitigate the detail "
-"removal caused by high \"Film Grain\" values required to preserve the "
-"look of very grainy films\n"
+"If enabled, the \"Film Grain Denoiser\" option can mitigate the detail removal caused by high \"Film Grain\" values required to preserve the look of very grainy films\n"
 "\n"
-"By default, the denoised frames are passed to be encoded as the final "
-"pictures, enabling this feature will lead to the original frames to be "
-"used instead. "
+"By default, the denoised frames are passed to be encoded as the final pictures, enabling this feature will lead to the original frames to be used instead. "
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:353
-msgid ""
-"Enables encoder optimization to produce faster (less CPU intensive) bit "
-"streams to decode, similar to the fastdecode tuning in x264 and x265."
+msgid "Enables encoder optimization to produce faster (less CPU intensive) bit streams to decode, similar to the fastdecode tuning in x264 and x265."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:362
-#: ../../vdms_panels/video_encoders/avc_x264.py:247
-#: ../../vdms_panels/video_encoders/hevc_x265.py:255
 msgid "Set profile restrictions"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:364
-#: ../../vdms_panels/video_encoders/avc_x264.py:249
-#: ../../vdms_panels/video_encoders/hevc_x265.py:257
 msgid "Specify level for a selected profile"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:366
-#: ../../vdms_panels/video_encoders/avc_x264.py:251
-#: ../../vdms_panels/video_encoders/hevc_x265.py:259
 msgid "Tune the encoding params"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/avc_x264.py:245
-#: ../../vdms_panels/video_encoders/hevc_x265.py:253
 msgid "Set the encoding preset (default \"medium\")"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/avc_x264.py:269
-msgid ""
-"specifies the target (average) bit rate for the encoder to use. Higher "
-"value = higher quality. Set -1 to disable this control."
+msgid "specifies the target (average) bit rate for the encoder to use. Higher value = higher quality. Set -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:217
-msgid ""
-"Variable Bit Rate. From 0-30, with 1 being highest quality/largest "
-"filesize and 30 being the lowest quality/smallest filesize. Set to -1 to "
-"disable this control."
+msgid "Variable Bit Rate. From 0-30, with 1 being highest quality/largest filesize and 30 being the lowest quality/smallest filesize. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:222
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:133
-msgid ""
-"Frames repeat a given number of times per second. In some countries this "
-"is 30 for NTSC, other countries (like Italy) use 25 for PAL"
+msgid "Frames repeat a given number of times per second. In some countries this is 30 for NTSC, other countries (like Italy) use 25 for PAL"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:226
-msgid ""
-"The default FourCC stored in an MPEG-4-coded file will be FMP4. If you "
-"want a different FourCC, set this option to xvid to force the FourCC xvid"
-" to be stored as the video FourCC rather than the default."
+msgid "The default FourCC stored in an MPEG-4-coded file will be FMP4. If you want a different FourCC, set this option to xvid to force the FourCC xvid to be stored as the video FourCC rather than the default."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:162
 msgid "Copy Video Codec"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:163
 msgid ""
-"This will just copy the video track as is, without any video re-encoding."
-"\n"
-"You will only be able to change output format, select other audio "
-"encoders and\n"
+"This will just copy the video track as is, without any video re-encoding.\n"
+"You will only be able to change output format, select other audio encoders and\n"
 "a few other options."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_no_enc.py:74
 msgid "Video export disabled"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_no_enc.py:75
 msgid ""
-"The Media target you just selected will only allow you to export files as"
-" audio tracks.\n"
-"You can then process audio source files only or extract indexed audio "
-"streams on\n"
+"The Media target you just selected will only allow you to export files as audio tracks.\n"
+"You can then process audio source files only or extract indexed audio streams on\n"
 "video files."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:326
 msgid ""
 "Speed sets how efficient the compression will be.\n"
 "\n"
-"When the Quality parameter is \"good\" or \"best\", values for Speed can "
-"be set between 0 and 5.\n"
+"When the Quality parameter is \"good\" or \"best\", values for Speed can be set between 0 and 5.\n"
 "\n"
-"Using 1 or 2 will increase encoding speed at the expense of having some "
-"impact on quality and rate control accuracy.\n"
+"Using 1 or 2 will increase encoding speed at the expense of having some impact on quality and rate control accuracy.\n"
 "\n"
-"4 or 5 will turn off rate distortion optimization, having even more of an"
-" impact on quality.\n"
+"4 or 5 will turn off rate distortion optimization, having even more of an impact on quality.\n"
 "\n"
-"When the Quality is set to realtime, the available values for Speed are 0"
-" to 8."
+"When the Quality is set to realtime, the available values for Speed are 0 to 8."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:335
 msgid ""
 "Time to spend encoding.\n"
 "\n"
 "\"good\" is the default and recommended for most applications;\n"
 "\n"
-"\"best\" is recommended if you have lots of time and want the best "
-"compression efficiency;\n"
+"\"best\" is recommended if you have lots of time and want the best compression efficiency;\n"
 "\n"
 "\"realtime\" is recommended for live / fast encoding."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:341
 msgid ""
-"If enabled, adds support for row based multithreading which greatly "
-"enhances the number of threads the encoder can utilise. This improves "
-"encoding speed significantly on systems that are otherwise underutilised "
-"when encoding VP9. Since the amount of additional threads depends on the "
-"number of \"tiles\", which itself depends on the video resolution, "
-"encoding higher resolution videos will see a larger performance "
-"improvement."
+"If enabled, adds support for row based multithreading which greatly enhances the number of threads the encoder can utilise. This improves encoding speed significantly on systems that are otherwise underutilised when encoding VP9. Since the amount of additional threads depends on the number of \"tiles\", which itself depends on the video resolution, encoding higher resolution videos will see a "
+"larger performance improvement."
 msgstr ""
 
-#: ../../vdms_utils/presets_manager_utils.py:46
 #, python-brace-format
 msgid "Supports ({0}) formats only, not ({1})"
 msgstr ""
 
-#: ../../vdms_utils/presets_manager_utils.py:49
 msgid "File formats not supported by the selected profile"
 msgstr ""
 
-#: ../../vdms_utils/presets_manager_utils.py:52
 msgid "Warning"
 msgstr ""
 
-#: ../../vdms_utils/presets_manager_utils.py:90
 msgid ""
 "No presets found.\n"
 "\n"
-"Possible solution: open the Presets Manager panel, go to the presets "
-"column and try to click the \"Restore all...\" button"
+"Possible solution: open the Presets Manager panel, go to the presets column and try to click the \"Restore all...\" button"
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:54
 msgid "Import queue file"
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:89
 #, python-brace-format
 msgid ""
 "ERROR: invalid data found loading queue file.\n"
@@ -3846,26 +2616,20 @@ msgid ""
 "Cannot contain multiple occurrences in `destination` keys value."
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:118
 msgid "Videomass - Add Items to Queue"
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:119
 msgid ""
-"Multiple items with identical names and destination paths cannot coexist."
-"\n"
+"Multiple items with identical names and destination paths cannot coexist.\n"
 "Please choose one of the following actions:"
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:123
 msgid "Replace occurrences with items from the imported queue."
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:124
 msgid "Add only the currently missing items to the queue."
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:125
 msgid "Remove the current queue and replace it with the imported one."
 msgstr ""
 

--- a/videomass/data/locale/zh_CN/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/zh_CN/LC_MESSAGES/videomass.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Videomass 5.0.26\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-30 11:02+0200\n"
+"POT-Creation-Date: 2025-07-30 15:28+0200\n"
 "PO-Revision-Date: 2025-04-19 11:19+0800\n"
 "Last-Translator: Gao Zimu <gaozimu_0502@163.com>\n"
 "Language: zh_CN\n"
@@ -3066,16 +3066,4 @@ msgstr "仅添加当前没有的项到队列。"
 
 msgid "Remove the current queue and replace it with the imported one."
 msgstr "移除当前队列并用导入的队列替换它。"
-
-#~ msgid "Some text boxes are still incomplete"
-#~ msgstr "一些文本框仍然不完整"
-
-#~ msgid "FFplay"
-#~ msgstr "FFplay"
-
-#~ msgid "Subtitle Mapping"
-#~ msgstr "字幕 Map"
-
-#~ msgid "Shortest"
-#~ msgstr ""
 

--- a/videomass/data/locale/zh_CN/LC_MESSAGES/videomass.po
+++ b/videomass/data/locale/zh_CN/LC_MESSAGES/videomass.po
@@ -1,13 +1,13 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2024 THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+# Chinese (Simplified, China) translations for Videomass.
+# Copyright (C) 2025 ORGANIZATION
+# This file is distributed under the same license as the Videomass project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Videomass 5.0.26\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-07-26 15:04+0200\n"
+"POT-Creation-Date: 2025-07-30 11:02+0200\n"
 "PO-Revision-Date: 2025-04-19 11:19+0800\n"
 "Last-Translator: Gao Zimu <gaozimu_0502@163.com>\n"
 "Language: zh_CN\n"
@@ -18,7 +18,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
-#: ../../gui_app.py:196
 #, python-brace-format
 msgid ""
 "Unexpected error while deleting file contents:\n"
@@ -29,165 +28,114 @@ msgstr ""
 "\n"
 "{0}"
 
-#: ../../vdms_dialogs/about_dialog.py:52
 msgid "Cross-platform graphical user interface for FFmpeg\n"
 msgstr ""
 
-#: ../../vdms_dialogs/audioproperties.py:224
 msgid "Videomass supports mono and stereo audio channels. If you are not sure set to \"Auto\" and source values will be copied."
 msgstr "Videomass 支持单声道和立体声音频通道。如果你不确定，请设置为 “Auto”，源值将被复制。"
 
-#: ../../vdms_dialogs/audioproperties.py:228
 msgid "The audio Rate (or sample-rate) is the sound sampling frequency and is measured in Hertz. The higher the frequency, the more true it will be to the sound source and the more the file will increase in size. For audio CD playback, set a sampling frequency of 44100 kHz. If you are not sure, set to \"Auto\" and source values will be copied."
 msgstr "音频速率（或采样率）是声音的采样频率，以赫兹为单位。频率越高，就越能真实反映声源，文件的大小也会增加。对于音频CD的播放，设置采样频率为44100kHz。如果你不确定，设置为 \"自动\"，声源值将被复制。"
 
-#: ../../vdms_dialogs/audioproperties.py:237
 msgid "The audio bitrate affects the file compression and thus the quality of listening. The higher the value, the higher the quality."
 msgstr "音频比特率影响文件的压缩，从而影响收听质量。该值越高，质量就越高。"
 
-#: ../../vdms_dialogs/audioproperties.py:241
 msgid "Bit depth is the number of bits of information in each sample, and it directly corresponds to the resolution of each sample. Bit depth is only meaningful in reference to a PCM digital signal. Non-PCM formats, such as lossy compression formats, do not have associated bit depths."
 msgstr "位深是指每个样本的信息位数，它直接对应于每个样本的分辨率。比特深度只有在参考 PCM 数字信号时才有意义。非 PCM 格式，如有损压缩格式，没有相关的比特深度。"
 
-#: ../../vdms_dialogs/epilogue.py:74 ../../vdms_dialogs/queuedlg.py:120
 msgid "When finished, once the operations have been completed successfully:"
 msgstr ""
 
-#: ../../vdms_dialogs/epilogue.py:80 ../../vdms_dialogs/queuedlg.py:126
 msgid "Trash the source files"
 msgstr "删除源文件"
 
-#: ../../vdms_dialogs/epilogue.py:84 ../../vdms_dialogs/queuedlg.py:130
 msgid "Clear the File List"
 msgstr "清空文件列表"
 
-#: ../../vdms_dialogs/epilogue.py:91 ../../vdms_dialogs/queuedlg.py:142
-#: ../../vdms_main/main_frame.py:1322
 msgid "Run"
 msgstr "运行"
 
-#: ../../vdms_dialogs/epilogue.py:97
 msgid "Videomass - Batch Mode"
 msgstr "Videomass - 批处理模式"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:47
 msgid "FFmpeg encoders"
 msgstr "FFmpeg 编码器"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:48
 msgid "supported encoders"
 msgstr "支持的编码器"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:50
 msgid "FFmpeg decoders"
 msgstr "FFmpeg 解码器"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:51
 msgid "supported decoders"
 msgstr "支持的解码器"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:77
-#: ../../vdms_panels/av_conversions.py:293
 msgid "Video"
 msgstr "视频"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:87
-#: ../../vdms_panels/av_conversions.py:305
 msgid "Audio"
 msgstr "音频"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:97
 msgid "Subtitle"
 msgstr "字幕"
 
-#: ../../vdms_dialogs/ffmpeg_codecs.py:114
-#: ../../vdms_dialogs/ffmpeg_codecs.py:123
-#: ../../vdms_dialogs/ffmpeg_codecs.py:132
-#: ../../vdms_dialogs/ffmpeg_formats.py:112
-#: ../../vdms_dialogs/ffmpeg_formats.py:115
-#: ../../vdms_dialogs/ffmpeg_formats.py:118
 msgid "description"
 msgstr "描述"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:72
 msgid "Informations"
 msgstr "信息"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:83
 msgid "Flags settings"
 msgstr "标记设置"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:93
 msgid "Flags enabled"
 msgstr "标记已启用"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:103
 msgid "Flags disabled"
 msgstr "标记已禁用"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:116
 msgid "FFmpeg configuration"
 msgstr "FFmpeg 配置"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:124
 msgid "flags"
 msgstr "标记"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:125 ../../vdms_dialogs/ffmpeg_conf.py:129
-#: ../../vdms_dialogs/ffmpeg_conf.py:133
 msgid "options"
 msgstr "选项"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:128 ../../vdms_dialogs/ffmpeg_conf.py:132
 msgid "status"
 msgstr "状态"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:167
 msgid "FFprobe   ...not found !"
 msgstr "FFprobe ...未找到！"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:175
 msgid "FFplay   ...not found !"
 msgstr "FFplay ...未找到！"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:205
-#: ../../vdms_panels/sequence_to_video.py:706
-#: ../../vdms_panels/video_to_sequence.py:606
 msgid "Enabled"
 msgstr "已启用"
 
-#: ../../vdms_dialogs/ffmpeg_conf.py:216
-#: ../../vdms_panels/sequence_to_video.py:706
-#: ../../vdms_panels/video_to_sequence.py:610
 msgid "Disabled"
 msgstr "已禁用"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:71
 #, fuzzy
 msgid "Demuxing only"
 msgstr "仅仅是解复用"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:82
 #, fuzzy
 msgid "Muxing only"
 msgstr "仅限多路复用"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:93
 #, fuzzy
 msgid "Demuxing/Muxing support"
 msgstr "支持解复用/复用"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:104
 msgid "FFmpeg file formats"
 msgstr "FFmpeg 文件格式"
 
-#: ../../vdms_dialogs/ffmpeg_formats.py:111
-#: ../../vdms_dialogs/ffmpeg_formats.py:114
-#: ../../vdms_dialogs/ffmpeg_formats.py:117
 msgid "supported formats"
 msgstr "支持的格式"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:46
 msgid ""
 "Contextual help based on the argument entered in the additional text field.\n"
 "Each argument consists of the type and a type-specific name.\n"
@@ -202,123 +150,90 @@ msgid ""
 "Some examples:"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:68 ../../vdms_dialogs/ffmpeg_help.py:301
-#: ../../vdms_dialogs/ffmpeg_help.py:315
 msgid "Help topic"
 msgstr "帮助主题列表"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:69
 msgid "List basic options"
 msgstr "列出基本选项"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:70
 msgid "List more options"
 msgstr "列出更多选项"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:71
 msgid "List all options (very long)"
 msgstr "列出所有选项（非常长）"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:72
 msgid "Show available devices"
 msgstr "显示可用的设备"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:73
 #, fuzzy
 msgid "Show available bit stream filters"
 msgstr "显示可用的比特流过滤器"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:74
 msgid "Show available protocols"
 msgstr "显示可用的协议"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:75
 msgid "Show available filters"
 msgstr "显示可用的滤镜"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:76
 msgid "Show available pixel formats"
 msgstr "显示可用的像素格式"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:77
 #, fuzzy
 msgid "Show available audio sample formats"
 msgstr "显示可用的音频样本格式"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:78
 msgid "Show available color names"
 msgstr "显示可用的颜色名称"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:79
 #, fuzzy
 msgid "List sources of the input device"
 msgstr "列表中输入设备的来源"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:80
 #, fuzzy
 msgid "List sinks of the output device"
 msgstr "列出输出设备的汇"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:81
 msgid "Show available HW acceleration methods"
 msgstr "显示可用的硬件加速方法"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:82
 msgid "Show license"
 msgstr "显示许可证"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:117 ../../vdms_dialogs/filter_scale.py:76
-#: ../../vdms_dialogs/shownormlist.py:98 ../../vdms_dialogs/shownormlist.py:107
-#: ../../vdms_dialogs/shownormlist.py:116 ../../vdms_miniframes/timeline.py:263
-#: ../../vdms_miniframes/timeline.py:283 ../../vdms_panels/concatenate.py:117
-#: ../../vdms_panels/sequence_to_video.py:117
-#: ../../vdms_panels/video_to_sequence.py:81
 msgid "Read me"
 msgstr "说明"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:123 ../../vdms_main/main_frame.py:534
 msgid "Show configuration"
 msgstr "显示配置"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:127 ../../vdms_main/main_frame.py:542
 msgid "Encoders"
 msgstr "编码器"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:131 ../../vdms_main/main_frame.py:545
 msgid "Decoders"
 msgstr "解码器"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:135 ../../vdms_main/main_frame.py:538
 #, fuzzy
 msgid "Muxers and Demuxers"
 msgstr "多路复用器和解扰器"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:165
 msgid "help topic list"
 msgstr "帮助主题列表"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:184
 msgid "Type the argument here and confirm with the enter key on your keyboard"
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:192
 #, fuzzy
 msgid "The search function allows you to find entries in the current topic"
 msgstr "搜索功能允许你在当前主题中查找条目"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:195
 msgid "Ignore case"
 msgstr "忽略大小写"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:196
 msgid "Ignore case distinctions: characters with different case will match."
 msgstr "忽略大小写的区别：不同大小写的字符将被匹配。"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:206
 msgid "FFmpeg help topics"
 msgstr "FFmpeg 帮助主题"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:254
 msgid ""
 "This is a multifunctional search tool useful for local help searches\n"
 "on multiple FFmpeg topics and options. The search control, to\n"
@@ -331,8 +246,6 @@ msgid ""
 "with those features."
 msgstr ""
 
-#: ../../vdms_dialogs/ffmpeg_help.py:320 ../../vdms_dialogs/ffmpeg_help.py:345
-#: ../../vdms_dialogs/ffmpeg_help.py:371
 msgid ""
 "\n"
 "  ..Nothing available"
@@ -340,7 +253,6 @@ msgstr ""
 "\n"
 "  ..没有可用的"
 
-#: ../../vdms_dialogs/ffmpeg_help.py:391
 msgid ""
 "\n"
 "  ..Not found"
@@ -348,230 +260,134 @@ msgstr ""
 "\n"
 "  ..未找到"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:91
 msgid "Before"
 msgstr "之前"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:97
 msgid "After"
 msgstr "之后"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:103
-#: ../../vdms_dialogs/filter_crop.py:239
 msgid "Search for a specific frame"
 msgstr "搜索一个指定的帧"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:117
-#: ../../vdms_dialogs/filter_crop.py:253
 msgid "Load"
 msgstr "加载"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:120
 msgid "Color EQ"
 msgstr "颜色均衡器"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:126
 #, fuzzy
 msgid "Contrast:"
 msgstr "容器："
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:134
-#: ../../vdms_dialogs/filter_colorcorrection.py:148
 msgid "-100 to +100, default value 0"
 msgstr "从 -100 到 +100，默认值 0"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:139
 msgid "Brightness:"
 msgstr "亮度："
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:158
 #, fuzzy
 msgid "Saturation:"
 msgstr "持续时间："
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:166
 msgid "0 to 300, default value 100"
 msgstr "从 0 到 300，默认值 100"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:170
 msgid "Gamma:"
 msgstr "伽马："
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:179
 msgid "0 to 100, default value 10"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:187
-#: ../../vdms_dialogs/filter_crop.py:306
-#: ../../vdms_dialogs/filter_deinterlace.py:209
-#: ../../vdms_dialogs/filter_denoisers.py:110
-#: ../../vdms_dialogs/filter_scale.py:210 ../../vdms_dialogs/filter_stab.py:316
-#: ../../vdms_dialogs/filter_transpose.py:105
-#: ../../vdms_miniframes/timeline.py:262 ../../vdms_miniframes/timeline.py:281
 msgid "Reset"
 msgstr "复位"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:207
 msgid "Color Correction EQ Tool"
 msgstr "颜色修正均衡工具"
 
-#: ../../vdms_dialogs/filter_colorcorrection.py:343
-#: ../../vdms_dialogs/filter_colorcorrection.py:383
-#: ../../vdms_dialogs/filter_colorcorrection.py:390
-#: ../../vdms_dialogs/filter_crop.py:417 ../../vdms_dialogs/filter_scale.py:287
-#: ../../vdms_dialogs/filter_scale.py:394 ../../vdms_dialogs/filter_stab.py:473
-#: ../../vdms_dialogs/filter_stab.py:483 ../../vdms_dialogs/filter_stab.py:494
-#: ../../vdms_dialogs/filter_transpose.py:182
-#: ../../vdms_dialogs/mediainfo.py:245 ../../vdms_dialogs/mediainfo.py:265
-#: ../../vdms_dialogs/mediainfo.py:285 ../../vdms_dialogs/mediainfo.py:305
-#: ../../vdms_dialogs/setting_profiles.py:281
-#: ../../vdms_dialogs/setting_profiles.py:289 ../../vdms_io/checkup.py:45
-#: ../../vdms_io/checkup.py:93 ../../vdms_io/io_tools.py:144
-#: ../../vdms_main/main_frame.py:904 ../../vdms_main/main_frame.py:939
-#: ../../vdms_main/main_frame.py:961 ../../vdms_main/main_frame.py:979
-#: ../../vdms_main/main_frame.py:999
-#: ../../vdms_panels/audio_encoders/acodecs.py:510
-#: ../../vdms_panels/audio_encoders/acodecs.py:800
-#: ../../vdms_panels/concatenate.py:186
-#: ../../vdms_panels/long_processing_task.py:60
-#: ../../vdms_panels/presets_manager.py:426
-#: ../../vdms_panels/presets_manager.py:490
-#: ../../vdms_panels/presets_manager.py:560
-#: ../../vdms_panels/presets_manager.py:599
-#: ../../vdms_panels/presets_manager.py:619
-#: ../../vdms_panels/presets_manager.py:657
-#: ../../vdms_panels/presets_manager.py:701
-#: ../../vdms_panels/presets_manager.py:714
-#: ../../vdms_panels/presets_manager.py:721
-#: ../../vdms_panels/presets_manager.py:756
-#: ../../vdms_panels/presets_manager.py:785
-#: ../../vdms_panels/presets_manager.py:791
-#: ../../vdms_panels/sequence_to_video.py:467
-#: ../../vdms_panels/sequence_to_video.py:473
-#: ../../vdms_panels/sequence_to_video.py:561
-#: ../../vdms_panels/sequence_to_video.py:571
-#: ../../vdms_panels/sequence_to_video.py:588
-#: ../../vdms_panels/sequence_to_video.py:596
-#: ../../vdms_panels/sequence_to_video.py:602
-#: ../../vdms_panels/sequence_to_video.py:643
-#: ../../vdms_panels/sequence_to_video.py:689
-#: ../../vdms_panels/video_to_sequence.py:512
-#: ../../vdms_panels/video_to_sequence.py:583
-#: ../../vdms_threads/ffplay_file.py:43
-#: ../../vdms_utils/presets_manager_utils.py:86
-#: ../../vdms_utils/presets_manager_utils.py:95
-#: ../../vdms_utils/queue_utils.py:68 ../../vdms_utils/queue_utils.py:82
-#: ../../vdms_utils/queue_utils.py:95
 msgid "Videomass - Error!"
 msgstr "Videomass - 错误！"
 
-#: ../../vdms_dialogs/filter_crop.py:228 ../../vdms_dialogs/filter_scale.py:109
 #, python-brace-format
 msgid "Source size: {0} x {1} pixels"
 msgstr "源尺寸：{0} × {1} 像素"
 
-#: ../../vdms_dialogs/filter_crop.py:236
 msgid "Crop color"
 msgstr "裁剪颜色"
 
-#: ../../vdms_dialogs/filter_crop.py:256
 msgid "Cropping area selection "
 msgstr "裁剪区的选择 "
 
-#: ../../vdms_dialogs/filter_crop.py:261 ../../vdms_dialogs/filter_scale.py:121
 msgid "Height"
 msgstr "高度"
 
-#: ../../vdms_dialogs/filter_crop.py:281
 msgid "Center"
 msgstr "中心"
 
-#: ../../vdms_dialogs/filter_crop.py:292 ../../vdms_dialogs/filter_scale.py:121
 msgid "Width"
 msgstr "宽度"
 
-#: ../../vdms_dialogs/filter_crop.py:334
 msgid "Crop Tool"
 msgstr "裁剪工具"
 
-#: ../../vdms_dialogs/filter_crop.py:335
 msgid "Choose the color to draw the cropping area"
 msgstr "选择用于显示裁剪区域的颜色"
 
-#: ../../vdms_dialogs/filter_crop.py:337
 msgid "Crop to width"
 msgstr "裁剪的宽度"
 
-#: ../../vdms_dialogs/filter_crop.py:338
 #, fuzzy
 msgid "Move vertically (set to -1 to center the vertical axis)"
 msgstr "纵向移动--设置为-1以使纵轴居中"
 
-#: ../../vdms_dialogs/filter_crop.py:340
 #, fuzzy
 msgid "Move horizontally (set to -1 to center the horizontal axis)"
 msgstr "水平移动--设置为-1，使水平轴居中。"
 
-#: ../../vdms_dialogs/filter_crop.py:342
 msgid "Crop to height"
 msgstr "裁剪的高度"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:56
 msgid "Advanced Options"
 msgstr "高级选项"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:57
-#: ../../vdms_panels/av_conversions.py:351
 msgid "Deinterlace"
 msgstr "去交错"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:59
 #, fuzzy
 msgid "Interlace"
 msgstr "隔行如隔山"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:63
 #, fuzzy
 msgid "Deinterlaces with w3fdif filter"
 msgstr "用w3fdif过滤器去隔行扫描"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:77
 #, fuzzy
 msgid "Deinterlaces with yadif filter"
 msgstr "用Yadif滤波器去隔行扫描"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:101
 #, fuzzy
 msgid "Interlaces with interlace filter"
 msgstr "带隔行扫描的隔行扫描过滤器"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:118
 #, fuzzy
 msgid "Deinterlacing and Interlacing"
 msgstr "去隔行扫描和隔行扫描"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:144
 #, fuzzy
 msgid "Deinterlace the input video with `w3fdif` filter"
 msgstr "用`w3fdif`过滤器对输入视频进行去交错处理。"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:146
 #, fuzzy
 msgid "Set the interlacing filter coefficients."
 msgstr "设置隔行扫描的系数。"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:148
-#: ../../vdms_dialogs/filter_deinterlace.py:158
 #, fuzzy
 msgid "Specify which frames to deinterlace."
 msgstr "指定哪些帧要去交错。"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:150
 #, fuzzy
 msgid "Deinterlace the input video with `yadif` filter. Using FFmpeg, this is the best and fastest choice"
 msgstr "用 \"yadif \"过滤器对输入视频进行去交错处理。使用FFmpeg，这是最好和最快的选择。"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:153
 #, fuzzy
 msgid ""
 "mode\n"
@@ -580,7 +396,6 @@ msgstr ""
 "mode/n\n"
 "要采用的隔行扫描模式。"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:155
 #, fuzzy
 msgid ""
 "parity\n"
@@ -589,12 +404,10 @@ msgstr ""
 "奇偶校验\n"
 "为输入隔行扫描视频假定的画场奇偶校验。"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:160
 #, fuzzy
 msgid "Simple interlacing filter from progressive contents."
 msgstr "来自逐行内容的简单隔行扫描。"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:162
 #, fuzzy
 msgid ""
 "scan:\n"
@@ -603,7 +416,6 @@ msgstr ""
 "scan:/n\n"
 "决定隔行扫描帧是取自逐行帧的偶数行（tff - 默认）还是奇数行（bff）。"
 
-#: ../../vdms_dialogs/filter_deinterlace.py:166
 msgid ""
 "lowpass:\n"
 "Enable (default) or disable the vertical lowpass filter to avoid twitter interlacing and reduce moire patterns.\n"
@@ -613,35 +425,28 @@ msgstr ""
 "启用（默认）或禁用垂直低通滤波器，以避免twitter交错，减少摩尔纹。\n"
 "默认为无设置。"
 
-#: ../../vdms_dialogs/filter_denoisers.py:56
 #, fuzzy
 msgid "Denoiser Filters"
 msgstr "去噪器过滤器"
 
-#: ../../vdms_dialogs/filter_denoisers.py:60
 #, fuzzy
 msgid "Enable nlmeans denoiser"
 msgstr "启用nlmeans去噪器"
 
-#: ../../vdms_dialogs/filter_denoisers.py:73
 #, fuzzy
 msgid "nlmeans options"
 msgstr "nlmeans选项"
 
-#: ../../vdms_dialogs/filter_denoisers.py:82
 #, fuzzy
 msgid "Enable hqdn3d denoiser"
 msgstr "启用hqdn3d去噪器"
 
-#: ../../vdms_dialogs/filter_denoisers.py:91
 msgid "hqdn3d options"
 msgstr "hqdn3d 选项"
 
-#: ../../vdms_dialogs/filter_denoisers.py:116
 msgid "Denoiser Tool"
 msgstr "降噪工具"
 
-#: ../../vdms_dialogs/filter_denoisers.py:117
 #, fuzzy
 msgid ""
 "nlmeans:\n"
@@ -650,7 +455,6 @@ msgstr ""
 "nlmeans:n\n"
 "使用非本地平均数算法的去噪帧能够恢复视频序列，即使有强烈的噪声。它是提高旧VHS录像带质量的理想选择。"
 
-#: ../../vdms_dialogs/filter_denoisers.py:122
 #, fuzzy
 msgid ""
 "hqdn3d:\n"
@@ -659,70 +463,53 @@ msgstr ""
 "hqdn3d:n\n"
 "这是一个高精度/高质量的三维去噪滤波器。它的目的是减少图像噪音，产生平滑的图像，使静止的图像真正静止。它应该增强可压缩性。"
 
-#: ../../vdms_dialogs/filter_scale.py:81
 msgid "View result"
 msgstr "查看结果"
 
-#: ../../vdms_dialogs/filter_scale.py:85
 msgid "New size in pixels"
 msgstr "新的尺寸，以像素为单位"
 
-#: ../../vdms_dialogs/filter_scale.py:89
 msgid "Width:"
 msgstr "宽度："
 
-#: ../../vdms_dialogs/filter_scale.py:99
 msgid "Height:"
 msgstr "高度："
 
-#: ../../vdms_dialogs/filter_scale.py:115
 msgid "Constrain proportions (keep aspect ratio)"
 msgstr "限制比例（保持长宽比）"
 
-#: ../../vdms_dialogs/filter_scale.py:120
 msgid "Which dimension to adjust?"
 msgstr "要调整哪个尺寸？"
 
-#: ../../vdms_dialogs/filter_scale.py:129
 msgid "Aspect Ratio"
 msgstr "屏幕高宽比"
 
-#: ../../vdms_dialogs/filter_scale.py:132
 #, fuzzy
 msgid "Setdar filter (display aspect ratio) example 16/9, 4/3 "
 msgstr "Setdar过滤器（显示长宽比）示例16/9，4/3 "
 
-#: ../../vdms_dialogs/filter_scale.py:137
-#: ../../vdms_dialogs/filter_scale.py:171
 #, fuzzy
 msgid "Numerator"
 msgstr "分子"
 
-#: ../../vdms_dialogs/filter_scale.py:162
-#: ../../vdms_dialogs/filter_scale.py:196
 #, fuzzy
 msgid "Denominator"
 msgstr "分母"
 
-#: ../../vdms_dialogs/filter_scale.py:166
 #, fuzzy
 msgid "Setsar filter (sample aspect ratio) example 1/1"
 msgstr "Setar滤波器（样本长宽比）示例1/1"
 
-#: ../../vdms_dialogs/filter_scale.py:217
 msgid "Resize Tool"
 msgstr "分辨率调整工具"
 
-#: ../../vdms_dialogs/filter_scale.py:218
 #, fuzzy
 msgid "Scale filter, set to 0 to disable"
 msgstr "刻度过滤器，设置为0表示禁用"
 
-#: ../../vdms_dialogs/filter_scale.py:221
 msgid "Display Aspect Ratio. Set to 0 to disable"
 msgstr "显示长宽比。设置为0以禁用"
 
-#: ../../vdms_dialogs/filter_scale.py:224
 #, fuzzy
 msgid ""
 "Sample (aka Pixel) Aspect Ratio.\n"
@@ -731,7 +518,6 @@ msgstr ""
 "Sample (aka Pixel) Aspect Ratio./n\n"
 "设置为0以禁用"
 
-#: ../../vdms_dialogs/filter_scale.py:366
 #, fuzzy
 msgid ""
 "If you want to keep the aspect ratio, select \"Constrain proportions\" below and\n"
@@ -742,184 +528,147 @@ msgstr ""
 "只指定一个维度，无论是宽度还是高度，并将另一个维度\n"
 "为-1或-2（有些编解码器需要-2，所以你应该先做一些测试）。"
 
-#: ../../vdms_dialogs/filter_stab.py:81
 msgid "Enable stabilizer"
 msgstr "启用稳定器"
 
-#: ../../vdms_dialogs/filter_stab.py:83
 msgid "Create a side-by-side comparison video"
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:88
 #, fuzzy
 msgid "Create a snapshot"
 msgstr "创建一个新的预设"
 
-#: ../../vdms_dialogs/filter_stab.py:106
-#: ../../vdms_panels/audio_encoders/acodecs.py:167
 msgid "Preview"
 msgstr "预览"
 
-#: ../../vdms_dialogs/filter_stab.py:109
 #, fuzzy
 msgid "Duration seconds:"
 msgstr "持续时间"
 
-#: ../../vdms_dialogs/filter_stab.py:118
 msgid "Video Detect"
 msgstr "视频检测"
 
-#: ../../vdms_dialogs/filter_stab.py:176
 #, fuzzy
 msgid "[TRIPOD] Enable tripod mode if checked"
 msgstr "[TRIPOD] 启用三脚架模式（如果选中）。"
 
-#: ../../vdms_dialogs/filter_stab.py:183
 msgid "Video transform"
 msgstr "视频转换"
 
-#: ../../vdms_dialogs/filter_stab.py:202
 #, fuzzy
 msgid "[OPTALGO] optimization algorithm"
 msgstr "[OPTALGO]优化算法"
 
-#: ../../vdms_dialogs/filter_stab.py:224
 #, fuzzy
 msgid "[CROP] Specify how to deal with borders at movement compensation"
 msgstr "[CROP] 指定如何处理运动补偿时的边界问题"
 
-#: ../../vdms_dialogs/filter_stab.py:231
 #, fuzzy
 msgid "[INVERT] Invert transforms if checked"
 msgstr "[INVERT] 如果勾选，则反转变换。"
 
-#: ../../vdms_dialogs/filter_stab.py:234
 #, fuzzy
 msgid "[RELATIVE] Consider transforms as relative to previous frame if checked, absolute if unchecked"
 msgstr "[RELATIVE] 如果勾选，则认为变换是相对于前一帧的，如果不勾选，则认为是绝对的。"
 
-#: ../../vdms_dialogs/filter_stab.py:279
 #, fuzzy
 msgid "Specify type of interpolation"
 msgstr "指定插值的类型"
 
-#: ../../vdms_dialogs/filter_stab.py:287
 #, fuzzy
 msgid "[TRIPOD2] virtual tripod mode, equivalent to relative=unchecked:smoothing=0"
 msgstr "[TRIPOD2]虚拟三脚架模式，相当于相对=未选中：平滑=0"
 
-#: ../../vdms_dialogs/filter_stab.py:294
 #, fuzzy
 msgid "Unsharp filter:"
 msgstr "非正弦波滤波器。"
 
-#: ../../vdms_dialogs/filter_stab.py:323
 msgid "Seek to a position on the video."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:325
 msgid "Make a snapshot of the video with the settings made."
 msgstr ""
 
-#: ../../vdms_dialogs/filter_stab.py:327
 #, fuzzy
 msgid "Set the snapshot duration from 3 to 15 seconds from the seek position, default is 5 seconds."
 msgstr "设置图像之间的时间间隔，单位是秒（从1到100秒），默认是1秒。"
 
-#: ../../vdms_dialogs/filter_stab.py:331
 #, fuzzy
 msgid "Set how shaky the video is and how quick the camera is. A value of 1 means little shakiness, a value of 10 means strong shakiness. Default value is 5."
 msgstr "设置视频的抖动程度和摄像机的速度。1的值意味着小的晃动，10的值意味着强的晃动。默认值为5。"
 
-#: ../../vdms_dialogs/filter_stab.py:335
 #, fuzzy
 msgid "Set the accuracy of the detection process. A value of 1 means low accuracy, a value of 15 means high accuracy. Default value is 15."
 msgstr "设置检测过程的准确性。值为1意味着低精确度，值为15意味着高精确度。默认值为15。"
 
-#: ../../vdms_dialogs/filter_stab.py:339
 #, fuzzy
 msgid "Set stepsize of the search process. The region around minimum is scanned with 1 pixel resolution. Default value is 6."
 msgstr "设置搜索过程的步长。最小值周围的区域以1像素的分辨率进行扫描。默认值是6。"
 
-#: ../../vdms_dialogs/filter_stab.py:343
 #, fuzzy
 msgid "Set minimum contrast. Below this value a local measurement field is discarded. The range is 0-1. Default value is 0.25."
 msgstr "设置最小对比度。低于此值的局部测量场会被丢弃。范围是0-1。默认值是0.25。"
 
-#: ../../vdms_dialogs/filter_stab.py:346
 #, fuzzy
 msgid "Set reference frame number for tripod mode. If enabled, the motion of the frames is compared to a reference frame in the filtered stream, identified by the specified number. The idea is to compensate all movements in a more-or-less static scene and keep the camera view absolutely still. The frames are counted starting from 1."
 msgstr "为三脚架模式设置参考帧号。如果启用，帧的运动将与过滤后的数据流中的参考帧进行比较，由指定的编号识别。这样做的目的是补偿或多或少静态场景中的所有运动，并保持摄像机视角绝对静止。帧数从1开始计算。"
 
-#: ../../vdms_dialogs/filter_stab.py:355
 #, fuzzy
-msgid "Set the number of frames (value*2 + 1) used for lowpass filtering the camera movements. Default value is 15. For example a number of 10 means that 21 frames are used (10 in the past and 10 in the future) to smoothen the motion in the video. A larger value leads to a smoother video, but limits the acceleration of the camera (pan/tilt movements). 0 is a special case where a static camera is simulated."
+msgid ""
+"Set the number of frames (value*2 + 1) used for lowpass filtering the camera movements. Default value is 15. For example a number of 10 means that 21 frames are used (10 in the past and 10 in the future) to smoothen the motion in the video. A larger value leads to a smoother video, but limits the acceleration of the camera (pan/tilt movements). 0 is a special case where a static camera is "
+"simulated."
 msgstr "设置用于对摄像机运动进行低通滤波的帧数（值*2+1）。默认值是15。例如，一个10的数字意味着使用21个帧（过去10个，未来10个）来平滑视频中的运动。更大的数值会导致更平滑的视频，但会限制摄像机的加速度（摇摄/倾斜运动）。0是一个模拟静态摄像机的特殊情况。"
 
-#: ../../vdms_dialogs/filter_stab.py:363
 #, fuzzy
 msgid "Set the camera path optimization algorithm. Values are: `gauss`: gaussian kernel low-pass filter on camera motion (default), and `avg`: averaging on transformations"
 msgstr "设置摄像机路径优化算法。其值为。`gauss`：摄像机运动的高斯核低通滤波器（默认），和`avg`：变换的平均数。"
 
-#: ../../vdms_dialogs/filter_stab.py:367
 #, fuzzy
 msgid "Set maximal angle in radians (degree*PI/180) to rotate frames. Default value is -1, meaning no limit."
 msgstr "设置旋转帧的最大角度，单位是弧度（度数*PI/180）。默认值是-1，意味着没有限制。"
 
-#: ../../vdms_dialogs/filter_stab.py:370
 #, fuzzy
 msgid "Specify how to deal with borders that may be visible due to movement compensation. Values are: `keep` keep image information from previous frame (default), `black` fill the border black"
 msgstr "指定如何处理由于移动补偿而可能出现的边界。数值是。`keep`保留前一帧的图像信息（默认），`black`将边界填充为黑色"
 
-#: ../../vdms_dialogs/filter_stab.py:375
 #, fuzzy
 msgid "Invert transforms if checked. Default is unchecked."
 msgstr "如果勾选，则反转变换。默认情况是不勾选。"
 
-#: ../../vdms_dialogs/filter_stab.py:377
 #, fuzzy
 msgid "Consider transforms as relative to previous frame if checked, absolute if unchecked. Default is checked."
 msgstr "如果勾选，则认为变换是相对于前一帧的，如果不勾选，则认为是绝对的。默认为选中。"
 
-#: ../../vdms_dialogs/filter_stab.py:380
 #, fuzzy
 msgid "Set percentage to zoom. A positive value will result in a zoom-in effect, a negative value in a zoom-out effect. Default value is 0 (no zoom)."
 msgstr "设置缩放的百分比。正值将导致放大的效果，负值将导致缩小的效果。默认值是0（无缩放）。"
 
-#: ../../vdms_dialogs/filter_stab.py:384
 #, fuzzy
 msgid "Set optimal zooming to avoid borders. Accepted values are: `0` disabled, `1` optimal static zoom value is determined (only very strong movements will lead to visible borders) (default), `2` optimal adaptive zoom value is determined (no borders will be visible), see zoomspeed. Note that the value given at zoom is added to the one calculated here."
 msgstr "设置最佳缩放以避免边界。可接受的值是。`0`禁用，`1`确定最佳的静态缩放值（只有非常强烈的移动才会导致可见的边界）（默认），`2`确定最佳的自适应缩放值（没有边界可见），见缩放速度。注意，在缩放时给出的值会加到这里的计算值上。"
 
-#: ../../vdms_dialogs/filter_stab.py:391
 #, fuzzy
 msgid "Set percent to zoom maximally each frame (enabled when optzoom is set to 2). Range is from 0 to 5, default value is 0.25."
 msgstr "设置每一帧最大缩放的百分比（当optzoom被设置为2时启用）。范围从0到5，默认值是0.25。"
 
-#: ../../vdms_dialogs/filter_stab.py:395
 #, fuzzy
 msgid "Specify type of interpolation. Available values are: `no` no interpolation, `linear` linear only horizontal, `bilinear` linear in both directions (default), `bicubic` cubic in both directions (slow)"
 msgstr "指定插值的类型。可用的值是。`no`不插值，`linear`只有水平方向的线性，`bilinear`两个方向的线性（默认），`bicubic`两个方向的立方（缓慢）。"
 
-#: ../../vdms_dialogs/filter_stab.py:400
 #, fuzzy
 msgid "Enable virtual tripod mode if checked, which is equivalent to relative=0:smoothing=0. Default is unchecked. Use also tripod option of vidstabdetect."
 msgstr "如果勾选，则启用虚拟三脚架模式，这相当于相对=0:平滑=0。 默认为未勾选。也可以使用vidstabdetect的三脚架选项。"
 
-#: ../../vdms_dialogs/filter_stab.py:405
 #, fuzzy
 msgid "Sharpen or blur the input video. Note the use of the unsharp filter which is always recommended."
 msgstr "对输入视频进行锐化或模糊处理。注意使用非锐化滤镜，这一点一直被推荐。"
 
-#: ../../vdms_dialogs/filter_stab.py:409
 msgid "Video Stabilizer Tool"
 msgstr "视频稳定工具"
 
-#: ../../vdms_dialogs/filter_stab.py:541 ../../vdms_io/io_tools.py:73
 msgid "Videomass - Loading..."
 msgstr "Videomass - 加载中..."
 
-#: ../../vdms_dialogs/filter_stab.py:542
 msgid ""
 "Please wait,\n"
 "This process will take a few seconds."
@@ -927,242 +676,177 @@ msgstr ""
 "请稍候，\n"
 "此过程会耗费一些时间。"
 
-#: ../../vdms_dialogs/filter_transpose.py:80
-#: ../../vdms_dialogs/filter_transpose.py:293
 msgid "Default position"
 msgstr "默认位置"
 
-#: ../../vdms_dialogs/filter_transpose.py:86
 msgid "Rotation setting"
 msgstr "旋转设置"
 
-#: ../../vdms_dialogs/filter_transpose.py:94
 msgid "90° (left)"
 msgstr "90°（左）"
 
-#: ../../vdms_dialogs/filter_transpose.py:96
 msgid "90° (right)"
 msgstr "90°（右）"
 
-#: ../../vdms_dialogs/filter_transpose.py:100
 msgid "180°"
 msgstr "180°"
 
-#: ../../vdms_dialogs/filter_transpose.py:115
 msgid "Transpose Tool"
 msgstr "旋转工具"
 
-#: ../../vdms_dialogs/filter_transpose.py:229
 msgid "Rotate 90 degrees right"
 msgstr "向右旋转 90 度"
 
-#: ../../vdms_dialogs/filter_transpose.py:251
 msgid "Rotate 180 degrees"
 msgstr "旋转 180 度"
 
-#: ../../vdms_dialogs/filter_transpose.py:272
 msgid "Rotate 90 degrees left"
 msgstr "向左旋转 90 度"
 
-#: ../../vdms_dialogs/mediainfo.py:82
 msgid "Format"
 msgstr "格式"
 
-#: ../../vdms_dialogs/mediainfo.py:96
 msgid "Video Stream"
 msgstr "视频流"
 
-#: ../../vdms_dialogs/mediainfo.py:109
 msgid "Audio Streams"
 msgstr "音频流"
 
-#: ../../vdms_dialogs/mediainfo.py:122
 msgid "Subtitle Streams"
 msgstr "字幕流"
 
-#: ../../vdms_dialogs/mediainfo.py:126
 msgid "Copy to clipboard"
 msgstr "复制到剪贴板"
 
-#: ../../vdms_dialogs/mediainfo.py:137
 msgid "FILE SELECTION"
 msgstr "文件选择"
 
-#: ../../vdms_dialogs/mediainfo.py:139 ../../vdms_dialogs/mediainfo.py:142
-#: ../../vdms_dialogs/mediainfo.py:145 ../../vdms_dialogs/mediainfo.py:148
-#: ../../vdms_main/main_frame.py:1318
 msgid "Properties"
 msgstr "属性"
 
-#: ../../vdms_dialogs/mediainfo.py:140 ../../vdms_dialogs/mediainfo.py:143
-#: ../../vdms_dialogs/mediainfo.py:146 ../../vdms_dialogs/mediainfo.py:149
 msgid "Values"
 msgstr "值"
 
-#: ../../vdms_dialogs/mediainfo.py:152
 msgid "Streams Properties"
 msgstr "流属性"
 
-#: ../../vdms_dialogs/mediainfo.py:244
 msgid "Unable to open the clipboard on Format tab"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:263
 msgid "Unable to open the clipboard on Video Streams tab"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:283
 msgid "Unable to open the clipboard on Audio Streams tab"
 msgstr ""
 
-#: ../../vdms_dialogs/mediainfo.py:303
 msgid "Unable to open the clipboard on Subtitle Streams tab"
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:90
 msgid "Where do you prefer to save your transcodes?"
 msgstr "你想在哪里保存你的转码？"
 
-#: ../../vdms_dialogs/preferences.py:101 ../../vdms_dialogs/preferences.py:128
-#: ../../vdms_dialogs/preferences.py:149 ../../vdms_dialogs/preferences.py:161
-#: ../../vdms_dialogs/preferences.py:173 ../../vdms_panels/filedrop.py:284
 msgid "Change"
 msgstr "更改"
 
-#: ../../vdms_dialogs/preferences.py:103
-#: ../../vdms_panels/av_conversions.py:1197 ../../vdms_panels/filedrop.py:602
-#: ../../vdms_panels/presets_manager.py:1050
 msgid "Same destination paths as source files"
 msgstr "使用与源文件相同的输出路径"
 
-#: ../../vdms_dialogs/preferences.py:108
 msgid "Assign optional suffix to destination file names:"
 msgstr "为输出文件名指定可选的后缀："
 
-#: ../../vdms_dialogs/preferences.py:114
 msgid "File removal preferences"
 msgstr "文件删除首选项"
 
-#: ../../vdms_dialogs/preferences.py:118
 msgid "Trash the source files after successful encoding"
 msgstr "编码成功后将源文件移至 Videomass 回收站"
 
-#: ../../vdms_dialogs/preferences.py:131
 msgid "File Preferences"
 msgstr "文件首选项"
 
-#: ../../vdms_dialogs/preferences.py:138
 msgid "Location of executables"
 msgstr "可执行文件的位置"
 
-#: ../../vdms_dialogs/preferences.py:140
 msgid ""
 "FFmpeg can be built by enabling/disabling its options and this depends on your needs.\n"
 "For some use cases it is possible to provide a custom build of FFmpeg where you can specify\n"
 "it in this preferences tab."
 msgstr ""
 
-#: ../../vdms_dialogs/preferences.py:147
 msgid "Enable a custom location to run FFmpeg"
 msgstr "启用自定义位置来运行 FFmpeg"
 
-#: ../../vdms_dialogs/preferences.py:159
 msgid "Enable a custom location to run FFprobe"
 msgstr "启用自定义位置来运行 FFprobe"
 
-#: ../../vdms_dialogs/preferences.py:171
 msgid "Enable a custom location to run FFplay"
 msgstr "启用自定义位置来运行 FFplay"
 
-#: ../../vdms_dialogs/preferences.py:183
 msgid "FFmpeg"
 msgstr "FFmpeg"
 
-#: ../../vdms_dialogs/preferences.py:189
 msgid "Look and Feel (requires application restart)"
 msgstr "外观（需要重启）"
 
-#: ../../vdms_dialogs/preferences.py:194
 msgid "Icon themes"
 msgstr "图标主题"
 
-#: ../../vdms_dialogs/preferences.py:208
 msgid "At the top of window (default)"
 msgstr "在窗口的顶部（默认）"
 
-#: ../../vdms_dialogs/preferences.py:209
 msgid "At the bottom of window"
 msgstr "在窗口的底部"
 
-#: ../../vdms_dialogs/preferences.py:210
 msgid "At the right of window"
 msgstr "在窗口的右边"
 
-#: ../../vdms_dialogs/preferences.py:211
 msgid "At the left of window"
 msgstr "在窗口的左边"
 
-#: ../../vdms_dialogs/preferences.py:213
 msgid "Place the toolbar"
 msgstr "工具栏放置位置"
 
-#: ../../vdms_dialogs/preferences.py:222
 msgid "Toolbar's icons size:"
 msgstr "工具栏图标大小："
 
-#: ../../vdms_dialogs/preferences.py:236
 msgid "Application Language (requires application restart)"
 msgstr "应用程序语言（需要重启）"
 
-#: ../../vdms_dialogs/preferences.py:248
 msgid "Look and Language"
 msgstr "外观和语言"
 
-#: ../../vdms_dialogs/preferences.py:254
 msgid "Upon exiting the application"
 msgstr "在退出应用程序时"
 
-#: ../../vdms_dialogs/preferences.py:259
 msgid "Always ask me to confirm"
 msgstr "总是要求我确认"
 
-#: ../../vdms_dialogs/preferences.py:261
 msgid "Clean the log files"
 msgstr "清理日志文件"
 
-#: ../../vdms_dialogs/preferences.py:264
 msgid "Remove cached files"
 msgstr "移除缓存文件"
 
-#: ../../vdms_dialogs/preferences.py:268
 msgid "On operations completion"
 msgstr "操作完成后"
 
-#: ../../vdms_dialogs/preferences.py:271
 msgid "These settings will remain active until the application is closed, If necessary, remember to reactivate them."
 msgstr "这些设置将一直保持有效，直到应用程序关闭。如果需要，请记住重新激活它们。"
 
-#: ../../vdms_dialogs/preferences.py:276
 msgid "Exit the application"
 msgstr "退出应用程序"
 
-#: ../../vdms_dialogs/preferences.py:279
 msgid "Shutdown the system"
 msgstr "关闭系统"
 
-#: ../../vdms_dialogs/preferences.py:283
 msgid "SUDO password:"
 msgstr "SUDO 密码："
 
-#: ../../vdms_dialogs/preferences.py:292
 msgid "Exit and Shutdown"
 msgstr "退出和关机"
 
-#: ../../vdms_dialogs/preferences.py:298
 msgid "Specify the character encoding format"
 msgstr "指定字符集编码"
 
-#: ../../vdms_dialogs/preferences.py:301
 msgid ""
 "Although UTF-8 is the default and most widely used standard encoding format, it is not the only encoding format available.\n"
 "Some file metadata may still contain non-UTF-8 character encodings resulting in the error \"'utf-8' codec can't decode bytes...\".\n"
@@ -1172,31 +856,24 @@ msgstr ""
 "一些文件的元数据可能仍然包含非 UTF-8 字符，从而导致错误 “utf-8' codec can't decode bytes...”。\n"
 "如果你知道文件使用的编码格式，你可以试试在这里指定它，例如：ISO 8859-1、ISO 8859-16 等。"
 
-#: ../../vdms_dialogs/preferences.py:311
 msgid "Character encoding:"
 msgstr "字符集编码："
 
-#: ../../vdms_dialogs/preferences.py:320
 msgid "Default application directories"
 msgstr "默认应用程序文件夹"
 
-#: ../../vdms_dialogs/preferences.py:324
 msgid "Configuration directory"
 msgstr "配置文件夹"
 
-#: ../../vdms_dialogs/preferences.py:337
 msgid "Cache directory"
 msgstr "缓存文件夹"
 
-#: ../../vdms_dialogs/preferences.py:349
 msgid "Log directory"
 msgstr "日志文件夹"
 
-#: ../../vdms_dialogs/preferences.py:363
 msgid "Advanced"
 msgstr "高级"
 
-#: ../../vdms_dialogs/preferences.py:369
 msgid ""
 "The following settings affect output messages and the log messages during transcoding processes.\n"
 "Be careful, by changing these settings some functions of the application may not work correctly,\n"
@@ -1206,123 +883,75 @@ msgstr ""
 "请谨慎调整这些设置，否则此程序的一些功能可能不能正确工作，\n"
 "仅在你知道在做什么时才更改。\n"
 
-#: ../../vdms_dialogs/preferences.py:376
 msgid "Set logging level flags used by FFmpeg"
 msgstr "设置 FFmpeg 使用的日志级别"
 
-#: ../../vdms_dialogs/preferences.py:383
 msgid "Set logging level flags used by FFplay"
 msgstr "设置 FFplay 使用的日志级别"
 
-#: ../../vdms_dialogs/preferences.py:391
 msgid "FFmpeg logging levels"
 msgstr "FFmpeg 日志级别"
 
-#: ../../vdms_dialogs/preferences.py:437
 msgid "By assigning an additional suffix you could avoid overwriting files"
 msgstr "通过指定一个额外的后缀，你可以避免覆盖文件"
 
-#: ../../vdms_dialogs/preferences.py:440
 msgid "Type sudo password here, only for Unix-like operating systems, not for MS Windows"
 msgstr "在这里输入 sudo 密码（仅使用于类 Unix 系统，不适用于 MS Windows）"
 
-#: ../../vdms_dialogs/preferences.py:443
 msgid "Preferences"
 msgstr "首选项"
 
-#: ../../vdms_dialogs/preferences.py:596 ../../vdms_dialogs/preferences.py:676
-#: ../../vdms_main/main_frame.py:879 ../../vdms_main/main_frame.py:1060
 msgid "Choose Destination"
 msgstr "选择输出目录"
 
-#: ../../vdms_dialogs/preferences.py:627
 msgid "Enter only alphanumeric characters. You can also use the hyphen (\"-\") and the underscore (\"_\"). Spaces are not allowed."
 msgstr "只允许输入字母和数字字符。你也可以使用连字符（“-”）和下划线（“_”）。不允许有空格。"
 
-#: ../../vdms_dialogs/preferences.py:642
-#: ../../vdms_dialogs/setting_profiles.py:257
-#: ../../vdms_dialogs/setting_profiles.py:264
-#: ../../vdms_dialogs/setting_profiles.py:286
-#: ../../vdms_dialogs/setting_profiles.py:309 ../../vdms_main/main_frame.py:399
-#: ../../vdms_main/main_frame.py:421 ../../vdms_panels/av_conversions.py:605
-#: ../../vdms_panels/av_conversions.py:612
-#: ../../vdms_panels/sequence_to_video.py:352
-#: ../../vdms_panels/video_to_sequence.py:399
 msgid "Videomass - Warning!"
 msgstr "Videomass - 警告！"
 
-#: ../../vdms_dialogs/preferences.py:731 ../../vdms_dialogs/preferences.py:771
-#: ../../vdms_dialogs/preferences.py:811 ../../vdms_dialogs/wizard_dlg.py:365
-#: ../../vdms_dialogs/wizard_dlg.py:384 ../../vdms_dialogs/wizard_dlg.py:403
 #, python-brace-format
 msgid "{} location"
 msgstr "{} 位置"
 
-#: ../../vdms_dialogs/queue_edit.py:36
-#: ../../vdms_dialogs/setting_profiles.py:38
 #, fuzzy
 msgid "One-Pass, Do not start with `ffmpeg -i filename`; do not end with `output-filename`"
 msgstr "一次性通过，不要以`ffmpeg -i filename`开始；不要以`output-filename`结束。"
 
-#: ../../vdms_dialogs/queue_edit.py:40
-#: ../../vdms_dialogs/setting_profiles.py:42
 #, fuzzy
 msgid "Two-Pass (optional), Do not start with `ffmpeg -i filename`; do not end with `output-filename`"
 msgstr "两次通过（可选），不要以`ffmpeg -i filename`开始；不要以`output-filename`结束。"
 
-#: ../../vdms_dialogs/queue_edit.py:59
 msgid "Videomass - Edit the selected item in the queue"
 msgstr "Videomass - 编辑队列中选择的项"
 
-#: ../../vdms_dialogs/queue_edit.py:71
-#: ../../vdms_dialogs/setting_profiles.py:92
 msgid "Pre-input arguments for One-Pass (optional)"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:82
-#: ../../vdms_dialogs/setting_profiles.py:151
-#: ../../vdms_panels/presets_manager.py:255
 msgid "FFmpeg arguments for one-pass encoding"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:88
-#: ../../vdms_dialogs/setting_profiles.py:158
-#: ../../vdms_panels/presets_manager.py:259
 msgid "Any optional arguments to add before input file on the one-pass encoding, e.g required names of some hardware accelerations like -hwaccel to use with CUDA."
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:102
-#: ../../vdms_dialogs/setting_profiles.py:98
 msgid "Pre-input arguments for Two-Pass (optional)"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:113
-#: ../../vdms_dialogs/setting_profiles.py:152
-#: ../../vdms_panels/presets_manager.py:257
 msgid "FFmpeg arguments for two-pass encoding"
 msgstr ""
 
-#: ../../vdms_dialogs/queue_edit.py:120
-#: ../../vdms_dialogs/setting_profiles.py:162
-#: ../../vdms_panels/presets_manager.py:263
 msgid "Any optional arguments to add before input file on the two-pass encoding, e.g required names of some hardware accelerations like -hwaccel to use with CUDA."
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:65 ../../vdms_main/main_frame.py:508
-#: ../../vdms_panels/presets_manager.py:189
-#: ../../vdms_panels/video_to_sequence.py:171
 msgid "Edit"
 msgstr "编辑"
 
-#: ../../vdms_dialogs/queuedlg.py:68
 msgid "Remove"
 msgstr "移除"
 
-#: ../../vdms_dialogs/queuedlg.py:71
 msgid "Remove all"
 msgstr "移除所有"
 
-#: ../../vdms_dialogs/queuedlg.py:74
 msgid ""
 "Export\n"
 "queue file"
@@ -1330,7 +959,6 @@ msgstr ""
 "导出\n"
 "队列文件"
 
-#: ../../vdms_dialogs/queuedlg.py:77
 msgid ""
 "Import\n"
 "queue file"
@@ -1338,29 +966,21 @@ msgstr ""
 "导入\n"
 "队列文件"
 
-#: ../../vdms_dialogs/queuedlg.py:85 ../../vdms_panels/filedrop.py:273
 msgid "Destination file name"
 msgstr "目标文件名"
 
-#: ../../vdms_dialogs/queuedlg.py:137
 msgid "Remove all items in the queue"
 msgstr "移除队列中的所有项"
 
-#: ../../vdms_dialogs/queuedlg.py:151
 msgid "Videomass - Queue"
 msgstr "Videomass - 队列"
 
-#: ../../vdms_dialogs/queuedlg.py:228
 msgid "Export queue file"
 msgstr "导出队列文件"
 
-#: ../../vdms_dialogs/queuedlg.py:296 ../../vdms_panels/av_conversions.py:1192
-#: ../../vdms_panels/presets_manager.py:1044
-#: ../../vdms_panels/video_to_sequence.py:600
 msgid "Same as source"
 msgstr ""
 
-#: ../../vdms_dialogs/queuedlg.py:301
 #, fuzzy
 msgid ""
 "Source\n"
@@ -1385,194 +1005,137 @@ msgstr ""
 "Time Period （时间周期\n"
 "Input Audio Map"
 
-#: ../../vdms_dialogs/renamer.py:76
 msgid "# will be replaced by ascending numbers starting with:"
 msgstr ""
 
-#: ../../vdms_dialogs/set_timestamp.py:87
 msgid "Font Size"
 msgstr "字体大小"
 
-#: ../../vdms_dialogs/set_timestamp.py:111
 msgid "Font Color"
 msgstr "字体颜色"
 
-#: ../../vdms_dialogs/set_timestamp.py:121
 msgid "Shadow Color"
 msgstr "阴影颜色"
 
-#: ../../vdms_dialogs/set_timestamp.py:132
 msgid "Show text box"
 msgstr "显示文本框"
 
-#: ../../vdms_dialogs/set_timestamp.py:136
 msgid "Box Color"
 msgstr "框的颜色"
 
-#: ../../vdms_dialogs/set_timestamp.py:156
 msgid "The timestamp size does not auto-adjust to the video size, you have to set the size here"
 msgstr "时间戳的大小不会根据视频的大小自动调整，你必须在这里设置大小"
 
-#: ../../vdms_dialogs/set_timestamp.py:160 ../../vdms_main/main_frame.py:559
 msgid "Timestamp settings"
 msgstr "时间戳设置"
 
-#: ../../vdms_dialogs/setting_profiles.py:46
 msgid "Supported Formats list (optional). Do not include the `.`"
 msgstr "支持的格式列表（可选）。不要包括 “.”"
 
-#: ../../vdms_dialogs/setting_profiles.py:47
 msgid "Output Format. Empty to copy format and codec. Do not include the `.`"
 msgstr "输出格式。清空以复制格式和编解码器。不要包括\".\""
 
-#: ../../vdms_dialogs/setting_profiles.py:70
 msgid "Profile Name"
 msgstr "配置文件名称"
 
-#: ../../vdms_dialogs/setting_profiles.py:74
-#: ../../vdms_panels/presets_manager.py:404
 msgid "Description"
 msgstr "描述"
 
-#: ../../vdms_dialogs/setting_profiles.py:149
 msgid "A short profile name"
 msgstr "一个简短的配置文件名称"
 
-#: ../../vdms_dialogs/setting_profiles.py:150
 msgid "A long description of the profile"
 msgstr "对配置文件的长篇描述"
 
-#: ../../vdms_dialogs/setting_profiles.py:153
 msgid "One or more comma-separated format names compatible with this profile"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:155
 msgid "Output format extension. Leave empty to copy codec and format"
 msgstr "输出格式的扩展名。留空以复制编解码器和格式"
 
-#: ../../vdms_dialogs/setting_profiles.py:256
 #, fuzzy
 msgid "Incomplete profile assignments"
 msgstr "不完整的个人资料分配"
 
-#: ../../vdms_dialogs/setting_profiles.py:263
 msgid "Formats must be comma-separated"
 msgstr "格式必须是以逗号分隔的"
 
-#: ../../vdms_dialogs/setting_profiles.py:279
-#: ../../vdms_utils/queue_utils.py:80
 #, python-brace-format
 msgid ""
 "ERROR: Keys mismatched for requested data.\n"
 "Invalid file: «{0}»"
 msgstr ""
 
-#: ../../vdms_dialogs/setting_profiles.py:285
-#: ../../vdms_dialogs/setting_profiles.py:308
 msgid "Profile already stored with same name"
 msgstr "已有相同名称的配置文件"
 
-#: ../../vdms_dialogs/setting_profiles.py:293
 msgid "Profile stored successfully!"
 msgstr "配置文件保存完成！"
 
-#: ../../vdms_dialogs/setting_profiles.py:311
 msgid "Profile change successful!"
 msgstr "配置文件更改完成！"
 
-#: ../../vdms_dialogs/showlogs.py:80
 msgid "Log file list"
 msgstr "日志文件列表"
 
-#: ../../vdms_dialogs/showlogs.py:82 ../../vdms_dialogs/showlogs.py:116
 msgid "Log messages"
 msgstr "日志信息"
 
-#: ../../vdms_dialogs/showlogs.py:105
 msgid "Refresh log messages"
 msgstr "刷新日志消息"
 
-#: ../../vdms_dialogs/showlogs.py:107
 msgid "Clear log messages"
 msgstr "清空日志消息"
 
-#: ../../vdms_dialogs/showlogs.py:160
 msgid "Select a log file"
 msgstr "选择一个日志文件"
 
-#: ../../vdms_dialogs/showlogs.py:167
 msgid "Are you sure you want to clear the selected log file?"
 msgstr "你确定要清除选定的日志文件吗？"
 
-#: ../../vdms_dialogs/showlogs.py:168 ../../vdms_dialogs/wizard_dlg.py:251
-#: ../../vdms_io/checkup.py:68 ../../vdms_main/main_frame.py:205
-#: ../../vdms_main/main_frame.py:798 ../../vdms_main/main_frame.py:1685
-#: ../../vdms_panels/presets_manager.py:349
-#: ../../vdms_panels/presets_manager.py:550
-#: ../../vdms_panels/presets_manager.py:590
-#: ../../vdms_panels/presets_manager.py:649
-#: ../../vdms_panels/presets_manager.py:684
-#: ../../vdms_panels/presets_manager.py:749
-#: ../../vdms_panels/presets_manager.py:775
-#: ../../vdms_panels/presets_manager.py:874
-#: ../../vdms_panels/presets_manager.py:904
 msgid "Please confirm"
 msgstr "请确认"
 
-#: ../../vdms_dialogs/shownormlist.py:83
 msgid "File name"
 msgstr "文件名称"
 
-#: ../../vdms_dialogs/shownormlist.py:84
 msgid "Max volume dBFS"
 msgstr "最大音量 dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:85
 msgid "Mean volume dBFS"
 msgstr "平均音量 dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:86
 #, fuzzy
 msgid "Offset dBFS"
 msgstr "偏移量dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:87
 #, fuzzy
 msgid "Result dBFS"
 msgstr "结果dBFS"
 
-#: ../../vdms_dialogs/shownormlist.py:92
 msgid "Post-normalization references:"
 msgstr ""
 
-#: ../../vdms_dialogs/shownormlist.py:102
 #, fuzzy
 msgid "=  Clipped peaks"
 msgstr "= 削减的峰值"
 
-#: ../../vdms_dialogs/shownormlist.py:111
 #, fuzzy
 msgid "=  No changes"
 msgstr "= 没有变化"
 
-#: ../../vdms_dialogs/shownormlist.py:121
 #, fuzzy
 msgid "=  Below max peak"
 msgstr "=低于最大峰值"
 
-#: ../../vdms_dialogs/shownormlist.py:166
-#: ../../vdms_panels/audio_encoders/acodecs.py:841
 #, fuzzy
 msgid "RMS-based volume statistics"
 msgstr "基于RMS的体积统计"
 
-#: ../../vdms_dialogs/shownormlist.py:191
-#: ../../vdms_panels/audio_encoders/acodecs.py:839
 #, fuzzy
 msgid "PEAK-based volume statistics"
 msgstr "基于PEAK的体积统计"
 
-#: ../../vdms_dialogs/shownormlist.py:216
 #, fuzzy
 msgid ""
 "...It means the resulting audio will be clipped,\n"
@@ -1587,7 +1150,6 @@ msgstr ""
 "水平。这将导致数据丢失，音频可能会\n"
 "声音失真。"
 
-#: ../../vdms_dialogs/shownormlist.py:242
 #, fuzzy
 msgid ""
 "...It means the resulting audio will not change,\n"
@@ -1598,7 +1160,6 @@ msgstr ""
 "...这意味着所产生的音频不会改变，因为它与源文件相同。\n"
 "因为它和源头是一样的。"
 
-#: ../../vdms_dialogs/shownormlist.py:266
 #, fuzzy
 msgid ""
 "...It means an audio signal will be produced with\n"
@@ -1609,15 +1170,12 @@ msgstr ""
 "...这意味着将产生一个音频信号，\n"
 "其音量比原来的低。"
 
-#: ../../vdms_dialogs/videomass_check_version.py:63
 msgid "Get Latest Version"
 msgstr "获取最新版本"
 
-#: ../../vdms_dialogs/videomass_check_version.py:67
 msgid "Checking for newer version"
 msgstr "检查更新的版本"
 
-#: ../../vdms_dialogs/videomass_check_version.py:95
 msgid ""
 "\n"
 "\n"
@@ -1627,7 +1185,6 @@ msgstr ""
 "\n"
 "新版本修复了错误并提供了新的功能。"
 
-#: ../../vdms_dialogs/videomass_check_version.py:96
 #, python-brace-format
 msgid ""
 "\n"
@@ -1640,7 +1197,6 @@ msgstr ""
 "这是 Videomass v.{0}\n"
 "\n"
 
-#: ../../vdms_dialogs/while_playing.py:37
 #, fuzzy
 msgid ""
 "q, ESC\n"
@@ -1683,65 +1239,51 @@ msgstr ""
 "right mouse click （鼠标右键）。\n"
 "鼠标左键双击"
 
-#: ../../vdms_dialogs/while_playing.py:92
 msgid "Shortcut keys while playing with FFplay"
 msgstr "使用 FFplay 时的快捷键"
 
-#: ../../vdms_dialogs/widget_utils.py:120 ../../vdms_main/main_frame.py:1326
 msgid "Stop"
 msgstr "停止"
 
-#: ../../vdms_dialogs/wizard_dlg.py:63
 msgid "Please take a moment to set up the application"
 msgstr "请花一点时间来设置应用程序"
 
-#: ../../vdms_dialogs/wizard_dlg.py:64
 msgid "Click the \"Next\" button to get started"
 msgstr "点击 “下一步” 按钮，开始使用"
 
-#: ../../vdms_dialogs/wizard_dlg.py:79
 msgid "Welcome to the Videomass Wizard!"
 msgstr "欢迎来到 Videomass 向导!"
 
-#: ../../vdms_dialogs/wizard_dlg.py:123
 msgid "Videomass is an application based on FFmpeg\n"
 msgstr "Videomass 是一个基于 FFmpeg 的应用程序。\n"
 
-#: ../../vdms_dialogs/wizard_dlg.py:125
 msgid "If FFmpeg is not on your computer, this application will be unusable"
 msgstr "如果你的电脑上没有 FFmpeg，这个应用程序将无法使用"
 
-#: ../../vdms_dialogs/wizard_dlg.py:128
 msgid ""
 "If you have already installed FFmpeg on your operating system,\n"
 "click the \"Auto-detection\" button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:131
 msgid ""
 "If you want to use a version of FFmpeg located on your filesystem\n"
 "but not installed on your operating system,\n"
 "click the \"Locate\" button."
 msgstr ""
 
-#: ../../vdms_dialogs/wizard_dlg.py:162
 msgid "Auto-detection"
 msgstr "自动检测"
 
-#: ../../vdms_dialogs/wizard_dlg.py:164
 msgid "Locate"
 msgstr "定位"
 
-#: ../../vdms_dialogs/wizard_dlg.py:214
 msgid "Click the \"Next\" button"
 msgstr "点击 “下一步” 按钮"
 
-#: ../../vdms_dialogs/wizard_dlg.py:235
 #, python-brace-format
 msgid "'{}' is not installed on your computer. Install it or indicate another location by clicking the 'Locate' button."
 msgstr "你的电脑上没有安装 “{}”。安装它或通过点击 “定位” 按钮指出其他位置。"
 
-#: ../../vdms_dialogs/wizard_dlg.py:249
 msgid ""
 "Videomass already seems to include FFmpeg.\n"
 "\n"
@@ -1751,11 +1293,9 @@ msgstr ""
 "\n"
 "你想用这个吗？"
 
-#: ../../vdms_dialogs/wizard_dlg.py:275
 msgid "Locating FFmpeg executables\n"
 msgstr "定位 FFmpeg 可执行文件\n"
 
-#: ../../vdms_dialogs/wizard_dlg.py:277
 msgid ""
 "\"ffmpeg\", \"ffprobe\" and \"ffplay\" are required. Complete all\n"
 "the text boxes below by clicking on the respective buttons."
@@ -1763,40 +1303,30 @@ msgstr ""
 "“ffmpeg”、“ffprobe” 和 “ffplay” 是必需的。\n"
 "请点击相应的按钮来完成下方所有文本框的填写。"
 
-#: ../../vdms_dialogs/wizard_dlg.py:437
 msgid "Wizard completed successfully!\n"
 msgstr "向导已成功完成！\n"
 
-#: ../../vdms_dialogs/wizard_dlg.py:438
 msgid "Remember that you can always change these settings later, through the Preferences dialog."
 msgstr "你可以随时在“首选项”中更改这些设置。"
 
-#: ../../vdms_dialogs/wizard_dlg.py:440
 msgid "Thank You!"
 msgstr "谢谢你！"
 
-#: ../../vdms_dialogs/wizard_dlg.py:441
 msgid "To exit click the \"Finish\" button"
 msgstr "要退出，请点击“完成”按钮"
 
-#: ../../vdms_dialogs/wizard_dlg.py:527
 msgid "< Previous"
 msgstr "< 上一步"
 
-#: ../../vdms_dialogs/wizard_dlg.py:530 ../../vdms_dialogs/wizard_dlg.py:613
 msgid "Next >"
 msgstr "下一步 >"
 
-#: ../../vdms_dialogs/wizard_dlg.py:535
 msgid "Videomass Wizard"
 msgstr "Videomass 向导"
 
-#: ../../vdms_dialogs/wizard_dlg.py:563 ../../vdms_dialogs/wizard_dlg.py:586
-#: ../../vdms_dialogs/wizard_dlg.py:591
 msgid "Finish"
 msgstr "完成"
 
-#: ../../vdms_io/checkup.py:44 ../../vdms_io/checkup.py:92
 #, python-brace-format
 msgid ""
 "Output folder does not exist:\n"
@@ -1807,32 +1337,25 @@ msgstr ""
 "\n"
 "“{}”\n"
 
-#: ../../vdms_io/checkup.py:65
 msgid "Files already exist, do you want to overwrite them?"
 msgstr "文件已存在，你想覆盖它吗？"
 
-#: ../../vdms_io/checkup.py:67
 msgid "Already exist"
 msgstr "已存在"
 
-#: ../../vdms_io/checkup.py:81
 msgid "Not found"
 msgstr "未找到"
 
-#: ../../vdms_io/checkup.py:82 ../../vdms_panels/filedrop.py:196
 msgid "Error list"
 msgstr "错误列表"
 
-#: ../../vdms_io/checkup.py:83
 msgid "File(s) not found"
 msgstr "文件未找到"
 
-#: ../../vdms_io/io_tools.py:56
 #, python-format
 msgid "File does not exist or is invalid:  %s"
 msgstr "文件不存在或无效：%s"
 
-#: ../../vdms_io/io_tools.py:74
 #, fuzzy
 msgid ""
 "Wait....\n"
@@ -1841,363 +1364,272 @@ msgstr ""
 "Wait....\n"
 "音频峰值分析。"
 
-#: ../../vdms_io/io_tools.py:179
 msgid "Videomass - Downloading..."
 msgstr "Videomass - 下载中..."
 
-#: ../../vdms_main/main_frame.py:186 ../../vdms_main/main_frame.py:1409
-#: ../../vdms_main/main_frame.py:1441
 msgid "Ready"
 msgstr "准备就绪"
 
-#: ../../vdms_main/main_frame.py:203
 msgid ""
 "Not all items in the queue were completed.\n"
 "\n"
 "Would you like to keep them in the queue?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:224
 #, python-brace-format
 msgid "Queue ({0})"
 msgstr "队列（{0}）"
 
-#: ../../vdms_main/main_frame.py:229 ../../vdms_main/main_frame.py:1334
 msgid "Queue"
 msgstr "队列"
 
-#: ../../vdms_main/main_frame.py:396 ../../vdms_main/main_frame.py:418
 msgid "There are still active windows with running processes, make sure you finish your work before exit."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:403
 msgid "Are you sure you want to exit the application?"
 msgstr "确定要退出吗？"
 
-#: ../../vdms_main/main_frame.py:405
 msgid "Exit"
 msgstr "退出"
 
-#: ../../vdms_main/main_frame.py:463
 msgid "Import files\tCtrl+O"
 msgstr "导入文件\tCtrl+O"
 
-#: ../../vdms_main/main_frame.py:466
 msgid "Open destination folder of encodings\tCtrl+D"
 msgstr "打开编码输出文件夹\tCtrl+D"
 
-#: ../../vdms_main/main_frame.py:469
 msgid "Load queue file"
 msgstr "加载队列文件"
 
-#: ../../vdms_main/main_frame.py:470
 msgid "Load a previously exported queue file"
 msgstr "加载一个之前导出的配置文件"
 
-#: ../../vdms_main/main_frame.py:473
 msgid "Open trash"
 msgstr "打开回收站"
 
-#: ../../vdms_main/main_frame.py:474
 msgid "Open the Videomass trash folder"
 msgstr "打开 Videomass 回收站"
 
-#: ../../vdms_main/main_frame.py:476
 msgid "Empty trash"
 msgstr "清空回收站"
 
-#: ../../vdms_main/main_frame.py:477
 msgid "Delete all files in the Videomass trash folder"
 msgstr "删除 Videomass 回收站中的所有文件"
 
-#: ../../vdms_main/main_frame.py:480
 msgid "Exit\tCtrl+Q"
 msgstr "退出\tCtrl+Q"
 
-#: ../../vdms_main/main_frame.py:481
 msgid "Completely exit the application"
 msgstr "完全退出应用程序"
 
-#: ../../vdms_main/main_frame.py:482
 msgid "File"
 msgstr "文件"
 
-#: ../../vdms_main/main_frame.py:486 ../../vdms_panels/filedrop.py:340
-#: ../../vdms_panels/filedrop.py:381
 msgid "Rename selected file\tCtrl+R"
 msgstr "重命名选中的文件\tCtrl+R"
 
-#: ../../vdms_main/main_frame.py:487
 msgid "Rename the destination of the selected file"
 msgstr "重命名选中的文件的输出"
 
-#: ../../vdms_main/main_frame.py:490 ../../vdms_panels/filedrop.py:341
-#: ../../vdms_panels/filedrop.py:384
 msgid "Batch rename files\tCtrl+B"
 msgstr "批量重命名\tCtrl+B"
 
-#: ../../vdms_main/main_frame.py:491
 msgid "Numerically renames the destination of all items in the list"
 msgstr "对列表中的所有项目目标按数字顺序重命名"
 
-#: ../../vdms_main/main_frame.py:496 ../../vdms_panels/filedrop.py:343
-#: ../../vdms_panels/filedrop.py:388
 msgid "Remove selected entry\tDEL"
 msgstr "移除选中项\tDEL"
 
-#: ../../vdms_main/main_frame.py:497
 msgid "Remove the selected file from the list"
 msgstr "从列表中移除选定的文件"
 
-#: ../../vdms_main/main_frame.py:500 ../../vdms_panels/filedrop.py:344
-#: ../../vdms_panels/filedrop.py:391
 msgid "Clear list\tShift+DEL"
 msgstr "清空列表\tShift+DEL"
 
-#: ../../vdms_main/main_frame.py:501
 msgid "Clear the file list"
 msgstr "清空文件列表"
 
-#: ../../vdms_main/main_frame.py:506
 msgid "Preferences\tCtrl+P"
 msgstr "首选项\tCtrl+P"
 
-#: ../../vdms_main/main_frame.py:507
 msgid "Application preferences"
 msgstr "应用程序首选项"
 
-#: ../../vdms_main/main_frame.py:512
 msgid "Find FFmpeg topics"
 msgstr "搜索 FFmpeg 帮助主题"
 
-#: ../../vdms_main/main_frame.py:513
 msgid "A useful tool to search for FFmpeg help topics and options"
 msgstr "一个搜索 FFmpeg 帮助主题和选项的有用工具"
 
-#: ../../vdms_main/main_frame.py:518
 msgid "Check for preset updates"
 msgstr "检查预设更新"
 
-#: ../../vdms_main/main_frame.py:519
 #, python-brace-format
 msgid "Check for new presets updates from {0}"
 msgstr "从 {0} 检查预设更新"
 
-#: ../../vdms_main/main_frame.py:521
 msgid "Get latest presets"
 msgstr "获取最新的预设"
 
-#: ../../vdms_main/main_frame.py:522
 #, python-brace-format
 msgid "Get the latest presets from {0}"
 msgstr "从 {0} 获取最新的预设"
 
-#: ../../vdms_main/main_frame.py:525
 #, fuzzy
 msgid "Work notes\tCtrl+N"
 msgstr "工作笔记\tCtrl+N"
 
-#: ../../vdms_main/main_frame.py:526
 #, fuzzy
 msgid "Read and write useful notes and reminders."
 msgstr "阅读和撰写有用的笔记和提醒。"
 
-#: ../../vdms_main/main_frame.py:528
 msgid "Tools"
 msgstr "工具"
 
-#: ../../vdms_main/main_frame.py:535
 msgid "Show FFmpeg's built-in configuration capabilities"
 msgstr "显示 FFmpeg 的内置配置功能"
 
-#: ../../vdms_main/main_frame.py:539
 msgid "Muxers and demuxers available on your version of FFmpeg"
 msgstr "在你的 FFmpeg 版本可用的复用器（Muxers）与解复用器（Demuxers）"
 
-#: ../../vdms_main/main_frame.py:543
 msgid "Encoders available on your version of FFmpeg"
 msgstr "在你的 FFmpeg 版本可用的编码器"
 
-#: ../../vdms_main/main_frame.py:546
 msgid "Decoders available on your version of FFmpeg"
 msgstr "在你的 FFmpeg 版本可用的解码器"
 
-#: ../../vdms_main/main_frame.py:550
 msgid "Enable timestamps on playback"
 msgstr "在播放时显示时间戳"
 
-#: ../../vdms_main/main_frame.py:551
 msgid "Displays timestamp when playing media with FFplay"
 msgstr "用 FFplay 播放媒体时显示时间戳"
 
-#: ../../vdms_main/main_frame.py:554
 msgid "Auto-exit after playback"
 msgstr "播放后自动退出"
 
-#: ../../vdms_main/main_frame.py:555
 msgid "If checked, the FFplay window will auto-close when playback is complete"
 msgstr "如果勾选，FFplay 窗口将在播放结束后自动关闭"
 
-#: ../../vdms_main/main_frame.py:559
 msgid "Customize the timestamp style"
 msgstr "自定义时间戳样式"
 
-#: ../../vdms_main/main_frame.py:562
 msgid "While playing..."
 msgstr "在播放时..."
 
-#: ../../vdms_main/main_frame.py:563
 msgid "Show useful shortcut keys when playing or previewing using FFplay"
 msgstr "显示在用 FFplay 播放或预览时有用的快捷键"
 
-#: ../../vdms_main/main_frame.py:567
 msgid "Show timeline editor\tCtrl+T"
 msgstr "显示时间线编辑器\tCtrl+T"
 
-#: ../../vdms_main/main_frame.py:568
 msgid "Set duration or trim slices of time to remove unwanted parts from your files"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:572
 msgid "View"
 msgstr "视图"
 
-#: ../../vdms_main/main_frame.py:579
 msgid "Home panel\tCtrl+Shift+H"
 msgstr "主界面\tCtrl+Shift+H"
 
-#: ../../vdms_main/main_frame.py:580
 msgid "Go to the «Home» panel"
 msgstr "转到 «主页» 面板"
 
-#: ../../vdms_main/main_frame.py:583
 msgid "Presets Manager\tCtrl+Shift+P"
 msgstr "预设管理器\tCtrl+Shift+P"
 
-#: ../../vdms_main/main_frame.py:584
 msgid "Go to the «Presets Manager» panel"
 msgstr "转到 «预设管理器» 面板"
 
-#: ../../vdms_main/main_frame.py:586
 msgid "A/V Conversions\tCtrl+Shift+V"
 msgstr "音频、视频转换\tCtrl+Shift+V"
 
-#: ../../vdms_main/main_frame.py:587
 msgid "Go to the «A/V Conversions» panel"
 msgstr "转到 «音频、视频转换» 面板"
 
-#: ../../vdms_main/main_frame.py:589
 #, fuzzy
 msgid "Concatenate Demuxer\tCtrl+Shift+D"
 msgstr "Concatenate Demuxer\tShift+D"
 
-#: ../../vdms_main/main_frame.py:590
 msgid "Go to the «Concatenate Demuxer» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:593
 #, fuzzy
 msgid "Still Image Maker\tCtrl+Shift+I"
 msgstr "静态图像制作\tShift+I"
 
-#: ../../vdms_main/main_frame.py:594
 msgid "Go to the «Still Image Maker» panel"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:596
 msgid "From Movie to Pictures\tCtrl+Shift+S"
 msgstr "转换视频到图片序列\tCtrl+Shift+S"
 
-#: ../../vdms_main/main_frame.py:597
 msgid "Go to the «From Movie to Pictures» panel"
 msgstr "转到 «转换视频为图片序列» 面板"
 
-#: ../../vdms_main/main_frame.py:600
 msgid "Output monitor\tCtrl+Shift+O"
 msgstr "输出监控器\tCtrl+Shift+O"
 
-#: ../../vdms_main/main_frame.py:601
 #, fuzzy
 msgid "Keeps track of the output for debugging errors"
 msgstr "为调试错误保持输出跟踪"
 
-#: ../../vdms_main/main_frame.py:603
 msgid "Go"
 msgstr "转到"
 
-#: ../../vdms_main/main_frame.py:607
 msgid "User guide"
 msgstr "用户指南"
 
-#: ../../vdms_main/main_frame.py:611
 msgid "System version"
 msgstr "系统版本"
 
-#: ../../vdms_main/main_frame.py:612
 msgid "Get version about your operating system, version of Python and wxPython."
 msgstr "获取你的操作系统、Python 和 wxPython 的版本。"
 
-#: ../../vdms_main/main_frame.py:616
 msgid "Show log files\tCtrl+L"
 msgstr "显示日志文件\tCtrl+L"
 
-#: ../../vdms_main/main_frame.py:617
 msgid "Viewing log messages"
 msgstr "查看日志信息"
 
-#: ../../vdms_main/main_frame.py:620
 msgid "Issue tracker"
 msgstr "问题跟踪器"
 
-#: ../../vdms_main/main_frame.py:624
 msgid "Contribute to the project"
 msgstr "向这个项目贡献"
 
-#: ../../vdms_main/main_frame.py:627
 msgid "Sponsor this project"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:628
 msgid "Become a developer supporter"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:629
 msgid "Donate"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:630
 msgid "Donate to the app developer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:634
 msgid "Other projects by the developer"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:650
 msgid "About Videomass"
 msgstr "关于 Videomass"
 
-#: ../../vdms_main/main_frame.py:651
 msgid "Check for newer version"
 msgstr "检查新的版本"
 
-#: ../../vdms_main/main_frame.py:652
 msgid "Check for the latest Videomass version"
 msgstr "检查最新的 Videomass 版本"
 
-#: ../../vdms_main/main_frame.py:654
 msgid "Help"
 msgstr "帮助"
 
-#: ../../vdms_main/main_frame.py:729
 msgid "Import files"
 msgstr "添加文件"
 
-#: ../../vdms_main/main_frame.py:752
 msgid "No default folder has been set for the destination of the encodings. The current setting is \"Same destination paths as source files\"."
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:784 ../../vdms_main/main_frame.py:809
 #, python-brace-format
 msgid ""
 "'{}':\n"
@@ -2206,11 +1638,9 @@ msgstr ""
 "“{}”：\n"
 "没有该文件或文件夹"
 
-#: ../../vdms_main/main_frame.py:797
 msgid "Are you sure to empty trash folder?"
 msgstr "你确定清空垃圾文件夹吗?"
 
-#: ../../vdms_main/main_frame.py:805
 #, python-brace-format
 msgid ""
 "'{}':\n"
@@ -2219,17 +1649,14 @@ msgstr ""
 "“{}”：\n"
 "没有要删除的文件。"
 
-#: ../../vdms_main/main_frame.py:862
 #, python-brace-format
 msgid "Installed release v{0}. A new presets release is available {1}"
 msgstr "安装的版本是 v{0}。新的预设版本可用 {1}"
 
-#: ../../vdms_main/main_frame.py:866
 #, python-brace-format
 msgid "Installed release v{0}. No new updates found."
 msgstr "安装的版本是 v{0}。找到了新版本。"
 
-#: ../../vdms_main/main_frame.py:896
 msgid ""
 "Wait....\n"
 "The archive is being downloaded"
@@ -2237,16 +1664,13 @@ msgstr ""
 "请稍候....\n"
 "档案正在下载中"
 
-#: ../../vdms_main/main_frame.py:908
 #, python-brace-format
 msgid "Successfully downloaded to \"{0}\""
 msgstr "成功下载到 “{0}”。"
 
-#: ../../vdms_main/main_frame.py:1120
 msgid "Some changes require restarting the application."
 msgstr "一些更改需要重启应用。"
 
-#: ../../vdms_main/main_frame.py:1126
 #, python-brace-format
 msgid ""
 "{0}\n"
@@ -2257,221 +1681,166 @@ msgstr ""
 "\n"
 "确定要重启应用吗？"
 
-#: ../../vdms_main/main_frame.py:1128
 msgid "Restart Videomass?"
 msgstr "重启 Videomass 吗？"
 
-#: ../../vdms_main/main_frame.py:1207
 #, python-brace-format
 msgid "A new release is available - v.{0}\n"
 msgstr "新版本可用 - v.{0}\n"
 
-#: ../../vdms_main/main_frame.py:1210
 msgid "You are using a development version that has not yet been released!\n"
 msgstr "您正在使用一个尚未发布的开发版本！\n"
 
-#: ../../vdms_main/main_frame.py:1213
 msgid "Congratulation! You are already using the latest version.\n"
 msgstr "恭喜！您正在使用最新版本。\n"
 
-#: ../../vdms_main/main_frame.py:1301
 msgid "Previous panel"
 msgstr "转到上一个面板"
 
-#: ../../vdms_main/main_frame.py:1302
 msgid "Back"
 msgstr "上一步"
 
-#: ../../vdms_main/main_frame.py:1305
 msgid "Next panel"
 msgstr "转到下一个面板"
 
-#: ../../vdms_main/main_frame.py:1306
 msgid "Next"
 msgstr "下一步"
 
-#: ../../vdms_main/main_frame.py:1309
 msgid "Home panel"
 msgstr "主页面板"
 
-#: ../../vdms_main/main_frame.py:1310
 msgid "Home"
 msgstr "主页"
 
-#: ../../vdms_main/main_frame.py:1313
 msgid "Play the selected imput file"
 msgstr "播放选择的输入文件"
 
-#: ../../vdms_main/main_frame.py:1314
 msgid "Play"
 msgstr "播放"
 
-#: ../../vdms_main/main_frame.py:1317
 msgid "Get informative data about imported media streams"
 msgstr "获取有关已导入媒体流的详细信息"
 
-#: ../../vdms_main/main_frame.py:1321
 msgid "Start batch processing"
 msgstr "开始批量处理"
 
-#: ../../vdms_main/main_frame.py:1325
 msgid "Stops current process"
 msgstr "停止当前过程"
 
-#: ../../vdms_main/main_frame.py:1329
 msgid "Add an item to Queue"
 msgstr "向队列添加项"
 
-#: ../../vdms_main/main_frame.py:1330
 msgid "Add to Queue"
 msgstr "添加至队列"
 
-#: ../../vdms_main/main_frame.py:1333
 msgid "Show queue"
 msgstr "显示队列"
 
-#: ../../vdms_main/main_frame.py:1408 ../../vdms_panels/presets_manager.py:569
 msgid "Videomass"
 msgstr "Videomass"
 
-#: ../../vdms_main/main_frame.py:1442
 msgid "Videomass - File List"
 msgstr "Videomass - 文件列表"
 
-#: ../../vdms_main/main_frame.py:1459
 msgid "Videomass - AV Conversions"
 msgstr "Videomass - 视频、音频转换"
 
-#: ../../vdms_main/main_frame.py:1488
 msgid "Videomass - Presets Manager"
 msgstr "Videomass - 预设管理器"
 
-#: ../../vdms_main/main_frame.py:1518
 #, fuzzy
 msgid "Videomass - Concatenate Demuxer"
 msgstr "Videomass - Concatenate Demuxer"
 
-#: ../../vdms_main/main_frame.py:1547
 msgid "Videomass - From Movie to Pictures"
 msgstr "Videomass - 转换视频为图片序列"
 
-#: ../../vdms_main/main_frame.py:1576
 #, fuzzy
 msgid "Videomass - Still Image Maker"
 msgstr "Videomass - 静态图像制作"
 
-#: ../../vdms_main/main_frame.py:1660 ../../vdms_panels/av_conversions.py:577
-#: ../../vdms_panels/filedrop.py:500 ../../vdms_panels/filedrop.py:616
-#: ../../vdms_panels/sequence_to_video.py:322
-#: ../../vdms_panels/video_to_sequence.py:369
-#: ../../vdms_panels/video_to_sequence.py:501
 msgid "Have to select an item in the file list first"
 msgstr "需要在列表中选择一个项"
 
-#: ../../vdms_main/main_frame.py:1682
 msgid ""
 "An item with the same destination file already exists.\n"
 "\n"
 "Do you want to replace it by adding the new item to the queue?"
 msgstr ""
 
-#: ../../vdms_main/main_frame.py:1703
 msgid "Videomass - FFmpeg Message Monitoring"
 msgstr "Videomass - FFmpeg 消息监控"
 
-#: ../../vdms_main/main_frame.py:1828
 #, python-brace-format
 msgid "The system will turn off in {0} seconds"
 msgstr "系统将在 {0} 秒后关机"
 
-#: ../../vdms_main/main_frame.py:1829
 msgid "Videomass - Shutdown!"
 msgstr "Videomass - 关机！"
 
-#: ../../vdms_main/main_frame.py:1836
 msgid "Error while shutting down. Please see file log for details."
 msgstr "关机时出现错误。请查看日志以获取详情。"
 
-#: ../../vdms_main/main_frame.py:1848
 #, python-brace-format
 msgid "Exiting the application in {0} seconds"
 msgstr "此程序将在 {0} 秒后退出"
 
-#: ../../vdms_main/main_frame.py:1849
 msgid "Videomass - Exiting!"
 msgstr "Videomass - 退出中！"
 
-#: ../../vdms_miniframes/timeline.py:46
 #, fuzzy
 msgid "Start point adjustment"
 msgstr "开始"
 
-#: ../../vdms_miniframes/timeline.py:48
 msgid "End point adjustment"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:105
 msgid "Hours"
 msgstr "时"
 
-#: ../../vdms_miniframes/timeline.py:106
 msgid "Minutes"
 msgstr "分"
 
-#: ../../vdms_miniframes/timeline.py:107
 msgid "Seconds"
 msgstr "秒"
 
-#: ../../vdms_miniframes/timeline.py:108
 msgid "Milliseconds"
 msgstr "毫秒"
 
-#: ../../vdms_miniframes/timeline.py:189 ../../vdms_miniframes/timeline.py:312
 msgid "No source duration:"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:208 ../../vdms_miniframes/timeline.py:298
-#: ../../vdms_miniframes/timeline.py:333 ../../vdms_miniframes/timeline.py:338
-#: ../../vdms_miniframes/timeline.py:441
 #, python-brace-format
 msgid "{0} {1}  |  Segment Duration: {2}"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:260 ../../vdms_miniframes/timeline.py:277
 msgid "End adjustment"
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:261 ../../vdms_miniframes/timeline.py:279
 #, fuzzy
 msgid "Start adjustment"
 msgstr "开始"
 
-#: ../../vdms_miniframes/timeline.py:320
 #, fuzzy
 msgid "Source duration:"
 msgstr "持续时间："
 
-#: ../../vdms_miniframes/timeline.py:387
 msgid "WARNING: Invalid selection, out of range."
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:461
 msgid ""
 "Start by dragging the bottom left handle,\n"
 "or right-click for options."
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:497
 #, fuzzy
 msgid "Start"
 msgstr "开始"
 
-#: ../../vdms_miniframes/timeline.py:498
 #, fuzzy
 msgid "End"
 msgstr "已启用"
 
-#: ../../vdms_miniframes/timeline.py:548
 msgid ""
 "The timeline editor is a tool that allows you to trim slices of time on selected imported media (see File List panel).\n"
 "\n"
@@ -2484,40 +1853,31 @@ msgid ""
 "The \"Start\"/\"End\" duration values always refer to the initial position of the timeline: 00:00:00.000. For other informations as the segment duration and warnings, please refer to the status bar messages."
 msgstr ""
 
-#: ../../vdms_miniframes/timeline.py:565
 #, fuzzy
 msgid "Timeline Editor Usage"
 msgstr "显示时间线\tCtrl+T"
 
-#: ../../vdms_panels/av_conversions.py:153
 msgid "Media:"
 msgstr "媒体："
 
-#: ../../vdms_panels/av_conversions.py:169
 msgid "Container:"
 msgstr "容器："
 
-#: ../../vdms_panels/av_conversions.py:180
 msgid "Save profile"
 msgstr "保存配置文件"
 
-#: ../../vdms_panels/av_conversions.py:183
 msgid "Target"
 msgstr "目标"
 
-#: ../../vdms_panels/av_conversions.py:316
 msgid "Miscellaneous"
 msgstr "杂项"
 
-#: ../../vdms_panels/av_conversions.py:323
 msgid "Save as a new profile of the Presets Manager."
 msgstr "另存为一个新的预设管理器配置文件。"
 
-#: ../../vdms_panels/av_conversions.py:325
 msgid "Available video encoders. \"Copy\" means that the video stream will not be re-encoded and will allow you (depending on the encoder) to change the container, audio codec and a few other parameters."
 msgstr "可用的视频编解码器。“Copy” 不是一个编码器，但表明视频流不会被重新编码，并允许改变格式或其他参数。"
 
-#: ../../vdms_panels/av_conversions.py:330
 msgid ""
 "Container format. It is usually represented by the file extension (output format).\n"
 "\n"
@@ -2531,52 +1891,39 @@ msgstr ""
 "\n"
 "如果媒体目标设置为 “Audio”，则可以从视频中提取仅包含音频的流，或者简单地转换音频源文件。"
 
-#: ../../vdms_panels/av_conversions.py:338
 msgid ""
 "Set output files target: \"Video\" to save output files as video files; \"Audio\" to save files using an audio encoder and format.\n"
 "\n"
 "Note that by using \"Audio\" as the target, you will still be able to work on the video source files but you will only be able to extract the audio streams, convert them and apply audio filters such as normalization."
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:346
 msgid "Preview video filters"
 msgstr "预览视频滤镜"
 
-#: ../../vdms_panels/av_conversions.py:347
 msgid "Disable active filters"
 msgstr "禁用激活的滤镜"
 
-#: ../../vdms_panels/av_conversions.py:348
-#: ../../vdms_panels/sequence_to_video.py:156
-#: ../../vdms_panels/video_to_sequence.py:113
 msgid "Resize"
 msgstr "调整分辨率"
 
-#: ../../vdms_panels/av_conversions.py:349
 msgid "Crop"
 msgstr "裁剪"
 
-#: ../../vdms_panels/av_conversions.py:350
 msgid "Transpose"
 msgstr "旋转"
 
-#: ../../vdms_panels/av_conversions.py:352
 msgid "Denoise"
 msgstr "降噪"
 
-#: ../../vdms_panels/av_conversions.py:353
 msgid "Stabilize"
 msgstr "稳定器"
 
-#: ../../vdms_panels/av_conversions.py:354
 msgid "Equalize"
 msgstr "均衡器"
 
-#: ../../vdms_panels/av_conversions.py:517
 msgid "Unable to preview Video Stabilizer filter"
 msgstr "无法预览视频稳定滤镜"
 
-#: ../../vdms_panels/av_conversions.py:602
 msgid ""
 "Unsupported file:\n"
 "Missing decoder or library? Check FFmpeg configuration."
@@ -2584,24 +1931,17 @@ msgstr ""
 "不支持的文件：\n"
 "缺少解码器或库？请检查 FFmpeg 配置。"
 
-#: ../../vdms_panels/av_conversions.py:611
-#: ../../vdms_panels/sequence_to_video.py:351
-#: ../../vdms_panels/video_to_sequence.py:398
 #, fuzzy
 msgid "The file is not a frame or a video file"
 msgstr "该文件不是一个框架或视频文件"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:434
-#: ../../vdms_panels/av_conversions.py:861
 #, fuzzy
 msgid "Undetected volume values! Click the \"Volume detect\" button to analyze audio volume data."
 msgstr "未检测到的音量值! 点击 \"音量检测 \"按钮来分析音频音量数据。"
 
-#: ../../vdms_panels/av_conversions.py:1186
 msgid "Off"
 msgstr "关闭"
 
-#: ../../vdms_panels/av_conversions.py:1203
 #, fuzzy
 msgid ""
 "Batch processing items\n"
@@ -2630,119 +1970,91 @@ msgstr ""
 "Time Period （时间周期\n"
 "Input Audio Map"
 
-#: ../../vdms_panels/av_conversions.py:1246
-#: ../../vdms_panels/presets_manager.py:814
 #, python-brace-format
 msgid "Write profile on «{0}»"
 msgstr "在 «{0}» 写入配置文件"
 
-#: ../../vdms_panels/av_conversions.py:1266
-#: ../../vdms_panels/presets_manager.py:513
 msgid "Enter name for new preset"
 msgstr "为新的预设输入名称"
 
-#: ../../vdms_panels/av_conversions.py:1276
-#: ../../vdms_panels/presets_manager.py:524
 msgid "Invalid file name, make sure to provide a valid name including the «.json» extension"
 msgstr ""
 
-#: ../../vdms_panels/av_conversions.py:1284
 #, fuzzy, python-brace-format
 msgid "Cannot save current data in file «{}»."
 msgstr "无法在文件'{}'中保存当前数据。"
 
-#: ../../vdms_panels/av_conversions.py:1289
 #, fuzzy
 msgid "Open Videomass preset"
 msgstr "关闭 Videomass"
 
-#: ../../vdms_panels/av_conversions.py:1307
 msgid "Videomass - Save new profile"
 msgstr "Videomass - 保存新配置文件"
 
-#: ../../vdms_panels/av_conversions.py:1308
 msgid "Where do you want to save this profile?"
 msgstr "你想在哪保存这个配置文件？"
 
-#: ../../vdms_panels/av_conversions.py:1309
 #, fuzzy
 msgid "Save the profile to a new preset"
 msgstr "在\"{}\"预设上创建一个新的配置文件"
 
-#: ../../vdms_panels/av_conversions.py:1310
 #, fuzzy
 msgid "Save the profile to an existing preset"
 msgstr "在\"{}\"预设上创建一个新的配置文件"
 
-#: ../../vdms_panels/choose_topic.py:69
 msgid "Welcome to Videomass"
 msgstr "欢迎来到 Videomass"
 
-#: ../../vdms_panels/choose_topic.py:71
 #, python-brace-format
 msgid "Version {}"
 msgstr "版本 {}"
 
-#: ../../vdms_panels/choose_topic.py:82
 msgid "Presets Manager"
 msgstr "预设管理器"
 
-#: ../../vdms_panels/choose_topic.py:85
 msgid "AV-Conversions"
 msgstr "音频、视频转换"
 
-#: ../../vdms_panels/choose_topic.py:88
 #, fuzzy
 msgid "Concatenate media files"
 msgstr "串联媒体文件"
 
-#: ../../vdms_panels/choose_topic.py:91
 msgid "Still Image Maker"
 msgstr "静态图像制作"
 
-#: ../../vdms_panels/choose_topic.py:94
 msgid "From Movie to Pictures"
 msgstr "转换视频为图片序列"
 
-#: ../../vdms_panels/choose_topic.py:123
 #, fuzzy
 msgid "Create, edit and use quickly your favorite FFmpeg presets and profiles with full formats support and codecs."
 msgstr "创建、编辑和快速使用您最喜爱的FFmpeg预设和配置文件，支持全部格式和编解码器。"
 
-#: ../../vdms_panels/choose_topic.py:127
 #, fuzzy
 msgid "A set of useful tools for audio and video conversions. Save your profiles and reuse them with Presets Manager."
 msgstr "一套用于音频和视频转换的有用工具。保存你的配置文件，并通过预设管理器重新使用它们。"
 
-#: ../../vdms_panels/choose_topic.py:131
 #, fuzzy
 msgid "Concatenate multiple media files based on import order without re-encoding"
 msgstr "根据进口顺序串联多个媒体文件，无需重新编码"
 
-#: ../../vdms_panels/choose_topic.py:134
 #, fuzzy
 msgid "Create video from a sequence of images, based on import order, with the ability to add an audio file."
 msgstr "根据导入顺序，从一连串的图像中创建视频，并能添加一个音频文件。"
 
-#: ../../vdms_panels/choose_topic.py:137
 msgid "Extract images (frames) from your movies in JPG, PNG, BMP, GIF formats."
 msgstr "从你的视频中提取 JPG、PNG、BMP、GIF 格式的图像（帧）。"
 
-#: ../../vdms_panels/concatenate.py:47
 #, fuzzy
 msgid "At least two files are required to perform concatenation."
 msgstr "至少需要两个文件才能进行串联。"
 
-#: ../../vdms_panels/concatenate.py:63
 msgid "Invalid data found"
 msgstr "找到了无效的数据"
 
-#: ../../vdms_panels/concatenate.py:68
 #, fuzzy
 msgid "The files do not have the same \"codec_types\", same \"sample_rate\" or same \"width\" or \"height\". Unable to proceed."
 msgstr "这些文件没有相同的 \"codec_types\"、相同的 \"sample_rate \"或相同的 \"width \"或 \"height\"。无法继续。"
 
-#: ../../vdms_panels/concatenate.py:84
 #, fuzzy
 msgid ""
 "\n"
@@ -2772,17 +2084,12 @@ msgstr ""
 "\n"
 "- 音频文件必须具有完全相同的格式、相同的编解码器和相同的采样率。"
 
-#: ../../vdms_panels/concatenate.py:125
 msgid "Videomass Documentation:"
 msgstr "Videomass 文档："
 
-#: ../../vdms_panels/concatenate.py:136
-#: ../../vdms_panels/sequence_to_video.py:212
-#: ../../vdms_panels/video_to_sequence.py:181
 msgid "Official FFmpeg documentation:"
 msgstr "官方 FFmpeg 文档："
 
-#: ../../vdms_panels/concatenate.py:253
 #, fuzzy
 msgid ""
 "Items to concatenate\n"
@@ -2799,269 +2106,207 @@ msgstr ""
 "Output Format\n"
 "Time Period"
 
-#: ../../vdms_panels/filedrop.py:45
 msgid "File has illegal characters like:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:46
 msgid "Invalid character found in path name: (\")"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:47
 #, fuzzy
 msgid "Directories are not allowed, just add files, please."
 msgstr "不允许有目录，只允许添加文件，谢谢。"
 
-#: ../../vdms_panels/filedrop.py:48
 msgid "File without format extension: please give an appropriate extension to the file name, example '.mkv', '.avi', '.mp3', etc."
 msgstr "没有格式扩展名的文件：请给文件名加上适当的扩展名，例如\".mkv\"、\".avi\"、\".mp3 \"等。"
 
-#: ../../vdms_panels/filedrop.py:84
 #, python-brace-format
 msgid "Name has illegal characters like: {0}"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:85
 msgid "Name already in use:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:185
 msgid "Duplicate file, it has already been added to the list."
 msgstr "重复的文件，它已经被添加至列表过。"
 
-#: ../../vdms_panels/filedrop.py:197
 #, fuzzy
 msgid "Rejected files"
 msgstr "添加文件"
 
-#: ../../vdms_panels/filedrop.py:269
 msgid "Source file"
 msgstr "源文件"
 
-#: ../../vdms_panels/filedrop.py:270
 msgid "Duration"
 msgstr "持续时间"
 
-#: ../../vdms_panels/filedrop.py:271
 msgid "Media type"
 msgstr "媒体类型"
 
-#: ../../vdms_panels/filedrop.py:272
 msgid "Size"
 msgstr "大小"
 
-#: ../../vdms_panels/filedrop.py:275 ../../vdms_panels/filedrop.py:405
 msgid "Drag one or more files below"
 msgstr "拖动下面的一个或多个文件"
 
-#: ../../vdms_panels/filedrop.py:282
 msgid "Save to:"
 msgstr "保存至："
 
-#: ../../vdms_panels/filedrop.py:306
 #, fuzzy
 msgid "Set a new destination folder for encodings"
 msgstr "创建一个新的预设"
 
-#: ../../vdms_panels/filedrop.py:308
 #, fuzzy
 msgid "Encodings destination folder"
 msgstr "配置文件夹"
 
-#: ../../vdms_panels/filedrop.py:338 ../../vdms_panels/filedrop.py:394
 #, fuzzy
 msgid "Play file"
 msgstr "配置文件"
 
-#: ../../vdms_panels/filedrop.py:408
 #, fuzzy
 msgid "Drag two or more Audio/Video files below"
 msgstr "拖动下面的一个或多个文件"
 
-#: ../../vdms_panels/filedrop.py:412
 #, fuzzy
 msgid "Drag one or more Image files below"
 msgstr "拖动下面的一个或多个文件"
 
-#: ../../vdms_panels/filedrop.py:415
 #, fuzzy
 msgid "Drag one or more Video files below"
 msgstr "拖动下面的一个或多个文件"
 
-#: ../../vdms_panels/filedrop.py:623
 #, fuzzy
 msgid "Rename the file destination"
 msgstr "恢复默认的目标文件夹"
 
-#: ../../vdms_panels/filedrop.py:624
 msgid "Rename the selected file to:"
 msgstr "重命名选中的文件至："
 
-#: ../../vdms_panels/filedrop.py:638 ../../vdms_panels/filedrop.py:648
-#: ../../vdms_panels/filedrop.py:679
 msgid "Add Files"
 msgstr "添加文件"
 
-#: ../../vdms_panels/filedrop.py:655
 msgid "Rename in batch"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:656
 #, python-brace-format
 msgid "Rename the {0} items to:"
 msgstr ""
 
-#: ../../vdms_panels/filedrop.py:658
 msgid "New Name #"
 msgstr "新名称 #"
 
-#: ../../vdms_panels/long_processing_task.py:114
 msgid "Sorry, all task failed !"
 msgstr "抱歉，全部任务失败了！"
 
-#: ../../vdms_panels/long_processing_task.py:115
 #, fuzzy
 msgid "The process was stopped due to a fatal error."
 msgstr "该进程由于一个致命的错误而被停止。"
 
-#: ../../vdms_panels/long_processing_task.py:116
 msgid "Interrupted Process !"
 msgstr "过程已中断 !"
 
-#: ../../vdms_panels/long_processing_task.py:117
 msgid "Successfully completed !"
 msgstr "成功完成 !"
 
-#: ../../vdms_panels/long_processing_task.py:118
 msgid "Not everything was successful."
 msgstr "有一部分任务没有成功。"
 
-#: ../../vdms_panels/long_processing_task.py:148
 msgid "Encoding Status"
 msgstr "编码状态"
 
-#: ../../vdms_panels/long_processing_task.py:152
 msgid "Current Log"
 msgstr "当前日志"
 
-#: ../../vdms_panels/long_processing_task.py:354
 msgid "Fatal Error !"
 msgstr "致命错误！"
 
-#: ../../vdms_panels/long_processing_task.py:363
 #, fuzzy
 msgid "Get your files at the destination you specified"
 msgstr "在你指定的目的地获取你的文件"
 
-#: ../../vdms_panels/long_processing_task.py:377
 msgid "For more details please read the Current Log."
 msgstr ""
 
-#: ../../vdms_panels/long_processing_task.py:380
 msgid "...Finished"
 msgstr "...完成"
 
-#: ../../vdms_panels/long_processing_task.py:399
 #, fuzzy
 msgid "Please wait... interruption in progress"
 msgstr "等等... 我打断了"
 
-#: ../../vdms_panels/long_processing_task.py:402
 msgid "...Interrupted"
 msgstr "...被打断"
 
-#: ../../vdms_panels/presets_manager.py:166
 msgid "Presets"
 msgstr "预设"
 
-#: ../../vdms_panels/presets_manager.py:180
 msgid "Write"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:184
 msgid "Delete"
 msgstr "删除"
 
-#: ../../vdms_panels/presets_manager.py:194
 msgid "Duplicate"
 msgstr "复制"
 
-#: ../../vdms_panels/presets_manager.py:199
 msgid "Profiles"
 msgstr "配置文件"
 
-#: ../../vdms_panels/presets_manager.py:206
 #, fuzzy
 msgid "One-Pass Encoding"
 msgstr "单程票"
 
-#: ../../vdms_panels/presets_manager.py:218
 #, fuzzy
 msgid "Two-Pass Encoding"
 msgstr "两种方式"
 
-#: ../../vdms_panels/presets_manager.py:232
 msgid "Choose a preset and view its profiles"
 msgstr "选择一个预设并查看其配置文件"
 
-#: ../../vdms_panels/presets_manager.py:233
 #, fuzzy
 msgid "Write a new profile and save it in the selected preset"
 msgstr "创建一个新的配置文件，并将其保存在选定的预置中"
 
-#: ../../vdms_panels/presets_manager.py:235
 msgid "Delete the selected profile"
 msgstr "删除所选配置文件"
 
-#: ../../vdms_panels/presets_manager.py:236
 msgid "Edit the selected profile"
 msgstr "编辑所选配置文件"
 
-#: ../../vdms_panels/presets_manager.py:237
 msgid "Duplicate the selected profile"
 msgstr "复制选中的配置文件"
 
-#: ../../vdms_panels/presets_manager.py:238
 msgid "Create new preset"
 msgstr "创建新的预设"
 
-#: ../../vdms_panels/presets_manager.py:240
 msgid "Remove selected preset"
 msgstr "移除选择的预设"
 
-#: ../../vdms_panels/presets_manager.py:242
 msgid "Backup selected preset"
 msgstr "备份选中的预设"
 
-#: ../../vdms_panels/presets_manager.py:244
 msgid "Backup the presets folder"
 msgstr "备份预设文件夹"
 
-#: ../../vdms_panels/presets_manager.py:246
 #, fuzzy
 msgid "Restore a preset"
 msgstr "导出选定对象"
 
-#: ../../vdms_panels/presets_manager.py:248
 #, fuzzy
 msgid "Restore a presets folder"
 msgstr "导入一个新的预置文件夹"
 
-#: ../../vdms_panels/presets_manager.py:250
 #, fuzzy
 msgid "Resets the selected preset to default values"
 msgstr "用Videomass默认的预设替换所选的预设"
 
-#: ../../vdms_panels/presets_manager.py:252
 #, fuzzy
 msgid "Reset all presets to default values"
 msgstr "检索所有Videomass的默认预置"
 
-#: ../../vdms_panels/presets_manager.py:254
 msgid "Refresh the presets list"
 msgstr "刷新预设列表"
 
-#: ../../vdms_panels/presets_manager.py:338
 #, python-brace-format
 msgid ""
 "Outdated presets version found: v{1}\n"
@@ -3075,28 +2320,22 @@ msgid ""
 "Do you want to perform this update now?"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:403
 msgid "Name"
 msgstr "名称"
 
-#: ../../vdms_panels/presets_manager.py:405
 msgid "Output Format"
 msgstr "输出格式"
 
-#: ../../vdms_panels/presets_manager.py:406
 msgid "Supported Format List"
 msgstr "支持的格式列表"
 
-#: ../../vdms_panels/presets_manager.py:531
 #, python-brace-format
 msgid "Cannot save current data in file '{}'."
 msgstr "无法在文件 “{}” 中保存当前数据。"
 
-#: ../../vdms_panels/presets_manager.py:535
 msgid "You just successfully created a new preset!"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:547
 #, fuzzy, python-brace-format
 msgid ""
 "Are you sure you want to remove \"{}\" preset?\n"
@@ -3107,7 +2346,6 @@ msgstr ""
 "\n"
 " 它将被移到预设文件夹的 \"移除 \"子文件夹中。"
 
-#: ../../vdms_panels/presets_manager.py:558
 #, python-brace-format
 msgid ""
 "{}\n"
@@ -3118,34 +2356,26 @@ msgstr ""
 "\n"
 "对不起，删除失败，无法继续。"
 
-#: ../../vdms_panels/presets_manager.py:568
 #, fuzzy, python-brace-format
 msgid "The preset \"{0}\" was successfully removed"
 msgstr "预设\"{0}\"已成功删除"
 
-#: ../../vdms_panels/presets_manager.py:583
-#: ../../vdms_panels/presets_manager.py:612
 #, fuzzy
 msgid "Open a destination folder"
 msgstr "目的地文件夹"
 
-#: ../../vdms_panels/presets_manager.py:588
 msgid "A file with this name already exists, do you want to overwrite it?"
 msgstr "已经有一个以此为名的文件，你想覆盖它吗？"
 
-#: ../../vdms_panels/presets_manager.py:602
-#: ../../vdms_panels/presets_manager.py:622
 #, fuzzy
 msgid "Backup completed successfully"
 msgstr ""
 "向导已成功完成!\n"
 "\n"
 
-#: ../../vdms_panels/presets_manager.py:631
 msgid "Open the preset you want to restore"
 msgstr ""
 
-#: ../../vdms_panels/presets_manager.py:645
 msgid ""
 "This preset already exists and is about to be updated. Don't worry, it will keep all your saved profiles.\n"
 "\n"
@@ -3155,14 +2385,12 @@ msgstr ""
 "\n"
 "你想要继续吗?"
 
-#: ../../vdms_panels/presets_manager.py:663
 #, fuzzy
 msgid "Restore successful"
 msgstr ""
 "向导已成功完成!\n"
 "\n"
 
-#: ../../vdms_panels/presets_manager.py:681
 msgid ""
 "This will update the presets database. Don't worry, it will keep all your saved profiles.\n"
 "\n"
@@ -3172,22 +2400,18 @@ msgstr ""
 "\n"
 "你想要继续吗?"
 
-#: ../../vdms_panels/presets_manager.py:689
 #, fuzzy
 msgid "Open the presets folder to restore"
 msgstr "导入一个新的预置文件夹"
 
-#: ../../vdms_panels/presets_manager.py:725
 #, fuzzy
 msgid "The presets database has been successfully updated"
 msgstr "预置数据库已成功更新"
 
-#: ../../vdms_panels/presets_manager.py:740
 #, fuzzy
 msgid "The selected preset is not part of Videomass's default presets."
 msgstr "用Videomass默认的预设替换所选的预设"
 
-#: ../../vdms_panels/presets_manager.py:745
 msgid ""
 "Be careful! The selected preset will be overwritten with the default one. Your profiles may be deleted!\n"
 "\n"
@@ -3197,12 +2421,9 @@ msgstr ""
 "\n"
 "你想要继续吗?"
 
-#: ../../vdms_panels/presets_manager.py:760
-#: ../../vdms_panels/presets_manager.py:794
 msgid "Successful recovery"
 msgstr "成功恢复"
 
-#: ../../vdms_panels/presets_manager.py:769
 #, fuzzy
 msgid ""
 "Be careful! This action will restore all presets to default ones. Your profiles may be deleted!\n"
@@ -3215,20 +2436,16 @@ msgstr ""
 "\n"
 "你想要继续吗?"
 
-#: ../../vdms_panels/presets_manager.py:833
 #, fuzzy, python-brace-format
 msgid "Edit profile on «{0}»"
 msgstr "编辑\"{}\"预设的配置文件"
 
-#: ../../vdms_panels/presets_manager.py:872
 msgid "Are you sure you want to delete the selected profile? It will no longer be possible to recover it."
 msgstr "你确定要删除选定的配置文件吗？这将不再可能恢复它。"
 
-#: ../../vdms_panels/presets_manager.py:891
 msgid "First select a profile in the list"
 msgstr "首先在列表中选择一个配置文件"
 
-#: ../../vdms_panels/presets_manager.py:899
 #, fuzzy
 msgid ""
 "The selected profile command has been changed manually.\n"
@@ -3237,12 +2454,10 @@ msgstr ""
 "所选的配置文件命令已被手动更改。\n"
 "你想在转换过程中应用它吗？"
 
-#: ../../vdms_panels/presets_manager.py:909
 #, fuzzy
 msgid "Don't show this dialog again"
 msgstr "不要再显示这个对话框"
 
-#: ../../vdms_panels/presets_manager.py:1054
 #, fuzzy
 msgid ""
 "Batch processing items\n"
@@ -3268,12 +2483,10 @@ msgstr ""
 "Time Period （时间周期\n"
 "Input Audio Map"
 
-#: ../../vdms_panels/sequence_to_video.py:54
 #, fuzzy
 msgid "Images need to be resized, please use Resize function."
 msgstr "图片需要调整大小，请使用调整大小功能。"
 
-#: ../../vdms_panels/sequence_to_video.py:73
 #, fuzzy
 msgid ""
 "\n"
@@ -3304,11 +2517,9 @@ msgstr ""
 "产生的视频将在 \"队列文件 \"列表中具有所选文件的名称，它将被保存在一个名为 \"Still_Images \"\n"
 "的文件夹中，并在您指定的路径上有一个渐进的数字。"
 
-#: ../../vdms_panels/sequence_to_video.py:129
 msgid "Enable a single still image"
 msgstr "启用单一静止图像"
 
-#: ../../vdms_panels/sequence_to_video.py:162
 #, fuzzy
 msgid ""
 "Force original aspect ratio using\n"
@@ -3317,31 +2528,24 @@ msgstr ""
 "Force original aspect ratio using\n"
 "填充，而不是拉伸"
 
-#: ../../vdms_panels/sequence_to_video.py:170
 msgid "Include audio file"
 msgstr "包括音频文件"
 
-#: ../../vdms_panels/sequence_to_video.py:173
 #, fuzzy
 msgid "Play the video until audio track finishes"
 msgstr "播放视频，直到音轨结束"
 
-#: ../../vdms_panels/sequence_to_video.py:180
-#: ../../vdms_panels/sequence_to_video.py:439
 msgid "Open audio file"
 msgstr "打开音频文件"
 
-#: ../../vdms_panels/sequence_to_video.py:199
 #, fuzzy
 msgid "Additional arguments"
 msgstr "补充论据"
 
-#: ../../vdms_panels/sequence_to_video.py:454
 #, fuzzy
 msgid "Open Audio File"
 msgstr "打开音频文件"
 
-#: ../../vdms_panels/sequence_to_video.py:466
 #, python-brace-format
 msgid ""
 "Invalid file: '{}'\n"
@@ -3352,7 +2556,6 @@ msgstr ""
 "\n"
 "{}"
 
-#: ../../vdms_panels/sequence_to_video.py:471
 #, python-brace-format
 msgid ""
 "Invalid file: '{}'\n"
@@ -3363,21 +2566,14 @@ msgstr ""
 "\n"
 "它似乎不是一个音频文件。"
 
-#: ../../vdms_panels/sequence_to_video.py:560
-#: ../../vdms_panels/sequence_to_video.py:587
-#: ../../vdms_panels/video_to_sequence.py:511
 #, python-brace-format
 msgid "Invalid file: '{}'"
 msgstr "无效文件：“{}”"
 
-#: ../../vdms_panels/sequence_to_video.py:570
-#: ../../vdms_panels/sequence_to_video.py:595
 #, python-brace-format
 msgid "Unsupported format '{}'"
 msgstr "不支持的格式 “{}”"
 
-#: ../../vdms_panels/sequence_to_video.py:576
-#: ../../vdms_panels/sequence_to_video.py:600
 #, python-brace-format
 msgid ""
 "File does not exist:\n"
@@ -3388,15 +2584,9 @@ msgstr ""
 "\n"
 "“{}”\n"
 
-#: ../../vdms_panels/sequence_to_video.py:577
 msgid "ERROR"
 msgstr "错误"
 
-#: ../../vdms_panels/sequence_to_video.py:707
-msgid "Shortest"
-msgstr ""
-
-#: ../../vdms_panels/sequence_to_video.py:715
 #, fuzzy
 msgid ""
 "Items to concatenate\n"
@@ -3427,7 +2617,6 @@ msgstr ""
 "Still image duration （静态图像时间）。\n"
 "Overall video duration （整体视频时间"
 
-#: ../../vdms_panels/video_to_sequence.py:50
 #, fuzzy
 msgid ""
 "\n"
@@ -3457,51 +2646,39 @@ msgstr ""
 "产生的图像将被保存在一个名为'Movie_to_Pictures'的文件夹中，并有一个渐进的数字，\n"
 "在您指定的路径中。"
 
-#: ../../vdms_panels/video_to_sequence.py:86
 msgid "Create thumbnails"
 msgstr "创建缩略图"
 
-#: ../../vdms_panels/video_to_sequence.py:87
 msgid "Create tiled mosaics"
 msgstr "多帧平铺拼接"
 
-#: ../../vdms_panels/video_to_sequence.py:88
 msgid "Create animated GIF"
 msgstr "创建 GIF 动画"
 
-#: ../../vdms_panels/video_to_sequence.py:90
 msgid "Options"
 msgstr "选项"
 
-#: ../../vdms_panels/video_to_sequence.py:119
 msgid "Output format:"
 msgstr "输出格式："
 
-#: ../../vdms_panels/video_to_sequence.py:131
 msgid "Rows:"
 msgstr "行数："
 
-#: ../../vdms_panels/video_to_sequence.py:141
 msgid "Columns:"
 msgstr "列："
 
-#: ../../vdms_panels/video_to_sequence.py:205
 msgid "Other unofficial resources:"
 msgstr "其他非官方的资源："
 
-#: ../../vdms_panels/video_to_sequence.py:229
 msgid "Set FPS control from 0.1 to 30.0 fps. The higher this value, the more images will be extracted."
 msgstr "设置 FPS，范围：0.1 到 30.0。这个值越高，提取的图像就越多。"
 
-#: ../../vdms_panels/video_to_sequence.py:232
 msgid "Spaces around the mosaic tiles. From 0 to 32 pixels"
 msgstr "每个帧块到其它帧块周围的留白。范围： 0 到 32"
 
-#: ../../vdms_panels/video_to_sequence.py:234
 msgid "Spaces around the mosaic borders. From 0 to 32 pixels"
 msgstr "帧块到图片边缘的留白。范围：0 到 32"
 
-#: ../../vdms_panels/video_to_sequence.py:626
 #, fuzzy
 msgid ""
 "Selected File\n"
@@ -3531,60 +2708,47 @@ msgstr ""
 "Custom Arguments\n"
 "Time Period"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:118
 msgid "Audio encoder settings, mapping and filters"
 msgstr "音频编码器设置，映射和滤镜"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:128
 msgid "Audio Encoder"
 msgstr "音频编码器"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:137
 msgid "Settings"
 msgstr "设置"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:148
 msgid "Index Selection:"
 msgstr "索引选择："
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:157
 msgid "Map:"
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:180
 msgid "Normalization"
 msgstr "归一化"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:191
 msgid "Volume detect"
 msgstr "音量检测"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:195
 msgid "Volume Statistics"
 msgstr "音量统计"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:199
 msgid "Target level:"
 msgstr "目标等级："
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:264
 #, fuzzy
 msgid "Gets maximum volume and average volume data in dBFS, then calculates the offset amount for audio normalization."
 msgstr "获取最大音量和平均音量数据，单位为dBFS，然后计算音频正常化的偏移量。"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:267
 #, fuzzy
 msgid "Limiter for the maximum peak level or the mean level (when switch to RMS) in dBFS. From -99.0 to +0.0; default for PEAK level is -1.0; default for RMS is -20.0"
 msgstr "最大峰值电平或平均电平（当切换到RMS时）的限制器，单位为dBFS。从-99.0到+0.0；PEAK电平的默认值是-1.0；RMS的默认值是-20.0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:271
 msgid ""
 "Normally on a video with correctly indexed streams and having one or more audio streams, the first audio stream should be indexed at \"1\", the second at \"2\" and so on (the video stream on the other hand is always indexed at \"0\"). In this case it is recommended to select the desired stream by setting a specific index, e.g \"1\" for for the first available audio stream.\n"
 "\n"
 "Set this control to \"Auto\" if the source file is simply an audio track."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:280
 #, fuzzy
 msgid ""
 "\"Auto\" keeps all audio streams and processes only the one selected by the \"Index Selection\" control.\n"
@@ -3594,31 +2758,25 @@ msgid ""
 "\"Index Only\" processes only the audio stream selected by the \"Index Selection\" control and removes all others from the video"
 msgstr "\"自动 \"保留所有的音频流，但只处理所选索引中的一个；\"全部 \"保留所有的音频流，并以所选索引的属性处理它们；\"仅索引 \"只处理和保留所选索引的音频流。"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:288
 #, fuzzy
 msgid "Integrated Loudness Target in LUFS. From -70.0 to -5.0, default is -16.0"
 msgstr "LUFS中的综合响度目标。从-70.0到-5.0，默认为-24.0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:291
 #, fuzzy
 msgid "Maximum True Peak in dBTP. From -1.5 to +0.0, default is -2.0"
 msgstr "最大真实峰值，单位为dBTP。从-9.0到+0.0，默认为-2.0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:294
 #, fuzzy
 msgid "Loudness Range Target in LUFS. From +1.0 to +20.0, default is +11.0"
 msgstr "响度范围目标（LUFS）。从+1.0到+20.0，默认为+7.0"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:297
 msgid "Play the audio stream selected in the \"Index Selection\" control. Using this function you can test the result of audio normalization."
 msgstr ""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:503
 #, fuzzy
 msgid "Selected index does not exist or does not contain any audio streams"
 msgstr "所选索引不存在或不包含任何音频流"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:508
 #, python-brace-format
 msgid ""
 "ERROR: Missing audio stream:\n"
@@ -3627,47 +2785,38 @@ msgstr ""
 "ERROR：缺少音频流:\n"
 "\"{}\""
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:726
 #, fuzzy
 msgid "PEAK level normalization, which will produce a maximum peak level equal to the set target level."
 msgstr "激活峰值电平正常化，这将产生一个等于设定的目标电平的最大峰值电平。"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:729
 #, fuzzy
 msgid "RMS-based normalization, which according to mean volume calculates the amount of gain to reach same average power signal."
 msgstr "激活基于有效值的归一化，根据平均音量计算出达到相同平均功率信号的增益量。"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:733
 #, fuzzy
 msgid ""
 "Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements the EBU R128 algorithm.\n"
 "Ideal for live normalization. It produces worse results than the High-quality two-pass Loudnorm normalization, but is faster."
 msgstr "激活两个通道的正常化。它使用 \"loudnorm \"滤波器对感知的响度进行归一化，该滤波器实现了EBU R128算法。"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:740
 #, fuzzy
 msgid ""
 "High-quality two-pass Loudnorm normalization. Normalizes the perceived loudness using the \"loudnorm\" filter, which implements\n"
 "the EBU R128 algorithm. Ideal for postprocessing."
 msgstr "激活两个通道的正常化。它使用 \"loudnorm \"滤波器对感知的响度进行归一化，该滤波器实现了EBU R128算法。"
 
-#: ../../vdms_panels/audio_encoders/acodecs.py:789
 msgid "You need to import at least one file"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:63
 msgid "Subtitle Mapping:"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:77
 msgid "Copy Chapters"
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:79
 msgid "Copy Metadata"
 msgstr "复制元数据"
 
-#: ../../vdms_panels/miscellaneous/miscell.py:85
 msgid ""
 "Select \"All\" to include any source file subtitles in the output video.\n"
 "\n"
@@ -3676,159 +2825,75 @@ msgid ""
 "This option is automatically ignored for output audio files."
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:90
 msgid "Copy the chapter markers as is from source file. This option is automatically ignored for output audio files."
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:93
 msgid "Copy all incoming metadata from source file, such as audio/video tags, titles, unique marks, and so on."
 msgstr ""
 
-#: ../../vdms_panels/miscellaneous/miscell.py:108
 #, fuzzy
 msgid "Additional options"
 msgstr "补充论据"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:89
-#: ../../vdms_panels/video_encoders/av1_svt.py:120
-#: ../../vdms_panels/video_encoders/avc_x264.py:90
-#: ../../vdms_panels/video_encoders/hevc_x265.py:98
-#: ../../vdms_panels/video_encoders/mpeg4.py:71
-#: ../../vdms_panels/video_encoders/vp9_webm.py:131
 #, fuzzy
 msgid "Reload"
 msgstr "重新加载"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:101
-#: ../../vdms_panels/video_encoders/av1_svt.py:129
-#: ../../vdms_panels/video_encoders/avc_x264.py:101
-#: ../../vdms_panels/video_encoders/hevc_x265.py:109
-#: ../../vdms_panels/video_encoders/mpeg4.py:82
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:97
-#: ../../vdms_panels/video_encoders/vp9_webm.py:141
 #, fuzzy
 msgid "Optimize for Web"
 msgstr "用于网络"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:247
-#: ../../vdms_panels/video_encoders/av1_svt.py:313
-#: ../../vdms_panels/video_encoders/avc_x264.py:242
-#: ../../vdms_panels/video_encoders/hevc_x265.py:250
-#: ../../vdms_panels/video_encoders/mpeg4.py:198
-#: ../../vdms_panels/video_encoders/vp9_webm.py:288
 msgid "Reloads the selected video encoder settings. Changes will be discarded."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:250
-#: ../../vdms_panels/video_encoders/avc_x264.py:273
-#: ../../vdms_panels/video_encoders/hevc_x265.py:277
-#: ../../vdms_panels/video_encoders/vp9_webm.py:291
 #, fuzzy
 msgid "Constant rate factor. Lower values correspond to higher quality and greater file size. Set to -1 to disable this control."
 msgstr "恒定速率因子。较低的值=较高的质量和较大的文件尺寸。设置-1来禁用这个控制。"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:254
-#: ../../vdms_panels/video_encoders/av1_svt.py:357
-#: ../../vdms_panels/video_encoders/vp9_webm.py:295
 msgid "Number of tile rows to use, default changes per resolution"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:256
-#: ../../vdms_panels/video_encoders/av1_svt.py:359
-#: ../../vdms_panels/video_encoders/vp9_webm.py:297
 msgid "Number of tile columns to use, default changes per resolution"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:259
-#: ../../vdms_panels/video_encoders/av1_svt.py:368
-#: ../../vdms_panels/video_encoders/avc_x264.py:253
-#: ../../vdms_panels/video_encoders/hevc_x265.py:261
-#: ../../vdms_panels/video_encoders/mpeg4.py:201
-#: ../../vdms_panels/video_encoders/vp9_webm.py:300
 #, fuzzy
 msgid "Set the Group Of Picture (GOP). Set to -1 to disable this control."
 msgstr "指定要使用的最小公差"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:262
-#: ../../vdms_panels/video_encoders/av1_svt.py:371
-#: ../../vdms_panels/video_encoders/avc_x264.py:256
-#: ../../vdms_panels/video_encoders/hevc_x265.py:264
-#: ../../vdms_panels/video_encoders/mpeg4.py:204
-#: ../../vdms_panels/video_encoders/vp9_webm.py:303
 #, fuzzy
 msgid "It can reduce the file size, but takes longer."
 msgstr "它可以减少文件大小，但需要更长的时间。"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:264
-#: ../../vdms_panels/video_encoders/av1_svt.py:373
-#: ../../vdms_panels/video_encoders/avc_x264.py:258
-#: ../../vdms_panels/video_encoders/hevc_x265.py:266
-#: ../../vdms_panels/video_encoders/mpeg4.py:206
-#: ../../vdms_panels/video_encoders/vp9_webm.py:305
 #, fuzzy
 msgid "Set minimum bitrate tolerance. Most useful in setting up a CBR encode. It is of little use otherwise. Set to -1 to disable this control."
 msgstr "指定一个最大公差。这仅与缓冲区大小一起使用。"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:268
-#: ../../vdms_panels/video_encoders/av1_svt.py:377
-#: ../../vdms_panels/video_encoders/avc_x264.py:262
-#: ../../vdms_panels/video_encoders/hevc_x265.py:270
-#: ../../vdms_panels/video_encoders/mpeg4.py:210
-#: ../../vdms_panels/video_encoders/vp9_webm.py:309
 #, fuzzy
 msgid "Specifies a maximum tolerance. Requires bufsize to be set. Set to -1 to disable this control."
 msgstr "指定要使用的最小公差"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:271
-#: ../../vdms_panels/video_encoders/av1_svt.py:380
-#: ../../vdms_panels/video_encoders/avc_x264.py:265
-#: ../../vdms_panels/video_encoders/hevc_x265.py:273
-#: ../../vdms_panels/video_encoders/mpeg4.py:213
-#: ../../vdms_panels/video_encoders/vp9_webm.py:312
 #, fuzzy
 msgid "Set ratecontrol buffer size, which determines the variability of the output bitrate. Set to -1 to disable this control."
 msgstr "指定解码器的缓冲区大小，它决定了输出比特率的可变性。"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:275
-#: ../../vdms_panels/video_encoders/av1_svt.py:384
-#: ../../vdms_panels/video_encoders/avc_x264.py:277
-#: ../../vdms_panels/video_encoders/hevc_x265.py:281
-#: ../../vdms_panels/video_encoders/mpeg4.py:231
-#: ../../vdms_panels/video_encoders/vp9_webm.py:316
 #, fuzzy
 msgid "Specifies the target (average) bit rate for the encoder to use. Higher value = higher quality. Set -1 to disable this control."
 msgstr "指定编码器要使用的目标（平均）比特率。更高的值=更高的质量。设置-1来禁用这个控制。"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:279
-#: ../../vdms_panels/video_encoders/av1_svt.py:388
-#: ../../vdms_panels/video_encoders/avc_x264.py:281
-#: ../../vdms_panels/video_encoders/hevc_x265.py:285
-#: ../../vdms_panels/video_encoders/mpeg4.py:235
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:131
-#: ../../vdms_panels/video_encoders/vp9_webm.py:320
 msgid "Video width and video height ratio."
 msgstr "视频宽度和视频高度的比例。"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:281
-#: ../../vdms_panels/video_encoders/av1_svt.py:390
-#: ../../vdms_panels/video_encoders/avc_x264.py:283
-#: ../../vdms_panels/video_encoders/hevc_x265.py:287
-#: ../../vdms_panels/video_encoders/mpeg4.py:237
-#: ../../vdms_panels/video_encoders/vp9_webm.py:322
 #, fuzzy
 msgid "Frame rate (frames per second). Frames repeat a given number of times per second. In some countries this is 30 for NTSC, other countries (like Italy) use 25 for PAL"
 msgstr "每秒钟重复一定数量的帧。在一些国家，NTSC是30，其他国家（如意大利）PAL是25。"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:285
 msgid "Quality/Speed ratio modifier. CPU Used sets how efficient the compression will be. Lower values mean slower encoding with better quality, and vice-versa. Valid values are from 0 to 8 inclusive."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:290
 #, fuzzy
 msgid "Quality and compression efficiency vs speed trade-off. \"good\" is the default and recommended for most applications; \"realtime\" is recommended for live/fast encoding (live streaming, video conferencing, etc); \"allintra\" for All Intra encoding."
 msgstr "\"good \"是默认的，推荐用于大多数应用；\"best \"是推荐的，如果你有很多时间并希望获得最好的压缩效率；\"realtime \"是推荐用于实时/快速编码"
 
-#: ../../vdms_panels/video_encoders/av1_aom.py:297
 msgid ""
 "Row Multi-Threading enables row-based multi-threading which maximizes CPU usage.\n"
 "\n"
@@ -3837,7 +2902,6 @@ msgid ""
 "Enabling Row Multi-Threading is only faster when the CPU has more threads than the number of encoded tiles."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:316
 msgid ""
 "presets 1-3 represent extremely high efficiency, for use when encode time is not important and quality/size of the resulting video file is critical.\n"
 "\n"
@@ -3848,7 +2912,6 @@ msgid ""
 "Preset 13 is even faster but not intended for direct human consumption--it can be used, for example, as a per-scene quality metric in VOD applications. One should use the lowest preset that is tolerable."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:327
 msgid ""
 "Constant rate factor. This parameter governs the quality/size trade-off.\n"
 "\n"
@@ -3859,7 +2922,6 @@ msgid ""
 "Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:334
 msgid ""
 "The \"Film Grain\" parameter allows SVT-AV1 to detect and delete film grain from the source video, and replace it with synthetic grain of the same character, resulting in significant bitrate savings.\n"
 "\n"
@@ -3872,65 +2934,45 @@ msgid ""
 "If the source video does not have natural grain, this parameter can be set to -1 to disable it or at least 0."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:346
 msgid ""
 "If enabled, the \"Film Grain Denoiser\" option can mitigate the detail removal caused by high \"Film Grain\" values required to preserve the look of very grainy films\n"
 "\n"
 "By default, the denoised frames are passed to be encoded as the final pictures, enabling this feature will lead to the original frames to be used instead. "
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:353
 msgid "Enables encoder optimization to produce faster (less CPU intensive) bit streams to decode, similar to the fastdecode tuning in x264 and x265."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:362
-#: ../../vdms_panels/video_encoders/avc_x264.py:247
-#: ../../vdms_panels/video_encoders/hevc_x265.py:255
 msgid "Set profile restrictions"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:364
-#: ../../vdms_panels/video_encoders/avc_x264.py:249
-#: ../../vdms_panels/video_encoders/hevc_x265.py:257
 #, fuzzy
 msgid "Specify level for a selected profile"
 msgstr "删除所选配置文件"
 
-#: ../../vdms_panels/video_encoders/av1_svt.py:366
-#: ../../vdms_panels/video_encoders/avc_x264.py:251
-#: ../../vdms_panels/video_encoders/hevc_x265.py:259
 msgid "Tune the encoding params"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/avc_x264.py:245
-#: ../../vdms_panels/video_encoders/hevc_x265.py:253
 msgid "Set the encoding preset (default \"medium\")"
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/avc_x264.py:269
 #, fuzzy
 msgid "specifies the target (average) bit rate for the encoder to use. Higher value = higher quality. Set -1 to disable this control."
 msgstr "指定编码器要使用的目标（平均）比特率。更高的值=更高的质量。设置-1来禁用这个控制。"
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:217
 msgid "Variable Bit Rate. From 0-30, with 1 being highest quality/largest filesize and 30 being the lowest quality/smallest filesize. Set to -1 to disable this control."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:222
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:133
 #, fuzzy
 msgid "Frames repeat a given number of times per second. In some countries this is 30 for NTSC, other countries (like Italy) use 25 for PAL"
 msgstr "每秒钟重复一定数量的帧。在一些国家，NTSC是30，其他国家（如意大利）PAL是25。"
 
-#: ../../vdms_panels/video_encoders/mpeg4.py:226
 msgid "The default FourCC stored in an MPEG-4-coded file will be FMP4. If you want a different FourCC, set this option to xvid to force the FourCC xvid to be stored as the video FourCC rather than the default."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:162
 msgid "Copy Video Codec"
 msgstr "复制视频编码"
 
-#: ../../vdms_panels/video_encoders/video_encodercopy.py:163
 msgid ""
 "This will just copy the video track as is, without any video re-encoding.\n"
 "You will only be able to change output format, select other audio encoders and\n"
@@ -3939,18 +2981,15 @@ msgstr ""
 "这只会复制视频轨，不进行视频重新编码。\n"
 "你将只能改变输出格式，选择其它音频编码器以及一些其他选项。"
 
-#: ../../vdms_panels/video_encoders/video_no_enc.py:74
 msgid "Video export disabled"
 msgstr "视频导出被禁用"
 
-#: ../../vdms_panels/video_encoders/video_no_enc.py:75
 msgid ""
 "The Media target you just selected will only allow you to export files as audio tracks.\n"
 "You can then process audio source files only or extract indexed audio streams on\n"
 "video files."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:326
 msgid ""
 "Speed sets how efficient the compression will be.\n"
 "\n"
@@ -3963,7 +3002,6 @@ msgid ""
 "When the Quality is set to realtime, the available values for Speed are 0 to 8."
 msgstr ""
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:335
 #, fuzzy
 msgid ""
 "Time to spend encoding.\n"
@@ -3975,25 +3013,22 @@ msgid ""
 "\"realtime\" is recommended for live / fast encoding."
 msgstr "\"good \"是默认的，推荐用于大多数应用；\"best \"是推荐的，如果你有很多时间并希望获得最好的压缩效率；\"realtime \"是推荐用于实时/快速编码"
 
-#: ../../vdms_panels/video_encoders/vp9_webm.py:341
-msgid "If enabled, adds support for row based multithreading which greatly enhances the number of threads the encoder can utilise. This improves encoding speed significantly on systems that are otherwise underutilised when encoding VP9. Since the amount of additional threads depends on the number of \"tiles\", which itself depends on the video resolution, encoding higher resolution videos will see a larger performance improvement."
+msgid ""
+"If enabled, adds support for row based multithreading which greatly enhances the number of threads the encoder can utilise. This improves encoding speed significantly on systems that are otherwise underutilised when encoding VP9. Since the amount of additional threads depends on the number of \"tiles\", which itself depends on the video resolution, encoding higher resolution videos will see a "
+"larger performance improvement."
 msgstr ""
 
-#: ../../vdms_utils/presets_manager_utils.py:46
 #, python-brace-format
 msgid "Supports ({0}) formats only, not ({1})"
 msgstr "只支持（{0}）格式，不支持（{1}）"
 
-#: ../../vdms_utils/presets_manager_utils.py:49
 #, fuzzy
 msgid "File formats not supported by the selected profile"
 msgstr "选定配置文件的第一遍"
 
-#: ../../vdms_utils/presets_manager_utils.py:52
 msgid "Warning"
 msgstr "警告"
 
-#: ../../vdms_utils/presets_manager_utils.py:90
 #, fuzzy
 msgid ""
 "No presets found.\n"
@@ -4004,11 +3039,9 @@ msgstr ""
 "\n"
 "可能的解决方案：打开预设管理器面板，进入预设栏，尝试点击 \"恢复所有... \"按钮"
 
-#: ../../vdms_utils/queue_utils.py:54
 msgid "Import queue file"
 msgstr "导入队列文件"
 
-#: ../../vdms_utils/queue_utils.py:89
 #, python-brace-format
 msgid ""
 "ERROR: invalid data found loading queue file.\n"
@@ -4017,25 +3050,20 @@ msgid ""
 "Cannot contain multiple occurrences in `destination` keys value."
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:118
 msgid "Videomass - Add Items to Queue"
 msgstr "Videomass - 向队列添加项"
 
-#: ../../vdms_utils/queue_utils.py:119
 msgid ""
 "Multiple items with identical names and destination paths cannot coexist.\n"
 "Please choose one of the following actions:"
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:123
 msgid "Replace occurrences with items from the imported queue."
 msgstr ""
 
-#: ../../vdms_utils/queue_utils.py:124
 msgid "Add only the currently missing items to the queue."
 msgstr "仅添加当前没有的项到队列。"
 
-#: ../../vdms_utils/queue_utils.py:125
 msgid "Remove the current queue and replace it with the imported one."
 msgstr "移除当前队列并用导入的队列替换它。"
 
@@ -4047,4 +3075,7 @@ msgstr "移除当前队列并用导入的队列替换它。"
 
 #~ msgid "Subtitle Mapping"
 #~ msgstr "字幕 Map"
+
+#~ msgid "Shortest"
+#~ msgstr ""
 

--- a/videomass/vdms_dialogs/filter_colorcorrection.py
+++ b/videomass/vdms_dialogs/filter_colorcorrection.py
@@ -25,6 +25,7 @@ This file is part of Videomass.
    along with Videomass.  If not, see <http://www.gnu.org/licenses/>.
 """
 import os
+import webbrowser
 import wx
 from videomass.vdms_utils.utils import time_to_integer
 from videomass.vdms_utils.utils import integer_to_time
@@ -181,21 +182,23 @@ class ColorEQ(wx.Dialog):
                        | wx.ALIGN_CENTRE_VERTICAL
                        | wx.ALIGN_CENTRE_HORIZONTAL, 10)
         sizercolor.Add(sizerflex2, 0, wx.ALL | wx.CENTRE, 5)
-        # bottom btns
-        gridBtn = wx.GridSizer(1, 2, 0, 0)
-        gridexit = wx.BoxSizer(wx.HORIZONTAL)
+        # ----- confirm buttons section
+        gridbtns = wx.GridSizer(1, 2, 0, 0)
+        gridhelp = wx.GridSizer(1, 1, 0, 0)
+        btn_help = wx.Button(self, wx.ID_HELP, "")
+        gridhelp.Add(btn_help, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        gridbtns.Add(gridhelp)
+        boxaff = wx.BoxSizer(wx.HORIZONTAL)
+        btn_cancel = wx.Button(self, wx.ID_CANCEL, "")
+        boxaff.Add(btn_cancel, 0)
+        btn_ok = wx.Button(self, wx.ID_OK)
+        boxaff.Add(btn_ok, 0, wx.LEFT, 5)
         btn_reset = wx.Button(self, wx.ID_ANY, _("Reset"))
         btn_reset.SetBitmap(iconreset, wx.LEFT)
-        gridBtn.Add(btn_reset, 0, wx.ALL, 5)
-        btn_cancel = wx.Button(self, wx.ID_CANCEL, "")
-        gridexit.Add(btn_cancel, 0)
-        btn_ok = wx.Button(self, wx.ID_OK)
-        gridexit.Add(btn_ok, 0, wx.LEFT, 5)
-        gridBtn.Add(gridexit, 0, wx.ALL | wx.ALIGN_RIGHT | wx.RIGHT, border=5)
-        sizerBase.Add(gridBtn, 0, wx.EXPAND)
-        self.SetSizer(sizerBase)
-        sizerBase.Fit(self)
-        self.Layout()
+        boxaff.Add(btn_reset, 0, wx.LEFT, 5)
+        gridbtns.Add(boxaff, 0, wx.ALL | wx.ALIGN_RIGHT | wx.RIGHT, border=5)
+        sizerBase.Add(gridbtns, 0, wx.EXPAND)
+
         # ----------------------Properties-----------------------#
         if ColorEQ.OS == 'Darwin':
             lab_imgsrc.SetFont(wx.Font(11, wx.SWISS, wx.NORMAL, wx.NORMAL))
@@ -205,6 +208,10 @@ class ColorEQ(wx.Dialog):
             lab_imgedit.SetFont(wx.Font(8, wx.SWISS, wx.NORMAL, wx.NORMAL))
 
         self.SetTitle(_("Color Correction EQ Tool"))
+        # ----- Set layout
+        self.SetSizer(sizerBase)
+        sizerBase.Fit(self)
+        self.Layout()
         # ----------------------Binding (EVT)-------------------------#
 
         self.Bind(wx.EVT_COMMAND_SCROLL, self.on_seek_time, self.sld_time)
@@ -249,6 +256,7 @@ class ColorEQ(wx.Dialog):
         self.Bind(wx.EVT_BUTTON, self.on_close, btn_cancel)
         self.Bind(wx.EVT_BUTTON, self.on_ok, btn_ok)
         self.Bind(wx.EVT_BUTTON, self.on_reset, btn_reset)
+        self.Bind(wx.EVT_BUTTON, self.on_help, btn_help)
 
         if not self.mills:
             self.sld_time.Disable()
@@ -454,6 +462,20 @@ class ColorEQ(wx.Dialog):
         self.sld_saturation.SetValue(100)
         self.sld_gamma.SetValue(10)
         self.equalize_image(self.concat_filter())
+    # -----------------------------------------------------------------------#
+
+    def on_help(self, event):
+        """
+        Open default web browser via Python Web-browser controller.
+        see <https://docs.python.org/3.8/library/webbrowser.html>
+
+        """
+        page = ('https://jeanslack.github.io/Videomass/User-guide/'
+                'Video_filters_en.pdf#%5B%7B%22num%22%3A40%2C%22gen'
+                '%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C56.7%2C625.'
+                '389%2C0%5D')
+
+        webbrowser.open(page)
     # -----------------------------------------------------------------------#
 
     def on_close(self, event):

--- a/videomass/vdms_dialogs/filter_colorcorrection.py
+++ b/videomass/vdms_dialogs/filter_colorcorrection.py
@@ -182,6 +182,7 @@ class ColorEQ(wx.Dialog):
                        | wx.ALIGN_CENTRE_VERTICAL
                        | wx.ALIGN_CENTRE_HORIZONTAL, 10)
         sizercolor.Add(sizerflex2, 0, wx.ALL | wx.CENTRE, 5)
+
         # ----- confirm buttons section
         gridbtns = wx.GridSizer(1, 2, 0, 0)
         gridhelp = wx.GridSizer(1, 1, 0, 0)

--- a/videomass/vdms_dialogs/filter_crop.py
+++ b/videomass/vdms_dialogs/filter_crop.py
@@ -319,22 +319,6 @@ class Crop(wx.Dialog):
         gridbtns.Add(boxaff, 0, wx.ALL | wx.ALIGN_RIGHT | wx.RIGHT, border=5)
         sizerBase.Add(gridbtns, 0, wx.EXPAND)
 
-
-        # # bottom layout for buttons
-        # gridBtn = wx.GridSizer(1, 2, 0, 0)
-        # gridexit = wx.BoxSizer(wx.HORIZONTAL)
-        # btn_reset = wx.Button(self, wx.ID_ANY, _("Reset"))
-        # btn_reset.SetBitmap(args[2], wx.LEFT)
-        # gridBtn.Add(btn_reset, 0, wx.ALL, 5)
-        # btn_cancel = wx.Button(self, wx.ID_CANCEL, "")
-        # gridexit.Add(btn_cancel, 0)
-        # btn_ok = wx.Button(self, wx.ID_OK)
-        # gridexit.Add(btn_ok, 0, wx.LEFT, 5)
-        # gridBtn.Add(gridexit, 0, wx.ALL | wx.ALIGN_RIGHT | wx.RIGHT, border=5)
-        # sizerBase.Add(gridBtn, 0, wx.EXPAND)
-
-
-
         # instance to Actor widget
         if os.path.exists(self.frame):
             bmp = make_bitmap(self.w_scaled, self.h_scaled, self.frame)

--- a/videomass/vdms_dialogs/filter_crop.py
+++ b/videomass/vdms_dialogs/filter_crop.py
@@ -25,6 +25,7 @@ This file is part of Videomass.
    along with Videomass.  If not, see <http://www.gnu.org/licenses/>.
 """
 import os
+import webbrowser
 import wx
 import wx.lib.statbmp
 import wx.lib.colourselect as csel
@@ -300,18 +301,40 @@ class Crop(wx.Dialog):
         boxctrl.Add(self.spin_y, 0, wx.CENTRE)
         label_Y = wx.StaticText(self, wx.ID_ANY, ("Y"))
         boxctrl.Add(label_Y, 0, wx.BOTTOM | wx.CENTRE, 5)
-        # bottom layout for buttons
-        gridBtn = wx.GridSizer(1, 2, 0, 0)
-        gridexit = wx.BoxSizer(wx.HORIZONTAL)
+
+        # ----- confirm buttons section
+        gridbtns = wx.GridSizer(1, 2, 0, 0)
+        gridhelp = wx.GridSizer(1, 1, 0, 0)
+        btn_help = wx.Button(self, wx.ID_HELP, "")
+        gridhelp.Add(btn_help, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        gridbtns.Add(gridhelp)
+        boxaff = wx.BoxSizer(wx.HORIZONTAL)
+        btn_cancel = wx.Button(self, wx.ID_CANCEL, "")
+        boxaff.Add(btn_cancel, 0)
+        btn_ok = wx.Button(self, wx.ID_OK)
+        boxaff.Add(btn_ok, 0, wx.LEFT, 5)
         btn_reset = wx.Button(self, wx.ID_ANY, _("Reset"))
         btn_reset.SetBitmap(args[2], wx.LEFT)
-        gridBtn.Add(btn_reset, 0, wx.ALL, 5)
-        btn_close = wx.Button(self, wx.ID_CANCEL, "")
-        gridexit.Add(btn_close, 0)
-        btn_ok = wx.Button(self, wx.ID_OK)
-        gridexit.Add(btn_ok, 0, wx.LEFT, 5)
-        gridBtn.Add(gridexit, 0, wx.ALL | wx.ALIGN_RIGHT | wx.RIGHT, border=5)
-        sizerBase.Add(gridBtn, 0, wx.EXPAND)
+        boxaff.Add(btn_reset, 0, wx.LEFT, 5)
+        gridbtns.Add(boxaff, 0, wx.ALL | wx.ALIGN_RIGHT | wx.RIGHT, border=5)
+        sizerBase.Add(gridbtns, 0, wx.EXPAND)
+
+
+        # # bottom layout for buttons
+        # gridBtn = wx.GridSizer(1, 2, 0, 0)
+        # gridexit = wx.BoxSizer(wx.HORIZONTAL)
+        # btn_reset = wx.Button(self, wx.ID_ANY, _("Reset"))
+        # btn_reset.SetBitmap(args[2], wx.LEFT)
+        # gridBtn.Add(btn_reset, 0, wx.ALL, 5)
+        # btn_cancel = wx.Button(self, wx.ID_CANCEL, "")
+        # gridexit.Add(btn_cancel, 0)
+        # btn_ok = wx.Button(self, wx.ID_OK)
+        # gridexit.Add(btn_ok, 0, wx.LEFT, 5)
+        # gridBtn.Add(gridexit, 0, wx.ALL | wx.ALIGN_RIGHT | wx.RIGHT, border=5)
+        # sizerBase.Add(gridBtn, 0, wx.EXPAND)
+
+
+
         # instance to Actor widget
         if os.path.exists(self.frame):
             bmp = make_bitmap(self.w_scaled, self.h_scaled, self.frame)
@@ -321,9 +344,6 @@ class Crop(wx.Dialog):
             self.bob = Actor(self.panelrect, bmp, 1, "")
             self.make_frame_from_file(None)
 
-        self.SetSizer(sizerBase)
-        sizerBase.Fit(self)
-        self.Layout()
         # ----------------------Properties-----------------------#
         self.panelrect.SetBackgroundColour(wx.Colour(Crop.BACKGROUND))
         if Crop.OS == 'Darwin':
@@ -341,6 +361,11 @@ class Crop(wx.Dialog):
                                  'the horizontal axis)'))
         self.spin_h.SetToolTip(_('Crop to height'))
 
+        # ----- Set layout
+        self.SetSizer(sizerBase)
+        sizerBase.Fit(self)
+        self.Layout()
+
         # ----------------------Binding (EVT)------------------------#
         self.Bind(wx.EVT_SPINCTRL, self.onWidth, self.spin_w)
         self.Bind(wx.EVT_SPINCTRL, self.onHeight, self.spin_h)
@@ -350,9 +375,10 @@ class Crop(wx.Dialog):
         self.Bind(wx.EVT_COMMAND_SCROLL, self.on_Seek, self.sld_time)
         self.Bind(wx.EVT_BUTTON, self.make_frame_from_file, self.btn_load)
 
-        self.Bind(wx.EVT_BUTTON, self.on_close, btn_close)
+        self.Bind(wx.EVT_BUTTON, self.on_close, btn_cancel)
         self.Bind(wx.EVT_BUTTON, self.on_ok, btn_ok)
         self.Bind(wx.EVT_BUTTON, self.on_reset, btn_reset)
+        self.Bind(wx.EVT_BUTTON, self.on_help, btn_help)
         self.btn_color.Bind(csel.EVT_COLOURSELECT, self.bob.oncolor)
         # self.Bind(wx.EVT_BUTTON, self.on_help, btn_help)
         pub.subscribe(self.to_real_scale_coords, "TO_REAL_SCALE")
@@ -516,6 +542,20 @@ class Crop(wx.Dialog):
         self.spin_h.SetValue(0)
         self.spin_y.SetValue(0)
         self.onDrawing()
+    # ------------------------------------------------------------------#
+
+    def on_help(self, event):
+        """
+        Open default web browser via Python Web-browser controller.
+        see <https://docs.python.org/3.8/library/webbrowser.html>
+
+        """
+        page = ('https://jeanslack.github.io/Videomass/User-guide/'
+                'Video_filters_en.pdf#%5B%7B%22num%22%3A13%2C%22gen'
+                '%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C56.7%2C785.'
+                '189%2C0%5D')
+
+        webbrowser.open(page)
     # ------------------------------------------------------------------#
 
     def on_close(self, event):

--- a/videomass/vdms_dialogs/filter_deinterlace.py
+++ b/videomass/vdms_dialogs/filter_deinterlace.py
@@ -489,8 +489,10 @@ class Deinterlace(wx.Dialog):
         Open default web browser via Python Web-browser controller.
         see <https://docs.python.org/3.8/library/webbrowser.html>
         """
-        page = ('https://jeanslack.github.io/Videomass/User-guide'
-                '/Video_filters_en.pdf')
+        page = ('https://jeanslack.github.io/Videomass/User-guide/'
+                'Video_filters_en.pdf#%5B%7B%22num%22%3A19%2C%22gen'
+                '%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C56.7%2C468.'
+                '539%2C0%5D')
 
         webbrowser.open(page)
     # ------------------------------------------------------------------#

--- a/videomass/vdms_dialogs/filter_denoisers.py
+++ b/videomass/vdms_dialogs/filter_denoisers.py
@@ -259,8 +259,10 @@ class Denoisers(wx.Dialog):
         Open default web browser via Python Web-browser controller.
         see <https://docs.python.org/3.8/library/webbrowser.html>
         """
-        page = ('https://jeanslack.github.io/Videomass/User-guide'
-                '/Video_filters_en.pdf')
+        page = ('https://jeanslack.github.io/Videomass/User-guide/'
+                'Video_filters_en.pdf#%5B%7B%22num%22%3A25%2C%22gen'
+                '%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C56.7%2C573.'
+                '439%2C0%5D')
 
         webbrowser.open(page)
     # ------------------------------------------------------------------#

--- a/videomass/vdms_dialogs/filter_scale.py
+++ b/videomass/vdms_dialogs/filter_scale.py
@@ -442,8 +442,10 @@ class Scale(wx.Dialog):
         Open default web browser via Python Web-browser controller.
         see <https://docs.python.org/3.8/library/webbrowser.html>
         """
-        page = ('https://jeanslack.github.io/Videomass/User-guide'
-                '/Video_filters_en.pdf')
+        page = ('https://jeanslack.github.io/Videomass/User-guide/'
+                'Video_filters_en.pdf#%5B%7B%22num%22%3A10%2C%22gen%22%'
+                '3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C56.7%2C785.'
+                '189%2C0%5D')
 
         webbrowser.open(page)
     # ------------------------------------------------------------------#

--- a/videomass/vdms_dialogs/filter_stab.py
+++ b/videomass/vdms_dialogs/filter_stab.py
@@ -695,8 +695,10 @@ class VidstabSet(wx.Dialog):
         see <https://docs.python.org/3.8/library/webbrowser.html>
 
         """
-        page = ('https://jeanslack.github.io/Videomass/User-guide'
-                '/Video_filters_en.pdf')
+        page = ('https://jeanslack.github.io/Videomass/User-guide/'
+                'Video_filters_en.pdf#%5B%7B%22num%22%3A28%2C%22gen'
+                '%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C56.7%2C785.'
+                '189%2C0%5D')
 
         webbrowser.open(page)
     # ------------------------------------------------------------------#

--- a/videomass/vdms_dialogs/filter_transpose.py
+++ b/videomass/vdms_dialogs/filter_transpose.py
@@ -25,6 +25,7 @@ This file is part of Videomass.
    along with Videomass.  If not, see <http://www.gnu.org/licenses/>.
 """
 import os
+import webbrowser
 from math import pi as pigreco
 import wx
 from videomass.vdms_threads.generic_task import FFmpegGenericTask
@@ -99,18 +100,24 @@ class Transpose(wx.Dialog):
         self.button_down = wx.Button(self, wx.ID_ANY,
                                      (_("180°")))  # capovolgi sotto
         boxctrl.Add(self.button_down, 0, wx.ALL | wx.CENTRE, 5)
+
         # ----- confirm buttons section
-        gridBtn = wx.GridSizer(1, 2, 0, 0)
-        gridexit = wx.BoxSizer(wx.HORIZONTAL)
+        gridbtns = wx.GridSizer(1, 2, 0, 0)
+        gridhelp = wx.GridSizer(1, 1, 0, 0)
+        btn_help = wx.Button(self, wx.ID_HELP, "")
+        gridhelp.Add(btn_help, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        gridbtns.Add(gridhelp)
+        boxaff = wx.BoxSizer(wx.HORIZONTAL)
+        btn_cancel = wx.Button(self, wx.ID_CANCEL, "")
+        boxaff.Add(btn_cancel, 0)
+        btn_ok = wx.Button(self, wx.ID_OK)
+        boxaff.Add(btn_ok, 0, wx.LEFT, 5)
         btn_reset = wx.Button(self, wx.ID_ANY, _("Reset"))
         btn_reset.SetBitmap(args[2], wx.LEFT)
-        gridBtn.Add(btn_reset, 0, wx.ALL, 5)
-        btn_cancel = wx.Button(self, wx.ID_CANCEL, "")
-        gridexit.Add(btn_cancel, 0)
-        btn_ok = wx.Button(self, wx.ID_OK)
-        gridexit.Add(btn_ok, 0, wx.LEFT, 5)
-        gridBtn.Add(gridexit, 0, wx.ALL | wx.ALIGN_RIGHT | wx.RIGHT, border=5)
-        sizerBase.Add(gridBtn, 0, wx.EXPAND)
+        boxaff.Add(btn_reset, 0, wx.LEFT, 5)
+        gridbtns.Add(boxaff, 0, wx.ALL | wx.ALIGN_RIGHT | wx.RIGHT, border=5)
+        sizerBase.Add(gridbtns, 0, wx.EXPAND)
+
         # ----------------------Properties--------------------------------#
         self.SetTitle(_("Transpose Tool"))
         self.panelimg.SetBackgroundColour(wx.Colour(Transpose.BACKGROUND))
@@ -146,6 +153,7 @@ class Transpose(wx.Dialog):
         self.Bind(wx.EVT_BUTTON, self.on_close, btn_cancel)
         self.Bind(wx.EVT_BUTTON, self.on_ok, btn_ok)
         self.Bind(wx.EVT_BUTTON, self.on_reset, btn_reset)
+        self.Bind(wx.EVT_BUTTON, self.on_help, btn_help)
     # ------------------------------------------------------------------#
 
     def process(self):
@@ -292,6 +300,20 @@ class Transpose(wx.Dialog):
         self.transpose['degrees'] = ["", 0]
         self.statictxt.SetLabel(_("Default position"))
         self.Layout()
+    # ------------------------------------------------------------------#
+
+    def on_help(self, event):
+        """
+        Open default web browser via Python Web-browser controller.
+        see <https://docs.python.org/3.8/library/webbrowser.html>
+
+        """
+        page = ('https://jeanslack.github.io/Videomass/User-guide/'
+                'Video_filters_en.pdf#%5B%7B%22num%22%3A19%2C%22gen'
+                '%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C56.7%2C711.'
+                '639%2C0%5D')
+
+        webbrowser.open(page)
     # ------------------------------------------------------------------#
 
     def on_close(self, event):


### PR DESCRIPTION
This PR complements the contextual help for video filters. Clicking on each of the contextual help buttons, located at the bottom of the button bar, will direct the user to the corresponding web page.